### PR TITLE
Pear release 1.11.1 docs

### DIFF
--- a/reference/pear/api.md
+++ b/reference/pear/api.md
@@ -451,6 +451,28 @@ Returns a `Boolean` promise for whether the call succeeded.
 
 Desktop Applications only.
 
+### `Pear.tray(options <Object>, listener <Async Function|Function>) => Promise<untray()>`
+
+Configure a tray icon for the application. This method will return a promise which resolve to a `untray()` method for removing the tray.
+
+The `listener` function is triggered whenever a menu item or the tray icon is clicked. It receives a single argument `key` that represents the menu item `key` that was clicked or the special value of `'click'` for when the menu icon itself was clicked. If no `listener` function is provided, a default listener will show the application window when triggered with `'click'` or `'show'` and quits with `'quit'`.
+
+A Pear application must be `hideable` to support adding a tray (see
+[`pear.gui.hideable`](./configuration.md#pear.gui.hideable-less-than-boolean-greater-than-default-false)).
+
+Desktop Applications only.
+
+**Options**
+
+* `icon <String>` Default: The Pear icon - The path for icon for the tray
+  relative to the project root.
+* `menu <Object>` Default: `{ show: `Show ${Pear.config.name}`, quit: 'Quit' }` - The
+  tray menu items. Each property of the object is the `key` passed to the
+  `listener` and whose value is the text displayed in the menu.
+* `os <Object>` Default: `{ win32: true, linux: true, darwin: true  }` - which
+  platforms support using the tray menu. The platform is checked via the
+  `process.platform` value.
+
 ### `const win = new Pear.Window(entry <String>, options <Object>)`
 
 Desktop Applications only.

--- a/reference/pear/api.md
+++ b/reference/pear/api.md
@@ -457,8 +457,9 @@ Configure a tray icon for the application. This method will return a promise whi
 
 The `listener` function is triggered whenever a menu item or the tray icon is clicked. It receives a single argument `key` that represents the menu item `key` that was clicked or the special value of `'click'` for when the menu icon itself was clicked. If no `listener` function is provided, a default listener will show the application window when triggered with `'click'` or `'show'` and quits with `'quit'`.
 
-A Pear application must be `hideable` to support adding a tray (see
-[`pear.gui.hideable`](./configuration.md#pear.gui.hideable-less-than-boolean-greater-than-default-false)).
+A Pear application must be `hideable` to support adding a tray (see [`pear.gui.hideable`](./configuration.md#pear.gui.hideable-less-than-boolean-greater-than-default-false)).
+
+WARNING: Linux tray support varies which can cause scenarios where the application's tray doesn't work and closing the app will be hidden and inaccessible. Using a tray and `hideable` on Linux is not recommended.
 
 Desktop Applications only.
 

--- a/reference/pear/api.md
+++ b/reference/pear/api.md
@@ -453,7 +453,7 @@ Desktop Applications only.
 
 ### `Pear.tray(options <Object>, listener <Async Function|Function>) => Promise<untray()>`
 
-Configure a tray icon for the application. This method will return a promise which resolves as a `untray()` method for removing the tray.
+Configure a tray icon for the application. This method will return a promise which resolves to an `untray()` function for removing the tray.
 
 The `listener` function is triggered whenever a menu item or the tray icon is clicked. It receives a single argument `key` that represents the menu item `key` that was clicked or the special value of `'click'` for when the menu icon itself was clicked. If no `listener` function is provided, a default listener will show the application window when triggered with `'click'` or `'show'` and quits with `'quit'`.
 

--- a/reference/pear/api.md
+++ b/reference/pear/api.md
@@ -465,7 +465,7 @@ Desktop Applications only.
 **Options**
 
 * `icon <String>` Default: The Pear icon - The path for icon for the tray
-  relative to the project root.
+  relative to the project root. Supported formats: PNG & JPEG
 * `menu <Object>` Default: `{ show: `Show ${Pear.config.name}`, quit: 'Quit' }` - The
   tray menu items. Each property of the object is the `key` passed to the
   `listener` and whose value is the text displayed in the menu.

--- a/reference/pear/api.md
+++ b/reference/pear/api.md
@@ -453,7 +453,7 @@ Desktop Applications only.
 
 ### `Pear.tray(options <Object>, listener <Async Function|Function>) => Promise<untray()>`
 
-Configure a tray icon for the application. This method will return a promise which resolve to a `untray()` method for removing the tray.
+Configure a tray icon for the application. This method will return a promise which resolves as a `untray()` method for removing the tray.
 
 The `listener` function is triggered whenever a menu item or the tray icon is clicked. It receives a single argument `key` that represents the menu item `key` that was clicked or the special value of `'click'` for when the menu icon itself was clicked. If no `listener` function is provided, a default listener will show the application window when triggered with `'click'` or `'show'` and quits with `'quit'`.
 
@@ -466,7 +466,7 @@ Desktop Applications only.
 
 * `icon <String>` Default: The Pear icon - The path for icon for the tray
   relative to the project root. Supported formats: PNG & JPEG
-* `menu <Object>` Default: `{ show: `Show ${Pear.config.name}`, quit: 'Quit' }` - The
+* `menu <Object>` Default: ``{ show: `Show ${Pear.config.name}`, quit: 'Quit' }`` - The
   tray menu items. Each property of the object is the `key` passed to the
   `listener` and whose value is the text displayed in the menu.
 * `os <Object>` Default: `{ win32: true, linux: true, darwin: true  }` - which

--- a/reference/pear/cli.md
+++ b/reference/pear/cli.md
@@ -232,5 +232,27 @@ Perform garbage collection and remove unused resources.
   --help|-h     Show help
 ```
 
+## `pear data [flags] [command]`
+
+View database contents.
+
+The database contains metadata stored on this device used by the Pear runtime.
+
+| Commands   | Description                |
+| ---------- | -------------------------- |
+| apps       | Installed apps             |
+| dht        | DHT known-nodes cache      |
+| gc         | Garbage collection records |
+
+```
+  --secrets   Show sensitive information, i.e. encryption-keys
+  --json      Newline delimited JSON output
+  --help|-h   Show help
+```
+
+### `pear data apps [flags] [link]`
+
+List installed apps, filtered by `[link]` if provided.
+
 
   

--- a/reference/pear/cli.md
+++ b/reference/pear/cli.md
@@ -256,9 +256,9 @@ The database contains metadata stored on this device used by the Pear runtime.
 | gc         | Garbage collection records |
 
 ```
-  --secrets   Show sensitive information, i.e. encryption-keys
-  --json      Newline delimited JSON output
-  --help|-h   Show help
+--secrets   Show sensitive information, i.e. encryption-keys
+--json      Newline delimited JSON output
+--help|-h   Show help
 ```
 
 ### `pear data apps [flags] [link]`

--- a/reference/pear/cli.md
+++ b/reference/pear/cli.md
@@ -156,7 +156,7 @@ Synchronize files from link to dir.
 
 > To dump to stdout use `-` in place of `<dir>`
 
-`<link>` can contain a path portion to dump a subset of the files for the Pear application. For example, if you wanted to dump only the `CHANGELOG.md` from Keet into a `dump-dir` directory, you would run:
+`<link>` can contain a path portion to dump a subset of the files for the Pear application. For example, to dump only the `CHANGELOG.md` from Keet into a `dump-dir` directory run:
 
 ```
 pear dump pear://keet/CHANGELOG.md dump-dir/

--- a/reference/pear/cli.md
+++ b/reference/pear/cli.md
@@ -227,7 +227,9 @@ Move user application storage between applications.
 
 Advanced. Reset an application to initial state
 
-Clears application storage for a given application link. You will ask for confirmation to reset as the storage will be deleted permanently and cannot be recovered. Use with caution.
+Clears application storage for a given application link.
+
+WARNING: Confirmation will be requested as the storage will be deleted permanently and cannot be recovered. Use with caution.
 
 ```
 --json      Newline delimited JSON output

--- a/reference/pear/cli.md
+++ b/reference/pear/cli.md
@@ -91,7 +91,6 @@ Run an application from a link or dir.
   --links <kvs>                  Override configured links with comma-separated key-values
   --chrome-webrtc-internals      Enable chrome://webrtc-internals
   --unsafe-clear-app-storage     Clear app storage
-  --unsafe-clear-preferences     Clear preferences (such as trustlist)
   --appling=path                 Set application shell path
   --checkout=n                   Run a checkout, n is version length
   --checkout=release             Run checkout from marked released length

--- a/reference/pear/cli.md
+++ b/reference/pear/cli.md
@@ -157,6 +157,12 @@ Synchronize files from link to dir.
 
 > To dump to stdout use `-` in place of `<dir>`
 
+`<link>` can contain a path portion to dump a subset of the files for the Pear application. For example, if you wanted to dump only the `CHANGELOG.md` from Keet into a `dump-dir` directory, you would run:
+
+```
+pear dump pear://keet/CHANGELOG.md dump-dir/
+```
+
 ```
   --dry-run|-d              Execute a dump without writing
   --checkout=n              Dump from specified checkout, n is version length

--- a/reference/pear/cli.md
+++ b/reference/pear/cli.md
@@ -218,6 +218,17 @@ Move user application storage between applications.
 --json      Newline delimited JSON output
 ```
 
+## `pear reset [flags] <link>`
+
+Advanced. Reset an application to initial state
+
+Clears application storage for given application link. Will ask for confirmation to reset as the storage will be deleted permanently and cannot be recovered. Use with caution.
+
+```
+--json      Newline delimited JSON output
+--help|-h   Show help
+```
+
 ## `pear gc [flags] [command]`
 
 Perform garbage collection and remove unused resources.

--- a/reference/pear/cli.md
+++ b/reference/pear/cli.md
@@ -227,7 +227,7 @@ Move user application storage between applications.
 
 Advanced. Reset an application to initial state
 
-Clears application storage for given application link. Will ask for confirmation to reset as the storage will be deleted permanently and cannot be recovered. Use with caution.
+Clears application storage for a given application link. You will ask for confirmation to reset as the storage will be deleted permanently and cannot be recovered. Use with caution.
 
 ```
 --json      Newline delimited JSON output

--- a/reference/pear/configuration.md
+++ b/reference/pear/configuration.md
@@ -52,7 +52,7 @@ The following `platform`s are supported:
 
 ### `pear.gui.name <String>`
 
-Override the app name which defaults to [name](#pear.name-less-than-string-greater-than).
+Override the app name which otherwise defaults to [name](#pear.name-less-than-string-greater-than).
 
 #### `pear.gui.width <Number>`
 

--- a/reference/pear/configuration.md
+++ b/reference/pear/configuration.md
@@ -146,6 +146,8 @@ Enable transparency. Must be set for opacity to work.
 
 Keep app running when all windows are closed.
 
+WARNING: Linux tray support varies which can cause scenarios where the application's tray doesn't work and closing the app will be hidden and inaccessible. Using a tray and `hideable` on Linux is not recommended.
+
 #### `pear.gui.backgroundColor <String>` (default: "#000" non-transparent, "#00000000" transparent)
 
 Background color (Hex, RGB, RGBA, HSL, HSLA, CSS color).

--- a/reference/pear/configuration.md
+++ b/reference/pear/configuration.md
@@ -50,6 +50,10 @@ The following `platform`s are supported:
 - `linux`
 - `win32`
 
+### `pear.gui.name <String>`
+
+Override the app name which defaults to [name](#pear.name-less-than-string-greater-than).
+
 #### `pear.gui.width <Number>`
 
 Window width (pixels).


### PR DESCRIPTION
Changes:

- Add `pear.gui.name` configuration option
- Add `Pear.tray()` api
- Add `pear data` cli
  - Including `pear data app [link]` nested command argument
- Add `pear reset cli
- Add note for `pear dump pear://key/path` support for subset of files being dumped