### PR TITLE
Correct type description for `encryptionKey` option

### DIFF
--- a/building-blocks/hypercore.md
+++ b/building-blocks/hypercore.md
@@ -120,7 +120,7 @@ Hypercore will produce the following files:
 |  **`valueEncoding`**  | one of 'json', 'utf-8', or 'binary'                                                     | String   | `'binary'`         |
 |   **`encodeBatch`**   | optionally apply an encoding to complete batches                                        | Function | `batch => { ... }` |
 |     **`keyPair`**     | optionally pass the public key and secret key as a key pair                             | Object   | `null`             |
-|  **`encryptionKey`**  | optionally pass an encryption key to enable block encryption                            | String   | `null`             |
+|  **`encryptionKey`**  | optionally pass an encryption key to enable block encryption                            | Buffer   | `null`             |
 |      **`onwait`**     | hook that is called if gets are waiting for download                                    | Function | `() => {}`         |
 |     **`timeout`**     | constructor timeout                                                                     | integer  | `0`                  |
 |     **`writable`**     |  disable appends and truncates                                                                     | Boolean  | `true`                |


### PR DESCRIPTION
Passing a `string` to the `encryptionKey` option doesn't work with hypercore `10.38.2`:

```js
import Corestore from "corestore"

const store = new Corestore(storageLocation);
const core = store.get({ encryptionKey: "password" })
```

Error:

```
  TypeError [Error]: batch element should be passed as a TypedArray
      at new BlockEncryption (/Users/didericis/Code/textorbium/node_modules/hypercore/lib/block-encryption.js:21:26)
      at Hypercore._openCapabilities (/Users/didericis/Code/textorbium/node_modules/hypercore/index.js:425:25)
      at async Hypercore._openSession (/Users/didericis/Code/textorbium/node_modules/hypercore/index.js:327:7)
```

This works fine:

```js
import Corestore from "corestore"
import b4a from "b4a"

const store = new Corestore(storageLocation);
const core = store.get({ encryptionKey: b4a.from("password") })
```