### PR TITLE
Remove `findingPeers()` & some `flush()` flow from hyperswarm examples

### DIFF
--- a/howto/create-a-full-peer-to-peer-filesystem-with-hyperdrive.md
+++ b/howto/create-a-full-peer-to-peer-filesystem-with-hyperdrive.md
@@ -128,11 +128,8 @@ const mirror = debounce(mirrorDrive)
 // to the Hypercore instance of the hyperdrive
 drive.core.on('append', mirror)
 
-const foundPeers = store.findingPeers()
-
 // join a topic
 swarm.join(drive.discoveryKey, { client: true, server: false })
-swarm.flush().then(() => foundPeers())
 
 // start the mirroring process (i.e copying the contents from remote drive to local dir)
 mirror()
@@ -198,9 +195,8 @@ const bee = new Hyperbee(core, {
 // wait till the properties of the hypercore instance are initialized
 await core.ready()
 
-const foundPeers = store.findingPeers()
 swarm.join(core.discoveryKey)
-swarm.flush().then(() => foundPeers())
+await swarm.flush()
 
 // execute the listBee function whenever the data is appended to the underlying hypercore
 core.on('append', listBee)

--- a/howto/replicate-and-persist-with-hypercore.md
+++ b/howto/replicate-and-persist-with-hypercore.md
@@ -78,18 +78,12 @@ Pear.teardown(() => swarm.destroy())
 const core = new Hypercore(path.join(Pear.config.storage, 'reader-storage'), Pear.config.args[0])
 await core.ready()
 
-const foundPeers = core.findingPeers()
 swarm.join(core.discoveryKey)
 swarm.on('connection', conn => core.replicate(conn))
 
 // swarm.flush() will wait until *all* discoverable peers have been connected to
-// It might take a while, so don't await it
-// Instead, use core.findingPeers() to mark when the discovery process is completed
-swarm.flush().then(() => foundPeers())
+await swarm.flush()
 
-// This won't resolve until either
-//    a) the first peer is found
-// or b) no peers could be found
 await core.update()
 
 let position = core.length

--- a/howto/share-append-only-databases-with-hyperbee.md
+++ b/howto/share-append-only-databases-with-hyperbee.md
@@ -192,10 +192,9 @@ const core = store.get({ key: b4a.from(key, 'hex') })
 // wait till the properties of the hypercore instance are initialized
 await core.ready()
 
-const foundPeers = store.findingPeers()
 // join a topic
 swarm.join(core.discoveryKey)
-swarm.flush().then(() => foundPeers())
+await swarm.flush()
 
 // update the meta-data information of the hypercore instance
 await core.update()

--- a/howto/work-with-many-hypercores-using-corestore.md
+++ b/howto/work-with-many-hypercores-using-corestore.md
@@ -100,9 +100,8 @@ const core = store.get({ key, valueEncoding: 'json' })
 // wait till all the properties of the hypercore instance are initialized
 await core.ready()
 
-const foundPeers = core.findingPeers()
 swarm.join(core.discoveryKey)
-swarm.flush().then(() => foundPeers())
+await swarm.flush()
 
 // update the meta-data of the hypercore instance
 await core.update()


### PR DESCRIPTION
`core.findingPeers()` is more of an advanced method that isn't used often in practice as applications usually only react when cores update. And isn't necessary in the guide.

`swarm.flush()` was kept in scenarios where replicating a hypercore immediately was required for simplicity. This also isn't used often in practice, but for the simplicity of the code, `swarm.flush()` makes sense in some examples.