### PR TITLE
Add `--force` flag for dump CLI

### DIFF
--- a/reference/pear/cli.md
+++ b/reference/pear/cli.md
@@ -163,6 +163,7 @@ Synchronize files from key to dir.
 ```
   --checkout=n              Dump from specified checkout, n is version length
   --json                    Newline delimited JSON output
+  --force|-f                Force overwrite existing files
   --no-ask                  Suppress permissions dialogs
   --help|-h                 Show help
 ```


### PR DESCRIPTION
Flag added in https://github.com/holepunchto/pear/pull/380.

This probably needs to wait to be merged until next release?