### PR TITLE
Fixed command-line argument parameter

### DIFF
--- a/howto/connect-to-many-peers-by-topic-with-hyperswarm.md
+++ b/howto/connect-to-many-peers-by-topic-with-hyperswarm.md
@@ -49,7 +49,7 @@ process.stdin.on('data', d => {
 })
 
 // Join a common topic
-const topic = process.argv[2] ? b4a.from(process.argv[2], 'hex') : crypto.randomBytes(32)
+const topic = process.argv[3] ? b4a.from(process.argv[3], 'hex') : crypto.randomBytes(32)
 const discovery = swarm.join(topic, { client: true, server: true })
 
 // The flushed promise will resolve when the topic has been fully announced to the DHT

--- a/howto/connect-two-peers-by-key-with-hyperdht.md
+++ b/howto/connect-two-peers-by-key-with-hyperdht.md
@@ -67,8 +67,8 @@ import DHT from 'hyperdht'
 import b4a from 'b4a'
 import process from 'bare-process'
 
-console.log('Connecting to:', process.argv[2])
-const publicKey = b4a.from(process.argv[2], 'hex')
+console.log('Connecting to:', process.argv[3])
+const publicKey = b4a.from(process.argv[3], 'hex')
 
 const dht = new DHT()
 const conn = dht.connect(publicKey)

--- a/howto/create-a-full-peer-to-peer-filesystem-with-hyperdrive.md
+++ b/howto/create-a-full-peer-to-peer-filesystem-with-hyperdrive.md
@@ -188,7 +188,7 @@ Pear.teardown(() => swarm.destroy())
 swarm.on('connection', conn => store.replicate(conn))
 
 // create/get the hypercore instance using the public key supplied as command-line arg
-const core = store.get({ key: b4a.from(process.argv[2], 'hex') })
+const core = store.get({ key: b4a.from(process.argv[3], 'hex') })
 
 // create a hyperbee instance using the hypercore instance
 const bee = new Hyperbee(core, {

--- a/howto/share-append-only-databases-with-hyperbee.md
+++ b/howto/share-append-only-databases-with-hyperbee.md
@@ -188,7 +188,7 @@ Pear.teardown(() => swarm.destroy())
 swarm.on('connection', conn => store.replicate(conn))
 
 // create or get the hypercore using the public key supplied as command-line argument
-const core = store.get({ key: b4a.from(process.argv[2], 'hex') })
+const core = store.get({ key: b4a.from(process.argv[3], 'hex') })
 // wait till the properties of the hypercore instance are initialized
 await core.ready()
 


### PR DESCRIPTION
Fixed command-line argument handling across files
references from process.argv[2] to process.argv[3] across several files for correct argument parsing.