### PR TITLE
Update Android SDK requirements for Mobile Guide

### DIFF
--- a/guide/making-a-bare-mobile-app.md
+++ b/guide/making-a-bare-mobile-app.md
@@ -8,7 +8,7 @@ We will be building an application that syncs data from the [Pearpass desktop ap
 
 1. Gradle version 8.10.2
 2. Java 23
-3. Android SDK (>= 28), NDK
+3. Android SDK (>= 29), NDK
 
 ## Project Setup
 


### PR DESCRIPTION
The Android SDK minimum version was updated ( https://github.com/holepunchto/bare-expo/commit/3061a525cadac713e7224c6e215cd074e492d539 ) so the guide should follow.