### PR TITLE
Convert all howtos to use `pear run --dev`

### DIFF
--- a/howto/connect-to-many-peers-by-topic-with-hyperswarm.md
+++ b/howto/connect-to-many-peers-by-topic-with-hyperswarm.md
@@ -58,13 +58,13 @@ discovery.flushed().then(() => {
 })
 ```
 
-In one terminal, open `peer-app` with `pear dev`
+In one terminal, open `peer-app` with `pear run --dev .`
 
 ```
 cd peer-app
-pear dev .
+pear run --dev .
 ```
 
-This will display the topic. Copy/paste that topic into as many additional terminals as desired with `pear dev . <SUPPLY TOPIC HERE>` (assuming that the current working directory of each terminal is the `peer-app` folder). Each peer will log information about the other connected peers.
+This will display the topic. Copy/paste that topic into as many additional terminals as desired with `pear run --dev . <SUPPLY TOPIC HERE>` (assuming that the current working directory of each terminal is the `peer-app` folder). Each peer will log information about the other connected peers.
 
 Start typing into any terminal, and it will be broadcast to all connected peers.

--- a/howto/connect-two-peers-by-key-with-hyperdht.md
+++ b/howto/connect-two-peers-by-key-with-hyperdht.md
@@ -50,7 +50,7 @@ server.listen(keyPair).then(() => {
 Pear.teardown(() => server.close())
 ```
 
-Open the `server-app` with `pear dev`.
+Open the `server-app` with `pear run --dev .`.
 
 Create the `client-app` project with the following commands:
 
@@ -81,7 +81,7 @@ Pass the key to the client:
 
 ```
 cd client-app
-pear dev -- <SUPPLY KEY HERE>
+pear run --dev . -- <SUPPLY KEY HERE>
 ```
 
 The `client-app` will spin up a client, and the public key copied earlier must be supplied as a command line argument for connecting to the server. The client process will log `got connection` into the console when it connects to the server.

--- a/howto/create-a-full-peer-to-peer-filesystem-with-hyperdrive.md
+++ b/howto/create-a-full-peer-to-peer-filesystem-with-hyperdrive.md
@@ -69,11 +69,11 @@ async function mirrorDrive () {
 }
 ```
 
-Open the `drive-writer-app` with `pear dev`:
+Open the `drive-writer-app` with `pear run --dev .`:
 
 ```
 cd drive-writer-app
-pear dev
+pear run --dev .
 ```
 
 The `drive-writer-app` creates a `LocalDrive` instance for a local directory and then mirrors the `LocalDrive` into the Hyperdrive instance. 
@@ -148,11 +148,11 @@ async function mirrorDrive () {
 
 The `drive-reader-app` creates a `LocalDrive` instance for a local directory and then mirrors the contents of the local Hyperdrive instance into the `LocalDrive` instance (which will write the contents to the local directory).
 
-In a new terminal, execute the `drive-reader-app` with `pear dev`, passing the key that the `drive-writer-app` already output:
+In a new terminal, execute the `drive-reader-app` with `pear run --dev .`, passing the key that the `drive-writer-app` already output:
 
 ```
 cd drive-reader-app
-pear dev -- <SUPPLY_KEY_HERE>
+pear run --dev . -- <SUPPLY_KEY_HERE>
 ```
 
 `LocalDrive` does not create the directory passed to it until something has been written, so create the `drive-writer-app/writer-dir` (`mkdir writer-dir`) and then add/remove/modify files inside `drive-writer-app/writer-dir` then press `Enter` in the writer's terminal (to import the local changes into the writer's drive). Observe that all new changes mirror into `reader-app/reader-dir`.
@@ -219,11 +219,11 @@ async function listBee () {
 
 Now the Hyperdrive can be inspected as though it were a Hyperbee, and log out some file metadata.
 
-Execute the `bee-reader-app` with `pear dev`, passing it the key output by the `driver-writer-app`:
+Execute the `bee-reader-app` with `pear run --dev .`, passing it the key output by the `driver-writer-app`:
 
 ```
 cd bee-reader-app
-pear dev
+pear run --dev .
 ```
 
 The `bee-reader-app` creates a Hyperbee instance using the Hypercore instance created with the copied public key. Every time the Hyperbee is updated (an `append` event is emitted on the underlying Hypercore), all file metadata nodes will be logged out.

--- a/howto/replicate-and-persist-with-hypercore.md
+++ b/howto/replicate-and-persist-with-hypercore.md
@@ -99,11 +99,11 @@ for await (const block of core.createReadStream({ start: core.length, live: true
 }
 ```
 
-In one terminal, open `writer-app` with `pear dev`.
+In one terminal, open `writer-app` with `pear run --dev .`.
 
 ```
 cd writer-app
-pear dev
+pear run --dev .
 ```
 
 The `writer-app` will output the Hypercore key.
@@ -112,7 +112,7 @@ In another terminal, open the `reader-app` and pass it the key:
 
 ```
 cd reader-app
-pear dev -- <SUPPLY THE KEY HERE>
+pear run --dev . -- <SUPPLY THE KEY HERE>
 ```
 
 As inputs are made to the terminal running the writer application, outputs should be shown in the terminal running the reader application.

--- a/howto/share-append-only-databases-with-hyperbee.md
+++ b/howto/share-append-only-databases-with-hyperbee.md
@@ -73,11 +73,11 @@ if (core.length <= 1) {
 }
 ```
 
-Open the app with `pear dev`:
+Open the app with `pear run --dev .`:
 
 ```
 cd bee-writer-app
-pear dev
+pear run --dev .
 ```
 
 Start the `bee-reader-app` project with the following commands:
@@ -149,7 +149,7 @@ Open the `bee-reader-app` and pass it the core key:
 
 ```
 cd bee-reader-app
-pear dev -- <SUPPLY KEY HERE>
+pear run --dev . -- <SUPPLY KEY HERE>
 ```
 
 Query the database by entering a key to lookup into the `bee-reader-app` terminal and hitting return.
@@ -208,11 +208,11 @@ console.log(`Raw Block ${seq}:`, lastBlock)
 console.log(`Decoded Block ${seq}`, Node.decode(lastBlock))
 ```
 
-Open the `core-reader-app` with `pear dev`, passing the core key to it:
+Open the `core-reader-app` with `pear run --dev .`, passing the core key to it:
 
 ```
 cd core-reader-app
-pear dev -- <SUPPLY KEY HERE>
+pear run --dev . -- <SUPPLY KEY HERE>
 ```
 
 Now we can examine the Hyperbee as if it were just a Hypercore.

--- a/howto/work-with-many-hypercores-using-corestore.md
+++ b/howto/work-with-many-hypercores-using-corestore.md
@@ -127,11 +127,11 @@ for (const key of otherKeys) {
 }
 ```
 
-In one terminal, open `multicore-writer-app` with `pear dev`.
+In one terminal, open `multicore-writer-app` with `pear run --dev .`.
 
 ```
 cd  multicore-writer-app
-pear dev
+pear run --dev .
 ```
 
 The `multicore-writer-app` will output the main core key.
@@ -140,7 +140,7 @@ In another terminal, open the `multicore-reader-app` and pass it the key:
 
 ```
 cd multicore-reader-app
-pear dev . <SUPPLY THE KEY HERE>
+pear run --dev . <SUPPLY THE KEY HERE>
 ```
 
 As inputs are made to the terminal running the writer application, outputs should be shown in the terminal running the reader application.


### PR DESCRIPTION
Also added a `.` where missing as a `<dir>` is required if not using a `<link>`.