### PR TITLE
fixed setup ui button click

### DIFF
--- a/lib/system-status.js
+++ b/lib/system-status.js
@@ -79,7 +79,7 @@ customElements.define('system-status', class extends HTMLElement {
         #panel { user-select: none; }
         blockquote { outline: 1px solid #323532; margin-inline-start: 0; margin-inline-end: 0; display: block; margin-block-start: 1rem; margin-block-end: 0; padding: 1px; font-size: .825rem; border-radius: 2px; }
         blockquote::before { content: "ℹ"; float: left; font-size: 1.625rem; margin-left: 1rem; margin-right: 0.625rem; }
-        button { background: #151517; color: #B0D944; border: 1px solid; padding: .575em .65em; cursor: pointer; margin-top: 2rem; font-size: 1.25rem; }
+        button { background: #151517; color: #B0D944; border: 1px solid; padding: .575em .65em; cursor: pointer; margin-top: 2rem; font-size: 1.20rem; }
         #tip { text-indent: 4px; margin-top: -.25rem }
         code {
           background: #3a4816;
@@ -90,7 +90,7 @@ customElements.define('system-status', class extends HTMLElement {
           font-family: 'overpass-mono';
           border-radius: 1px;
         }
-        #tip > p { margin: 0; padding: 0}
+        #tip > p { margin-top: 6px; margin-bottom: 6px; padding: 0}
         #tip {
           margin-top: 3rem;
         }
@@ -111,8 +111,10 @@ customElements.define('system-status', class extends HTMLElement {
         <blockquote>
           <p>Pear setup is nearly complete.</p>
         </blockquote>
-        <p id=tip><small>To finish installing Pear Runtime set your system path to <code>${BIN}</code>${!isWin? ' or click the button.' : '.'}</small></p>
-            ${!isWin ? '<p><button> Automatic Setup Completion </button><p>' : ''}
+        <div id="tip">
+          <p>To finish installing Pear Runtime set your system path to <p><code>${BIN}</code></p>${!isWin? ' or click the button.' : '.'}</p>
+        </div>
+        ${!isWin ? '<p><button> Automatic Setup Completion </button><p>' : ''}
       </div>
     </div>
     `

--- a/lib/system-status.js
+++ b/lib/system-status.js
@@ -73,21 +73,6 @@ customElements.define('system-status', class extends HTMLElement {
     this.shellProfiles = null
     this.root = this.attachShadow({ mode: 'open' })
     this.#render()
-
-    this.button = this.root.querySelector('button')
-
-    if (this.button) {
-      const listener = () => {
-        this.button.removeEventListener('click', listener)
-        this.#install()
-          .then(() => {
-            this.#render()
-            console.log('now show version info, and a gif showing pear command line help output run through')
-          })
-          .catch((err) => this.#error(err))
-      }
-      this.button.addEventListener('click', listener)
-    }
   }
 
   #render () {
@@ -139,6 +124,20 @@ customElements.define('system-status', class extends HTMLElement {
       }
     </div>
     `
+    this.button = this.root.querySelector('button')
+
+    if (this.button) {
+      const listener = () => {
+        this.button.removeEventListener('click', listener)
+        this.#install()
+          .then(() => {
+            this.#render()
+            console.log('now show version info, and a gif showing pear command line help output run through')
+          })
+          .catch((err) => this.#error(err))
+      }
+      this.button.addEventListener('click', listener)
+    }
   }
 
   #error (err) {

--- a/lib/system-status.js
+++ b/lib/system-status.js
@@ -106,17 +106,14 @@ customElements.define('system-status', class extends HTMLElement {
         }
       </style>
       <h1>System Status</h1>
-      ${
-        this.installed
-? '<pear-welcome></pear-welcome>'
-: `
-          <blockquote>
-           <p>Pear setup is nearly complete.</p>
-          </blockquote>
-      <p id=tip><small>To finish installing Pear Runtime set your system path to <code>${BIN}</code>${!isWin? ' or click the button bellow.' : '.'}</small></p>
-          ${!isWin ? '<p><button> Automatic Setup Completion </button><p>' : ''}
-        `
-      }
+      <pear-welcome></pear-welcome>
+      <div id="setup">
+        <blockquote>
+          <p>Pear setup is nearly complete.</p>
+        </blockquote>
+        <p id=tip><small>To finish installing Pear Runtime set your system path to <code>${BIN}</code>${!isWin? ' or click the button.' : '.'}</small></p>
+            ${!isWin ? '<p><button> Automatic Setup Completion </button><p>' : ''}
+      </div>
     </div>
     `
     this.root = this.attachShadow({ mode: 'open' })
@@ -125,12 +122,19 @@ customElements.define('system-status', class extends HTMLElement {
 
     this.button = this.root.querySelector('button')
 
+    if (this.installed) {
+      this.root.querySelector('#setup').style.display = 'none'
+    } else {
+      this.root.querySelector('pear-welcome').style.display = 'none'
+    }
+
     if (this.button) {
       const listener = () => {
         this.button.removeEventListener('click', listener)
         this.#install()
           .then(() => {
-            this.replaceWith(new this.constructor())
+            this.root.querySelector('pear-welcome').style.display = ''
+            this.root.querySelector('#setup').style.display = 'none'
             console.log('now show version info, and a gif showing pear command line help output run through')
           })
           .catch((err) => this.#error(err))

--- a/lib/system-status.js
+++ b/lib/system-status.js
@@ -124,20 +124,9 @@ customElements.define('system-status', class extends HTMLElement {
       }
     </div>
     `
-    this.button = this.root.querySelector('button')
-
-    if (this.button) {
-      const listener = () => {
-        this.button.removeEventListener('click', listener)
-        this.#install()
-          .then(() => {
-            this.#render()
-            console.log('now show version info, and a gif showing pear command line help output run through')
-          })
-          .catch((err) => this.#error(err))
-      }
-      this.button.addEventListener('click', listener)
-    }
+    this.shadowRoot.querySelector('button')?.addEventListener('click', () => {
+      this.#install().then(() => this.#render()).catch((err) => this.#error(err))
+    })
   }
 
   #error (err) {

--- a/lib/system-status.js
+++ b/lib/system-status.js
@@ -92,6 +92,7 @@ customElements.define('system-status', class extends HTMLElement {
           padding-bottom: 0.15rem;
           font-family: 'overpass-mono';
           border-radius: 1px;
+          user-select: text;
         }
         #tip > p { margin-top: 6px; margin-bottom: 6px; padding: 0}
         #tip {

--- a/lib/system-status.js
+++ b/lib/system-status.js
@@ -71,9 +71,27 @@ customElements.define('system-status', class extends HTMLElement {
     this.statement = `export PATH="${BIN}":$PATH`
     this.stmtrx = new RegExp(`^export PATH="${BIN}":\\$PATH$`, 'm')
     this.shellProfiles = null
-    this.installed = this.#installed()
-    this.template = document.createElement('template')
-    this.template.innerHTML = `
+    this.root = this.attachShadow({ mode: 'open' })
+    this.#render()
+
+    this.button = this.root.querySelector('button')
+
+    if (this.button) {
+      const listener = () => {
+        this.button.removeEventListener('click', listener)
+        this.#install()
+          .then(() => {
+            this.#render()
+            console.log('now show version info, and a gif showing pear command line help output run through')
+          })
+          .catch((err) => this.#error(err))
+      }
+      this.button.addEventListener('click', listener)
+    }
+  }
+
+  #render () {
+    this.shadowRoot.innerHTML = `
     <div id="panel">
       <style>
         #panel { user-select: none; }
@@ -106,45 +124,21 @@ customElements.define('system-status', class extends HTMLElement {
         }
       </style>
       <h1>System Status</h1>
-      <pear-welcome></pear-welcome>
-      <div id="setup">
-        <blockquote>
-          <p>Pear setup is nearly complete.</p>
-        </blockquote>
-        <div id="tip">
+      ${
+        this.#installed()
+        ? '<pear-welcome></pear-welcome>'
+        : `
+          <blockquote>
+           <p>Pear setup is nearly complete.</p>
+          </blockquote>
           <p>To finish installing Pear Runtime set your system path to</p>
           <p><code>${BIN}</code></p>
           <p>${!isWin? ' or click the button.' : ''}</p>
-        </div>
-        ${!isWin ? '<p><button> Automatic Setup Completion </button><p>' : ''}
-      </div>
+          ${!isWin ? '<p><button> Automatic Setup Completion </button><p>' : ''}
+        `
+      }
     </div>
     `
-    this.root = this.attachShadow({ mode: 'open' })
-
-    this.root.appendChild(this.template.content.cloneNode(true))
-
-    this.button = this.root.querySelector('button')
-
-    if (false) {
-      this.root.querySelector('#setup').style.display = 'none'
-    } else {
-      this.root.querySelector('pear-welcome').style.display = 'none'
-    }
-
-    if (this.button) {
-      const listener = () => {
-        this.button.removeEventListener('click', listener)
-        this.#install()
-          .then(() => {
-            this.root.querySelector('pear-welcome').style.display = ''
-            this.root.querySelector('#setup').style.display = 'none'
-            console.log('now show version info, and a gif showing pear command line help output run through')
-          })
-          .catch((err) => this.#error(err))
-      }
-      this.button.addEventListener('click', listener)
-    }
   }
 
   #error (err) {

--- a/lib/system-status.js
+++ b/lib/system-status.js
@@ -112,7 +112,9 @@ customElements.define('system-status', class extends HTMLElement {
           <p>Pear setup is nearly complete.</p>
         </blockquote>
         <div id="tip">
-          <p>To finish installing Pear Runtime set your system path to <p><code>${BIN}</code></p>${!isWin? ' or click the button.' : '.'}</p>
+          <p>To finish installing Pear Runtime set your system path to</p>
+          <p><code>${BIN}</code></p>
+          <p>${!isWin? ' or click the button.' : ''}</p>
         </div>
         ${!isWin ? '<p><button> Automatic Setup Completion </button><p>' : ''}
       </div>
@@ -124,7 +126,7 @@ customElements.define('system-status', class extends HTMLElement {
 
     this.button = this.root.querySelector('button')
 
-    if (this.installed) {
+    if (false) {
       this.root.querySelector('#setup').style.display = 'none'
     } else {
       this.root.querySelector('pear-welcome').style.display = 'none'


### PR DESCRIPTION
This PR fixes navigation after installation. Before this fix, the documentation would show below the setup button if clicked after installation. See:

![image](https://github.com/holepunchto/pear-desktop/assets/15270736/e7d613a0-d7e2-4319-8ed4-4ef85c505dee)
