### PR TITLE
Updated Youtube links and used embeds

### DIFF
--- a/guide/getting-started.md
+++ b/guide/getting-started.md
@@ -4,7 +4,7 @@ Pear Runtime can be installed from the [pears.com](pears.com) or via [npm](https
 
 Since `npm` (or equivalent package manager) is needed to install application dependencies this guide will walk through installing `pear` with `npm`.
 
-> [Build with Pear - Episode 01: Developing with Pear](https://www.youtube.com/watch?v=y2G97xz78gU)
+{% embed url="https://www.youtube.com/watch?v=y2G97xz78gU" %} Build with Pear - Episode 01: Developing with Pear {% endembed %}
 
 ## Requirements
 

--- a/guide/making-a-pear-desktop-app.md
+++ b/guide/making-a-pear-desktop-app.md
@@ -4,7 +4,7 @@ This guide demonstrates how to build a peer-to-peer chat application.
 
 It continues where [Starting a Pear Desktop Project](./starting-a-pear-desktop-project.md) left off.
 
-> [Build with Pear - Episode 01: Developing with Pear](https://www.youtube.com/watch?v=y2G97xz78gU)
+{% embed url="https://www.youtube.com/watch?v=BEadqmp7lA0" %} Build with Pear - Episode 02: Sharing Pear Applications {% endembed %}
 
 ## Step 1. HTML Structure and CSS Styles
 

--- a/guide/making-a-pear-terminal-app.md
+++ b/guide/making-a-pear-terminal-app.md
@@ -4,7 +4,7 @@ This guide demonstrates how to build a peer-to-peer chat application.
 
 It continues where [Starting a Pear Terminal Project](./starting-a-pear-terminal-project.md) left off.
 
-> [Build with Pear - Episode 04: Pear Terminal Applications]https://www.youtube.com/watch?v=73KVE0wocTE
+{% embed url="https://www.youtube.com/watch?v=UoGJ7PtAwtI" %} Build with Pear - Episode 04: Pear Terminal Applications {% endembed %}
 
 ## Step 1. Install modules
 

--- a/guide/releasing-a-pear-app.md
+++ b/guide/releasing-a-pear-app.md
@@ -4,7 +4,7 @@ Pear applications are stored in an append-only log ([hypercore](../building-bloc
 
 Each version is identified by `<fork>.<length>.<key>`. The length corresponds to the length of the application's append-only log at the time.
 
-> [Build with Pear - Episode 03: Releasing Pear Applications](https://www.youtube.com/watch?v=UuzTlzEET4o)
+{% embed url="https://www.youtube.com/watch?v=OTwY_avUPyI" %} Build with Pear - Episode 03: Releasing Pear Applications {% endembed %}
 
 `pear run <key>` opens the application.
 

--- a/guide/sharing-a-pear-app.md
+++ b/guide/sharing-a-pear-app.md
@@ -2,7 +2,7 @@
 
 Applications can be shared with peers by seeding them to the network from an efficient local data structure (a [hypercore](../bulding-blocks.md#hyeprcore])). We call the mirroring of a local file system into the Pear platform Application Storage "staging". Seeding is sharing an app from a machine over the Distributed Hash Table (DHT) (via [hyperswarm](../building-blocks.md#hyperswarm)) so that other peers can replicate, consume and reseed the application.
 
-> [Build with Pear - Episode 02: Sharing Pear Applications](https://www.youtube.com/watch?v=slYj9_ifpZQ)
+{% embed url="https://www.youtube.com/watch?v=BEadqmp7lA0" %} Build with Pear - Episode 02: Sharing Pear Applications {% endembed %}
 
 This guide can either follow on from, [Making a Pear Desktop Application](./making-a-pear-desktop-app.md), [Making a Pear Terminal Application](./making-a-pear-terminal-app.md), or get setup quickly with the following:
 

--- a/guide/starting-a-pear-desktop-project.md
+++ b/guide/starting-a-pear-desktop-project.md
@@ -2,7 +2,7 @@
 
 This section shows how to generate, configure, and develop a Pear desktop project, in preparation for [Making a Pear Desktop Application](./making-a-pear-desktop-app.md).
 
-> [Build with Pear - Episode 01: Developing with Pear](https://www.youtube.com/watch?v=y2G97xz78gU)
+{% embed url="https://www.youtube.com/watch?v=y2G97xz78gU" %} Build with Pear - Episode 01: Developing with Pear {% endembed %}
 
 ## Step 1. Initialization
 

--- a/guide/starting-a-pear-terminal-project.md
+++ b/guide/starting-a-pear-terminal-project.md
@@ -1,6 +1,6 @@
 # Starting a Pear Terminal Project
 
-> [Build with Pear - Episode 04: Pear Terminal Applications]https://www.youtube.com/watch?v=73KVE0wocTE
+{% embed url="https://www.youtube.com/watch?v=UoGJ7PtAwtI" %} Build with Pear - Episode 04: Pear Terminal Applications {% endembed %}
 
 ## Step 1. Init
 

--- a/howto/connect-to-many-peers-by-topic-with-hyperswarm.md
+++ b/howto/connect-to-many-peers-by-topic-with-hyperswarm.md
@@ -4,7 +4,7 @@ In the former example, two peers connected directly using the first peer's publi
 
 The [Hyperswarm](../building-blocks/hyperswarm.md) module provides a higher-level interface over the underlying DHT, abstracting away the mechanics of establishing and maintaining connections. Instead, 'join' topics, and the swarm discovers peers automatically. It also handles reconnections in the event of failures.
 
-> [Build with Pear - Episode 01: Developing with Pear](https://www.youtube.com/watch?v=y2G97xz78gU)
+{% embed url="https://www.youtube.com/watch?v=y2G97xz78gU" %} Build with Pear - Episode 01: Developing with Pear {% endembed %}
 
 In the [How to connect two Peers by key with Hyperdht](./connect-two-peers-by-key-with-hyperdht.md), we needed to explicitly indicate which peer was the server and which was the client. By using Hyperswarm, we create two peers, have them join a common topic, and let the swarm deal with connections.
 

--- a/howto/create-a-full-peer-to-peer-filesystem-with-hyperdrive.md
+++ b/howto/create-a-full-peer-to-peer-filesystem-with-hyperdrive.md
@@ -2,8 +2,6 @@
 
 [`Hyperdrive`](../building-blocks/hyperdrive.md) is a secure, real-time distributed file system designed for easy peer-to-peer file sharing. In the same way that a Hyperbee is just a wrapper around a Hypercore, a Hyperdrive is a wrapper around two Hypercores: one is a Hyperbee index for storing file metadata, and the other is used to store file contents.
 
-> [Build with Pear - Episode 08: Peer-to-Peer File Systems](https://www.youtube.com/watch?v=ie7Nx3SF8sA)
-
 This How-to consists of three applications: `drive-writer-app`, `drive-reader-app` and `bee-reader-app`.
 
 Now let's mirror a local directory into a Hyperdrive, replicate it with a reader peer, who then mirrors it into their own local copy. When the writer modifies its drive, by adding, removing, or changing files, the reader's local copy will be updated to reflect that. To do this, we'll use two additional tools: [`MirrorDrive`](../helpers/mirrordrive.md) and [`LocalDrive`](../helpers/localdrive.md), which handle all interactions between Hyperdrives and the local filesystem.

--- a/howto/replicate-and-persist-with-hypercore.md
+++ b/howto/replicate-and-persist-with-hypercore.md
@@ -4,7 +4,7 @@ In the HyperDHT How-to ([Connect Two Peers](./connect-two-peers-by-key-with-hype
 
 [`Hypercore`](../building-blocks/hypercore.md) is a secure, distributed append-only log. It is built for sharing enormous datasets and streams of real-time data. It has a secure transport protocol, making it easy to build fast and scalable peer-to-peer applications.
 
-> [Build with Pear - Episode 06: Replication and Persistence](https://www.youtube.com/watch?v=MxykB79LhR4&t)
+{% embed url="https://www.youtube.com/watch?v=5t2mOi0BeDg" %} Build with Pear - Episode 05: Replication and Persistence {% endembed %}
 
 In this guide we'll extend the ephemeral chat example in [Connect Many Peers](./connect-to-many-peers-by-topic-with-hyperswarm.md) but using Hypercore to add many significant new features:
 

--- a/howto/share-append-only-databases-with-hyperbee.md
+++ b/howto/share-append-only-databases-with-hyperbee.md
@@ -3,9 +3,6 @@
 
 [Hyperbee](../building-blocks/hyperbee.md) is an append-only B-tree based on Hypercore. It provides a key/value-store API with methods to insert and get key/value pairs, perform atomic batch insertions, and create sorted iterators.
 
-
-> [Build with Pear - Episode 07: Peer-to-Peer Databases](https://www.youtube.com/watch?v=E7ysAVa_V-s)
-
 This How-to consists of three applications: `bee-writer-app` , `bee-reader-app` and `core-reader-app`.
 
 The `bee-writer-app` stores 100k entries from a given dictionary file into a Hyperbee instance. The Corestore instance used to create the Hyperbee instance is replicated using Hyperswarm. This enables other peers to replicate their Corestore instance and sparsely (on-demand) download the dictionary data into their local Hyperbee instances.


### PR DESCRIPTION
This script below converts the embeds to the existing format `> [Title](link)` with the quote block too.

```
const exampleString = 'This is a test\n{% embed url="https://www.youtube.com/watch?v=I228t0jKH4" %} How HP Works {% embeded %}\nWorld and another {% embed url="https://www.youtube.com/watch?v=I228t0jKH4" %} Some other video {% embeded %}\n{% someothertag %}';

const regex = /{% embed url="([^"]+)" %}\s*(.*?)\s*{% embeded %}/g; //This works
const result = exampleString.replace(regex, '> [$2]($1)');

console.log(result);
```

Can use the regex in pear-runtime to replace the embeds.

Also changed to E2 in Making a pear desktop application instead of 1st video as it's more appropriate