### PR TITLE
remove a redundant replicate corestore

### DIFF
--- a/howto/work-with-many-hypercores-using-corestore.md
+++ b/howto/work-with-many-hypercores-using-corestore.md
@@ -102,7 +102,6 @@ await core.ready()
 
 const foundPeers = core.findingPeers()
 swarm.join(core.discoveryKey)
-swarm.on('connection', conn => core.replicate(conn))
 swarm.flush().then(() => foundPeers())
 
 // update the meta-data of the hypercore instance


### PR DESCRIPTION
corestore is replicated already https://github.com/holepunchto/pear-docs/blob/main/howto/work-with-many-hypercores-using-corestore.md?plain=1#L45

```
swarm.on('connection', (conn) => store.replicate(conn))
```

so no need to replicate again for a hypercore in corestore
```
// no need this core.replicate
swarm.on('connection', conn => core.replicate(conn))
```
