### PR TITLE
Add `bare-expo` example & brief architecture explanation

### DIFF
--- a/examples/bare-on-mobile.md
+++ b/examples/bare-on-mobile.md
@@ -6,7 +6,7 @@ To get started with embedding [Bare](../reference/bare/overview.md) into an [Exp
 
 [^1]: This term was chosen to avoid ambiguity with worker threads as implemented by <https://github.com/holepunchto/bare-worker>.
 
-The following examples can be used as references for building more deeply mobile applications using the Bare runtime:
+For deeper integration with a mobile application, the following examples can be used as references:
 
 - [Bare Android](https://github.com/holepunchto/bare-android)
 - [Bare iOS](https://github.com/holepunchto/bare-ios)

--- a/examples/bare-on-mobile.md
+++ b/examples/bare-on-mobile.md
@@ -1,10 +1,14 @@
 # Bare on Mobile
 
-The following examples can be used as references for building mobile applications using the Bare runtime:
+Bare can be embedded into mobile applications to serve as the "Pear-end" where the peer-to-peer code of the application is run.
+
+To get started with embedding [Bare](../reference/bare/overview.md) into an [Expo](https://expo.dev/) mobile application use the [Bare on Expo](https://github.com/holepunchto/bare-expo) example as reference. This example integrates Bare as an isolated thread, called a worklet, via [`react-native-bare-kit`](https://github.com/holepunchto/react-native-bare-kit). All code passed when starting the worklet will run in the Bare runtime.
+
+The following examples can be used as references for building more deeply mobile applications using the Bare runtime:
 
 - [Bare Android](https://github.com/holepunchto/bare-android)
 - [Bare iOS](https://github.com/holepunchto/bare-ios)
 
 > The Bare JavaScript runtime runs equally well on both mobile and desktop applications.
 
-For further reference on using Bare, please refer to [GitHub (Bare)](https://github.com/holepunchto/bare)
+For further reference on using Bare, please refer to [GitHub (Bare)](https://github.com/holepunchto/bare).

--- a/examples/bare-on-mobile.md
+++ b/examples/bare-on-mobile.md
@@ -2,7 +2,9 @@
 
 Bare can be embedded into mobile applications to serve as the "Pear-end" where the peer-to-peer code of the application is run.
 
-To get started with embedding [Bare](../reference/bare/overview.md) into an [Expo](https://expo.dev/) mobile application use the [Bare on Expo](https://github.com/holepunchto/bare-expo) example as reference. This example integrates Bare as an isolated thread, called a worklet, via [`react-native-bare-kit`](https://github.com/holepunchto/react-native-bare-kit). All code passed when starting the worklet will run in the Bare runtime.
+To get started with embedding [Bare](../reference/bare/overview.md) into an [Expo](https://expo.dev/) mobile application use the [Bare on Expo](https://github.com/holepunchto/bare-expo) example as reference. This example integrates Bare as an isolated thread, called a worklet[^1], via [`react-native-bare-kit`](https://github.com/holepunchto/react-native-bare-kit). All code passed when starting the worklet will run in the Bare runtime.
+
+[^1]: This term was chosen to avoid ambiguity with worker threads as implemented by <https://github.com/holepunchto/bare-worker>.
 
 The following examples can be used as references for building more deeply mobile applications using the Bare runtime:
 

--- a/examples/bare-on-mobile.md
+++ b/examples/bare-on-mobile.md
@@ -2,7 +2,7 @@
 
 Bare can be embedded into mobile applications to serve as the "Pear-end" where the peer-to-peer code of the application is run.
 
-To get started with embedding [Bare](../reference/bare/overview.md) into an [Expo](https://expo.dev/) mobile application use the [Bare on Expo](https://github.com/holepunchto/bare-expo) example as reference. This example integrates Bare as an isolated thread, called a worklet[^1], via [`react-native-bare-kit`](https://github.com/holepunchto/react-native-bare-kit). All code passed when starting the worklet will run in the Bare runtime.
+To get started with embedding [Bare](../reference/bare/overview.md) into an [Expo](https://expo.dev/) mobile application use the [Bare on Expo](https://github.com/holepunchto/bare-expo) example as reference. This example integrates Bare as an isolated thread, called a worklet[^1], via [`react-native-bare-kit`](https://github.com/holepunchto/react-native-bare-kit). All code passed when starting the worklet will run in the Bare runtime and can be communicated with via remote procedure calls.
 
 [^1]: This term was chosen to avoid ambiguity with worker threads as implemented by <https://github.com/holepunchto/bare-worker>.
 


### PR DESCRIPTION
Added an explanation of the "Pear-end" / worklet pattern to give context to why one wants to use Bare in a mobile application.