### PR TITLE
Fixed datatype tags breaking rendering

### DIFF
--- a/reference/configuration.md
+++ b/reference/configuration.md
@@ -18,11 +18,11 @@ Pear versioning is automatic. The `package.json` file does **not** require a ver
 
 ## The `package.json` `pear` field.
 
-### `pear.name` <String>
+### `pear.name <String>`
 
 The name of the application. Overrides `package.json` `name`.
 
-### `pear.builtinsMap` <Object> <small>Terminal Applications Only</small>
+### `pear.builtinsMap <Object>` <small>Terminal Applications Only</small>
 
 Terminal Applications run on the [`bare`](https://github.com/holepunchto/bare) JavaScript runtime,
 which has a very small core so code with expects say, an `fs` module will throw MODULE_NOT_FOUND
@@ -45,87 +45,87 @@ An example `package.json`:
 
 > In future this option may also apply to Desktop Applications.
 
-### `pear.gui` <Object>
+### `pear.gui <Object>`
 
 Graphical User Interface configuration options.
 
-#### `pear.gui.width` <Number>
+#### `pear.gui.width <Number>`
 
 Window width (pixels).
 
-#### `pear.gui.height` <Number>
+#### `pear.gui.height <Number>`
 
 Window height (pixels).
 
-#### `pear.gui.x` <Number>
+#### `pear.gui.x <Number>`
 
 Horizontal window position (pixels).
 
-#### `pear.gui.y` <Number>
+#### `pear.gui.y <Number>`
 
 Vertical window position (pixels).
 
-#### `pear.gui.minWidth` <Number>
+#### `pear.gui.minWidth <Number>`
 
 Window minimum width (pixels).
 
-#### `pear.gui.minHeight` <Number>
+#### `pear.gui.minHeight <Number>`
 
 Window minimum height (pixels).
 
-#### `pear.gui.maxWidth` <Number>
+#### `pear.gui.maxWidth <Number>`
 
 Window maximum width (pixels).
 
-#### `pear.gui.maxHeight` <Number>
+#### `pear.gui.maxHeight <Number>`
 
 Window maximum height (pixels).
 
-#### `pear.gui.center` <Boolean> (default: `false`)
+#### `pear.gui.center <Boolean>` (default: `false`)
 
 Center window.
 
-#### `pear.gui.resizable` <Boolean> (default: `true`)
+#### `pear.gui.resizable <Boolean>` (default: `true`)
 
 Window resizability.
 
-#### `pear.gui.movable` <Boolean> (default: `true`)
+#### `pear.gui.movable <Boolean>` (default: `true`)
 
 Window movability.
 
-#### `pear.gui.minimizable` <Boolean> (default: `true`)
+#### `pear.gui.minimizable <Boolean>` (default: `true`)
 
 Window minimizability.
 
-#### `pear.gui.maximizable` <Boolean> (default: `true`)
+#### `pear.gui.maximizable <Boolean>` (default: `true`)
 
 Window maximizability.
 
-#### `pear.gui.closable` <Boolean> (default: `true`)
+#### `pear.gui.closable <Boolean>` (default: `true`)
 
 Window closability.
 
-#### `pear.gui.focusable` <Boolean> (default: `true`)
+#### `pear.gui.focusable <Boolean>` (default: `true`)
 
 Window focusability.
 
-#### `pear.gui.alwaysOnTop` <Boolean> (default: `false`)
+#### `pear.gui.alwaysOnTop <Boolean>` (default: `false`)
 
 Set window to always be on top.
 
-#### `pear.gui.fullscreen` <Boolean> (default: `false`)
+#### `pear.gui.fullscreen <Boolean>` (default: `false`)
 
 Set window to fullscreen on start.
 
-#### `pear.gui.kiosk` <Boolean> (default: `false`)
+#### `pear.gui.kiosk <Boolean>` (default: `false`)
 
 Set window to enter kiosk mode on start.
 
-#### `pear.gui.autoHideMenuBar` <Boolean> (default: `false`)
+#### `pear.gui.autoHideMenuBar <Boolean>` (default: `false`)
 
 Hide menu bar unless Alt key is pressed (Linux, Windows).
 
-#### `pear.gui.hasShadow` <Boolean> (default: `true`)
+#### `pear.gui.hasShadow <Boolean>` (default: `true`)
 
 Window shadow.
 
@@ -137,19 +137,19 @@ Set window opacity (0.0 - 1.0) (Windows, macOS).
 
 Enable transparency. Must be set for opacity to work.
 
-#### `pear.gui.backgroundColor` <String> (default: "#000" non-transparent, "#00000000" transparent)
+#### `pear.gui.backgroundColor <String>` (default: "#000" non-transparent, "#00000000" transparent)
 
 Background color (Hex, RGB, RGBA, HSL, HSLA, CSS color).
 
-### `pear.stage` <Object>
+### `pear.stage <Object>`
 
 Staging configuration options.
 
-#### `pear.stage.entrypoints` <Array>
+#### `pear.stage.entrypoints <Array>`
 
 An array of entrypoints as staging start-points in addition to (deduped) main entry point.
 
-#### `pear.stage.ignore` <Array>
+#### `pear.stage.ignore <Array>`
 
 An array of file paths to ignore relative to `package.json` file.
 
@@ -157,7 +157,7 @@ An array of file paths to ignore relative to `package.json` file.
 
 File watching configuration options.
 
-#### `pear.watch.reload.page` <String> (default: `"refresh"`)
+#### `pear.watch.reload.page <String>` (default: `"refresh"`)
 
 String may be:
 


### PR DESCRIPTION
The datatype tags are breaking markdown rendering: `<Object>` ,etc. 

Before:

![Screenshot from 2024-02-13 13-08-20](https://github.com/holepunchto/pear-runtime/assets/6217900/a82838de-3757-424b-a3b2-92421299803b)