### PR TITLE
Adjust hyperswarm example to pass topic arg directly

### DIFF
--- a/howto/connect-to-many-peers-by-topic-with-hyperswarm.md
+++ b/howto/connect-to-many-peers-by-topic-with-hyperswarm.md
@@ -48,7 +48,7 @@ process.stdin.on('data', d => {
 })
 
 // Join a common topic
-const topic = process.argv[2] ? b4a.from(process.argv[2], 'hex') : crypto.randomBytes(32)
+const topic = process.argv[3] ? b4a.from(process.argv[3], 'hex') : crypto.randomBytes(32)
 const discovery = swarm.join(topic, { client: true, server: true })
 
 // The flushed promise will resolve when the topic has been fully announced to the DHT
@@ -61,9 +61,9 @@ In one terminal, open `peer-app` with `pear dev`
 
 ```
 cd peer-app
-pear dev
+pear dev .
 ```
 
-This will display the topic. Copy/paste that topic into as many additional terminals as desired with `pear dev -- <SUPPLY TOPIC HERE>` (assuming that the current working directory of each terminal is the `peer-app` folder). Each peer will log information about the other connected peers.
+This will display the topic. Copy/paste that topic into as many additional terminals as desired with `pear dev . <SUPPLY TOPIC HERE>` (assuming that the current working directory of each terminal is the `peer-app` folder). Each peer will log information about the other connected peers.
 
 Start typing into any terminal, and it will be broadcast to all connected peers.


### PR DESCRIPTION
It seems the tutorial as is assumes that `--` will pass the args to the application instead of to pear itself. I'm not sure when this became the case, but currently it works to just point to the app via the `.` (since the tutorial directs the user to cd into the app directory) and pass the `topic` afterwards.

With this change, the argument position needs to be changed as well.

Added explicit `.` for the first run of the app to make it more obvious that the second run of the app is just passing the topic instead of automatically generating one.