### PR TITLE
Clarify where to run apps in howtos

### DIFF
--- a/howto/connect-two-peers-by-key-with-hyperdht.md
+++ b/howto/connect-two-peers-by-key-with-hyperdht.md
@@ -52,7 +52,7 @@ Pear.teardown(() => server.close())
 
 Open the `server-app` with `pear run --dev .`.
 
-Create the `client-app` project with the following commands:
+In another terminal create the `client-app` project with the following commands:
 
 ```
 mkdir client-app
@@ -80,10 +80,9 @@ conn.once('open', () => console.log('got connection!'))
 process.stdin.pipe(conn).pipe(process.stdout)
 ```
 
-Pass the key to the client:
+Run the client passing it the key from the server:
 
 ```
-cd client-app
 pear run --dev . <SUPPLY KEY HERE>
 ```
 

--- a/howto/create-a-full-peer-to-peer-filesystem-with-hyperdrive.md
+++ b/howto/create-a-full-peer-to-peer-filesystem-with-hyperdrive.md
@@ -225,7 +225,7 @@ Execute the `drive-bee-reader-app` with `pear run --dev .`, passing it the key o
 
 ```
 cd drive-bee-reader-app
-pear run --dev .
+pear run --dev . <SUPPLY_KEY_HERE>
 ```
 
 The `drive-bee-reader-app` creates a Hyperbee instance using the Hypercore instance created with the copied public key. Every time the Hyperbee is updated (an `append` event is emitted on the underlying Hypercore), all file metadata nodes will be logged out.

--- a/howto/create-a-full-peer-to-peer-filesystem-with-hyperdrive.md
+++ b/howto/create-a-full-peer-to-peer-filesystem-with-hyperdrive.md
@@ -69,10 +69,9 @@ async function mirrorDrive () {
 }
 ```
 
-Open the `drive-writer-app` with `pear run --dev .`:
+Open the `drive-writer-app` with:
 
 ```
-cd drive-writer-app
 pear run --dev .
 ```
 
@@ -148,10 +147,9 @@ async function mirrorDrive () {
 
 The `drive-reader-app` creates a `LocalDrive` instance for a local directory and then mirrors the contents of the local Hyperdrive instance into the `LocalDrive` instance (which will write the contents to the local directory).
 
-In a new terminal, execute the `drive-reader-app` with `pear run --dev .`, passing the key that the `drive-writer-app` already output:
+Run the `drive-reader-app` with `pear run --dev .`, passing the key that the `drive-writer-app` already output:
 
 ```
-cd drive-reader-app
 pear run --dev . <SUPPLY_KEY_HERE>
 ```
 
@@ -224,7 +222,6 @@ Now the Hyperdrive can be inspected as though it were a Hyperbee, and log out so
 Execute the `drive-bee-reader-app` with `pear run --dev .`, passing it the key output by the `driver-writer-app`:
 
 ```
-cd drive-bee-reader-app
 pear run --dev . <SUPPLY_KEY_HERE>
 ```
 

--- a/howto/share-append-only-databases-with-hyperbee.md
+++ b/howto/share-append-only-databases-with-hyperbee.md
@@ -73,14 +73,13 @@ if (core.length <= 1) {
 }
 ```
 
-Open the app with `pear run --dev .`:
+Run the app with:
 
 ```
-cd bee-writer-app
 pear run --dev .
 ```
 
-Start the `bee-reader-app` project with the following commands:
+Start the `bee-reader-app` project in a new terminal with the following commands:
 
 ```
 mkdir bee-reader-app
@@ -148,7 +147,6 @@ stdin.on('data', (data) => {
 Open the `bee-reader-app` and pass it the core key:
 
 ```
-cd bee-reader-app
 pear run --dev . <SUPPLY KEY HERE>
 ```
 
@@ -213,7 +211,6 @@ console.log(`Decoded Block ${seq}`, Node.decode(lastBlock))
 Open the `core-reader-app` with `pear run --dev .`, passing the core key to it:
 
 ```
-cd core-reader-app
 pear run --dev . <SUPPLY KEY HERE>
 ```
 


### PR DESCRIPTION
The wording is adjusted to make it clearer when one pear app should be left running and where to run apps in general.

In some cases a reader would be prompted to make a directory and then change directories into it and modify some files. After modifying the files, they would be asked to change into the directory again even though they would be in the directory already. This has been clarified by removing commands for changing directory where the reader will be already in that directory.

Also added a prompt that had a missing argument.