### PR TITLE
Update Troubleshooting Steps for Pear platform itself to be generic

### DIFF
--- a/reference/pear/troubleshooting.md
+++ b/reference/pear/troubleshooting.md
@@ -6,11 +6,11 @@ The article aims to help troubleshooting confusing scenarios while developing Pe
 
 The `Pear.teardown(cb)` callback is triggered whenever the Pear app start to unload. If it is not exiting, then something is keeping the applications event loop running. A common cause of this is not cleaning up the [worker pipe](./api.md#const-pipe-pear.worker.pipe) by calling `pipe.end()` to gracefully end the writable part of the stream.
 
-## `pear run` Exits Without Running the Application
+## `pear` CLI Exits Without Running the Application
 
 If after debugging an application it seems the issue is happening in the Pear platform itself, try the following steps to debug the issue:
 
-1. Run pear app with logs enabled `pear --log run .`.
+1. Run pear command with logs enabled `pear --log [command]`.
 2. If no helpful info, run sidecar with logs `pear sidecar --log-level 3`.  
    If the `pear sidecar` stops after printing `Closing any current Sidecar clients...`, then the current Pear Sidecar process is hanging. Check the next steps for forensics that might explain why, but then kill existing Pear processes.  
    _Note_ that this will close any running pear applications such as Keet.


### PR DESCRIPTION
`pear run` was the most common command to show issues. But it's possible that other commands also could be debugged using the same steps, given `sidecar` is used for every other command.