### PR TITLE
Less words in pear terminal guide

### DIFF
--- a/guide/starting-a-pear-terminal-project.md
+++ b/guide/starting-a-pear-terminal-project.md
@@ -10,9 +10,9 @@ cd chat-bot
 pear init --yes
 ```
 
-This will create a base structure for the project.
+This creates the base project structure.
 
-- `package.json`. Configuration for the app. Notice the `pear` property.
-- `index.js`. The entrpoint for the app.
-- `app.js`. The main code.
-- `test/index.test.js`. Skeleton for writing tests.
+- `package.json`. App configuration. Notice the `pear` property.
+- `index.js`. App entrypoint.
+- `app.js`. Main code.
+- `test/index.test.js`. Test skeleton.


### PR DESCRIPTION
This content is repeated almost word-for-word in 'making a pear desktop project', so it might not be needed

I don't really like the list layout, with all the punctuation and capitalisation, but didn't touch that as it depends on global style decisions