### PR TITLE
Fix `Pear.updates()` API link in Pear Desktop Project Starting Guide

### DIFF
--- a/guide/starting-a-pear-desktop-project.md
+++ b/guide/starting-a-pear-desktop-project.md
@@ -59,7 +59,8 @@ The app should now show:
 
 ![Automatic reload](../assets/chat-app-2.png)
 
-> Live reload with hot-module reloading is possible by using the `pear.watch` configuration and the [`pear.updates`](../reference/pear/api.md#pearupdateslistener-async-functionfunction) API. The [pear-hotmods](https://github.com/holepunchto/pear-hotmods) convenience module can also be used.
+> Live reload with hot-module reloading is possible by using the `pear.watch` configuration and the [`pear.updates`](../reference/pear/api.md#pearupdateslistener-async-functionfunction--streamxreadable
+) API. The [pear-hotmods](https://github.com/holepunchto/pear-hotmods) convenience module can also be used.
 
 ## Step 4. Configuration
 

--- a/guide/starting-a-pear-desktop-project.md
+++ b/guide/starting-a-pear-desktop-project.md
@@ -59,8 +59,7 @@ The app should now show:
 
 ![Automatic reload](../assets/chat-app-2.png)
 
-> Live reload with hot-module reloading is possible by using the `pear.watch` configuration and the [`pear.updates`](../reference/pear/api.md#pearupdateslistener-async-functionfunction--streamxreadable
-) API. The [pear-hotmods](https://github.com/holepunchto/pear-hotmods) convenience module can also be used.
+> Live reload with hot-module reloading is possible by using the `pear.watch` configuration and the [`pear.updates`](../reference/pear/api.md#pear.updates-listener-less-than-async-function-or-function-greater-than-greater-than-streamx.readabl) API. The [pear-hotmods](https://github.com/holepunchto/pear-hotmods) convenience module can also be used.
 
 ## Step 4. Configuration
 


### PR DESCRIPTION
Clicking the link in
https://docs.pears.com/guides/starting-a-pear-desktop-project#:~:text=pear.updates%20API was just opening the Pear API page instead of opening the `Pear.updates()` API part of the page specifically. This change fixes that.