### PR TITLE
Add `libatomic1` as dependency for ubuntu install

### DIFF
--- a/guide/getting-started.md
+++ b/guide/getting-started.md
@@ -10,17 +10,21 @@ Since `npm` (or equivalent package manager) is needed to install application dep
 
 Pear runs on Windows, Mac and Linux.
 
+Linux requires the `libatomic` library which can be installed using:
+
+```console
+sudo apt install libatomic1
+```
+
+```console
+sudo yum install libatomic
+```
+
 The `pear` CLI can be installed from [npm](https://www.npmjs.com/), which comes with [`node`](https://nodejs.org/en/about).
 
 The `npm` package manager can also be used to install application dependencies later on.
 
 On MacOS and Linux, we recommend installing `node` using [`nvm`](https://github.com/nvm-sh/nvm#installing-and-updating)
-
-For Ubuntu, install the following:
-
-```console
-sudo apt install libatomic1
-```
 
 On Windows we recommend installing `node` with [`nvs`](https://github.com/jasongin/nvs#setup).
 

--- a/guide/getting-started.md
+++ b/guide/getting-started.md
@@ -12,12 +12,34 @@ Pear runs on Windows, Mac and Linux.
 
 Linux requires the `libatomic` library which can be installed using:
 
+Debian/Ubuntu:
+
 ```console
 sudo apt install libatomic1
 ```
 
+RHEL/CentOS:
+
 ```console
 sudo yum install libatomic
+```
+
+Fedora:
+
+```console
+sudo dnf install libatomic
+```
+
+Alpine Linux:
+
+```console
+sudo apk add libatomic
+```
+
+Arch Linux:
+
+```console
+sudo pacman -S libatomic_ops
 ```
 
 The `pear` CLI can be installed from [npm](https://www.npmjs.com/), which comes with [`node`](https://nodejs.org/en/about).

--- a/guide/getting-started.md
+++ b/guide/getting-started.md
@@ -16,6 +16,12 @@ The `npm` package manager can also be used to install application dependencies l
 
 On MacOS and Linux, we recommend installing `node` using [`nvm`](https://github.com/nvm-sh/nvm#installing-and-updating)
 
+For Ubuntu, install the following:
+
+```console
+sudo apt install libatomic1
+```
+
 On Windows we recommend installing `node` with [`nvs`](https://github.com/jasongin/nvs#setup).
 
 > The Pear Runtime does not rely on `node`, `node` is only needed to install and run the `npm` package manager.


### PR DESCRIPTION
Necessary for running pear terminal apps in Ubuntu