### PR TITLE
Remove warning about running on QEMU android emulation for mobile guide

### DIFF
--- a/guide/making-a-bare-mobile-app.md
+++ b/guide/making-a-bare-mobile-app.md
@@ -288,9 +288,6 @@ npm run ios
 
 ### Android
 
-> [!IMPORTANT]  
-> You may experience problems running the app on an emulated Android device under QEMU due to https://github.com/holepunchto/libjs/issues/4. If you encounter crashes, try running the app on a real Android device instead.
-
 ```bash
 npm run android
 ```


### PR DESCRIPTION
Fixed in https://github.com/holepunchto/libjs/commit/25513fdade427be9877406cc768953241abc49b0

ht @AndreiRegiani for pointing it out

Waiting on https://github.com/holepunchto/bare-expo/pull/15 to merge since it's the same warning.