### PR TITLE
fix extraneous closing tag in example HTML

### DIFF
--- a/guide/making-a-pear-desktop-app.md
+++ b/guide/making-a-pear-desktop-app.md
@@ -154,8 +154,8 @@ Start by defining the app's layout in `index.html`:
           <input type="submit" value="Send" />
         </form>
       </div>
-    </div>
-  </main>
+    </main>
+  </body>
 </html>
 ```
 


### PR DESCRIPTION
Prettier caught the extra `</div>`. Technically, `<body>` doesn't need to be closed, but it helps keep indentation consistent.