### PR TITLE
fix: Add teardown callback for mobile guide

### DIFF
--- a/guide/making-a-bare-mobile-app.md
+++ b/guide/making-a-bare-mobile-app.md
@@ -237,6 +237,7 @@ fs.mkdirSync(path)
 const invite = Bare.argv[1]
 const pair = Autopass.pair(new Corestore(path), invite)
 const pass = await pair.finished()
+Bare.on('teardown', () => pass.close())
 
 await pass.ready()
 


### PR DESCRIPTION
Users should close resources like autopass in a teardown callback. In this case it will speed up reruns as `pass.close()` calls hyperswarm's `.destroy()` which will clean up the DHT records, speeding up joining on rerun.