### PR TITLE
Change RPC to IPC language in mobile bare docs

### DIFF
--- a/examples/bare-on-mobile.md
+++ b/examples/bare-on-mobile.md
@@ -2,7 +2,7 @@
 
 Bare can be embedded into mobile applications to serve as the "Pear-end" where the peer-to-peer code of the application is run.
 
-To get started with embedding [Bare](../reference/bare/overview.md) into an [Expo](https://expo.dev/) mobile application use the [Bare on Expo](https://github.com/holepunchto/bare-expo) example as reference. This example integrates Bare as an isolated thread, called a worklet[^1], via [`react-native-bare-kit`](https://github.com/holepunchto/react-native-bare-kit). All code passed when starting the worklet will run in the Bare runtime and can be communicated with via remote procedure calls.
+To get started with embedding [Bare](../reference/bare/overview.md) into an [Expo](https://expo.dev/) mobile application use the [Bare on Expo](https://github.com/holepunchto/bare-expo) example as reference. This example integrates Bare as an isolated thread, called a worklet[^1], via [`react-native-bare-kit`](https://github.com/holepunchto/react-native-bare-kit). All code passed when starting the worklet will run in the Bare runtime and can be communicated with via an inter-process communication (IPC) stream.
 
 [^1]: This term was chosen to avoid ambiguity with worker threads as implemented by <https://github.com/holepunchto/bare-worker>.
 


### PR DESCRIPTION
`bare-kit` API switched to just an IPC abstraction.