### PR TITLE
Pear release 1.7.0

### DIFF
--- a/reference/pear/api.md
+++ b/reference/pear/api.md
@@ -375,11 +375,12 @@ will be waited upon until resolution before calling the next teardown handler.
 
 ### Pear.reload()
 
-Soft-restart Terminal applications (keeps I/O), refresh application in Desktop applications.
+Refresh application in Desktop applications. Not available in terminal
+applications.
 
 ### `Pear.restart()`
 
-Restart the application.
+Restart the application. Desktop Applications only.
 
 ### `Pear.exit(code)`
 

--- a/reference/pear/api.md
+++ b/reference/pear/api.md
@@ -334,10 +334,6 @@ Captures available desktop sources. Resolves to an array of objects with shape `
 
 **References**
 
-* [win.getMediaSourceId()](#const-sourceid--await-wingetmediasourceid)
-* [view.getMediaSourceId()](#const-sourceid--await-viewgetmediasourceid)
-* [self.getMediaSourceId()](#const-sourceid--await-selfgetmediasourceid)
-* [parent.getMediaSourceId()](#const-sourceid--await-parentgetmediasourceid)
 * https://www.electronjs.org/docs/latest/api/desktop-capturer#desktopcapturergetsourcesoptions
 * https://www.electronjs.org/docs/latest/api/structures/desktop-capturer-source
 * [`<NativeImage>`](https://www.electronjs.org/docs/latest/api/native-image)
@@ -566,17 +562,6 @@ Unmaximize/unminimize the window if it is currently maximized/minimized.
 Send arguments to the window. They will be serialized with `JSON.stringify`.
 
 
-### `const sourceId = await win.getMediaSourceId()`
-
-Resolves to: `<String>`
-
-Correlates to the `id` property of objects in the array returned from [Pear.media.desktopSources](#const-sources---await-appmediadesktopsources-options).
-
-**References**
-
-* [Pear.media.desktopSources](#const-sources--await-appmediadesktopsourcesoptions-object)
-* https://www.electronjs.org/docs/latest/api/browser-window#wingetmediasourceid
-
 ### `const dimensions = await win.dimensions()`
 
 Resolves to: `{x <Integer>, y <Integer>, width <Integer>, height <Integer>} | null`.
@@ -732,17 +717,6 @@ Blur the view.
 
 Send arguments to the view. They will be serialized with `JSON.stringify`.
 
-### `const sourceId = await view.getMediaSourceId()`
-
-Resolves to: `<String>`
-
-Supplies the `id` property of objects in the array returned from [Pear.media.desktopSources](#const-sources---await-appmediadesktopsources-options).
-
-**References**
-
-* [Pear.media.desktopSources](#const-sources---await-appmediadesktopsources-options)
-* https://www.electronjs.org/docs/latest/api/browser-window#wingetmediasourceid
-
 ### `const dimensions = await view.dimensions()`
 
 Resolves to: `{x <Integer>, y <Integer>, width <Integer>, height <Integer>} | null`.
@@ -830,15 +804,6 @@ Resolves to: `<Boolean>`
 
 Hide current view or window.
 
-### `const sourceId = await self.getMediaSourceId()`
-
-Get the sourceId of the current window or view.
-
-**References**
-
-* [win.getMediaSourceId()](const-sourceId--await-wingetMediaSourceId)
-
-
 ### `const success = await self.minimize()`
 
 Resolves to: `<Boolean>`
@@ -924,15 +889,6 @@ Show parent view or window.
 Resolves to: `<Boolean>`
 
 Hide parent view or window.
-
-### `const sourceId = await parent.getMediaSourceId()`
-
-Get the sourceId of the parent window or view.
-
-**References**
-
-* [win.getMediaSourceId()](#const-sourceId--await-wingetMediaSourceId)
-
 
 ### `const success = await parent.minimize()`
 

--- a/reference/pear/cli.md
+++ b/reference/pear/cli.md
@@ -158,6 +158,7 @@ Synchronize files from link to dir.
 > To dump to stdout use `-` in place of `<dir>`
 
 ```
+  --dry-run|-d              Execute a dump without writing
   --checkout=n              Dump from specified checkout, n is version length
   --json                    Newline delimited JSON output
   --force|-f                Force overwrite existing files


### PR DESCRIPTION
Updating docs to Pear 1.7.0.

Changes:
- Remove `.getMediaSourceId()`
- Note that `Pear.restart()` & `Pear.reload()` is desktop only
- Add back `--dry-run` flag for `dump` command