### PR TITLE
Pear release 1.8.0 docs

### DIFF
--- a/guide/sharing-a-pear-app.md
+++ b/guide/sharing-a-pear-app.md
@@ -34,7 +34,7 @@ The channel name can be any valid name. Using `dev` for local development checks
 
 Stage will output a diff of changes - the first time will all be additions of course - and then it will output the application link.
 
-If the application is a desktop application there will also be a warmup step where the application is opened in the background and analyzed for initialization-to-loaded critical-path. This metadata is stored along with the application into an application-dedicated hypercore inside Pear. This helps the desktop application load faster. All state is local and by default only the original machine that stages an application can write to this application-dedicated hypercore.
+There will be a warmup step where the application is analyzed for initialization-to-loaded critical-path. This metadata is stored along with the application into an application-dedicated hypercore inside Pear. This helps the application load faster. All state is local and by default only the original machine that stages an application can write to this application-dedicated hypercore.
 
 > Some frontend frameworks will load different assets based on whether the `NODE_ENV` environment variable is set to `production`. If the application has this need, use `NODE_ENV=production pear stage dev` in order to stage the production library code so that when Stage Warmup occurs the captured critical-path consists of production assets.
 

--- a/reference/pear/api.md
+++ b/reference/pear/api.md
@@ -433,6 +433,14 @@ The `listener` function is called for every incoming wakeup with a `wakeup` obje
 
 Also returns a [`streamx`](https://github.com/mafintosh/streamx) `Readable`) stream.
 
+### `Pear.badge(count <Integer|null>) => Promise<Boolean>`
+
+Set the badge number for the application on desktop for Linux & MacOS. Setting the `count` to `0` will hide the badge while `null` will display a plain dot on MacOS only.
+
+Returns a `Boolean` promise for whether the call succeeded.
+
+Desktop Applications only.
+
 ### `const win = new Pear.Window(entry <String>, options <Object>)`
 
 Desktop Applications only.

--- a/reference/pear/cli.md
+++ b/reference/pear/cli.md
@@ -48,7 +48,8 @@ Outputs diff information and project link.
 ```
   --json                      Newline delimited JSON output
   --dry-run|-d                Execute a stage without writing
-  --ignore                    Comma separated file path ignore list
+  --ignore <list>             Comma separated file path ignore list
+  --truncate <n>              Advanced. Truncate to version length n
   --name                      Advanced. Override app name
   --no-ask                    Suppress permissions dialogs
   --help|-h                   Show help

--- a/reference/pear/configuration.md
+++ b/reference/pear/configuration.md
@@ -155,7 +155,9 @@ Note that this is only for requests that the Pear app makes itself such as loadi
 
 ### `pear.userAgent <string>` (default: `Pear ${Pear.#state.id}`)
 
-User Agent to use when Pear makes web requests. Desktop Applications only.
+User Agent to use when Pear makes web requests. Pear will use the default `userAgent` when making requests to the Sidecar.
+
+Desktop Applications only.
 
 ### `pear.stage <Object>`
 

--- a/reference/pear/configuration.md
+++ b/reference/pear/configuration.md
@@ -153,6 +153,10 @@ Note that this is only for requests that the Pear app makes itself such as loadi
 }
 ```
 
+### `pear.userAgent <string>` (default: `Pear ${Pear.#state.id}`)
+
+User Agent to use when Pear makes web requests. Desktop Applications only.
+
 ### `pear.stage <Object>`
 
 Staging configuration options.

--- a/reference/pear/configuration.md
+++ b/reference/pear/configuration.md
@@ -159,7 +159,11 @@ Staging configuration options.
 
 #### `pear.stage.entrypoints <Array>`
 
-An array of entrypoints as staging start-points in addition to (deduped) main entry point.
+An array of entrypoint paths as staging start-points in addition to (deduped) main entry point.
+
+#### `pear.stage.prefetch <Array>`
+
+An array of file paths to the warmup during staging in addition to all entry points. This is useful for loading assets needed to start the application quickly.
 
 #### `pear.stage.ignore <Array>`
 


### PR DESCRIPTION
Includes:

## API
- `Pear.badge(count)`  
   Note that I picked `null` to be the documented way to display a plain dot. The API deviates from electron a smidge in that it needs something that is coerced into a number, but because the `count` needs to be not a number to be a plain dot, I picked `null` instead of `undefined`.

## Config
- `pear.stage.prefetch`
- `pear.userAgent`

## CLI
- minor update to `stage` command (the rest is already up to date)

## Guides
- Update info about warmup process to reflect the new `drive-analyzer` approach  
   Removed mention of it being run in the background and that it was desktop only.