### PR TITLE
Doc updates for Pear release 1.6.0

### DIFF
--- a/reference/pear/api.md
+++ b/reference/pear/api.md
@@ -168,6 +168,16 @@ Root directory of project.
 
 Directory for Pear runtime.
 
+### `Pear.config.dht.nodes <Array<Object>>`
+
+A list of known [DHT](../../building-blocks/hyperdht.md) nodes of the form `{ host: <String>, port: <Number> }`. The nodes are set when the Pear application is started.
+
+Unless started with a custom set of bootstrap nodes, Pear caches known nodes to speed up connecting to the swarm and to make it more resilient.
+
+### `Pear.config.dht.bootstrap <Array<Object>>`
+
+A list of custom bootstrap nodes Pear is started with of the form `{ host: <String>, port: <Number> }`.
+
 ## `Pear.checkpoint(<Any>) => Promise`
 
 Stores state that will be available as `Pear.config.checkpoint` next time the application starts.

--- a/reference/pear/cli.md
+++ b/reference/pear/cli.md
@@ -188,10 +188,14 @@ This command instructs any existing sidecar process to shutdown
 and then becomes the sidecar.
 
 ```
-  --verbose|-v     Additional output
-  --mem            memory mode: RAM corestore
-  --key=key        Advanced. Switch release lines
-  --help|-h        Show help
+  --mem                 memory mode: RAM corestore
+  --log-level <level>   Level to log at. 0,1,2,3 (OFF,ERR,INF,TRC)
+  --log-labels <list>   Labels to log (internal, always logged)
+  --log-fields <list>   Show/hide: date,time,h:level,h:label,h:delta
+  --log-stacks          Add a stack trace to each log message
+  --log                 Label:sidecar Level:2 Fields: h:level,h:label
+  --key <key>           Advanced. Switch release lines
+  --help|-h             Show help
 ```
 
 ## `pear versions`

--- a/reference/pear/cli.md
+++ b/reference/pear/cli.md
@@ -158,6 +158,7 @@ Synchronize files from link to dir.
 > To dump to stdout use `-` in place of `<dir>`
 
 ```
+  --dry-run|-d              Execute a dump without writing
   --checkout=n              Dump from specified checkout, n is version length
   --json                    Newline delimited JSON output
   --force|-f                Force overwrite existing files


### PR DESCRIPTION
Includes updates for the following changes in 1.6.0:

- Internal - Added sidecar logs
- Performance - Added DHT persistent cache
- CLI - pear dump --dry-run flag

The preferences methods have already been [removed](https://github.com/holepunchto/pear-docs/pull/146).