### PR TITLE
Use 4th argument instead of 3rd

### DIFF
--- a/howto/connect-two-peers-by-key-with-hyperdht.md
+++ b/howto/connect-two-peers-by-key-with-hyperdht.md
@@ -67,8 +67,8 @@ import DHT from 'hyperdht'
 import b4a from 'b4a'
 import process from 'bare-process'
 
-console.log('Connecting to:', process.argv[2])
-const publicKey = b4a.from(process.argv[2], 'hex')
+console.log('Connecting to:', process.argv[3])
+const publicKey = b4a.from(process.argv[3], 'hex')
 
 const dht = new DHT()
 const conn = dht.connect(publicKey)


### PR DESCRIPTION
`process.argv` is

```
[
  'pear',
  'dev',
  '--',
  '<the key>',
  '.'
]
```
So the key is the 4th argument