### PR TITLE
Use `beforeExit` in mobile ex & update docs removing `teardown` event

### DIFF
--- a/guide/making-a-bare-mobile-app.md
+++ b/guide/making-a-bare-mobile-app.md
@@ -236,7 +236,7 @@ fs.mkdirSync(path)
 const invite = Bare.argv[1]
 const pair = Autopass.pair(new Corestore(path), invite)
 const pass = await pair.finished()
-Bare.on('teardown', () => pass.close())
+Bare.on('beforeExit', () => pass.close())
 
 await pass.ready()
 

--- a/guide/making-a-bare-mobile-app.md
+++ b/guide/making-a-bare-mobile-app.md
@@ -27,7 +27,7 @@ cd autopass-mobile-example
 And install the dependencies we will need:
 
 ```bash
-npm i b4a bare-fs bare-rpc corestore autopass @react-native-clipboard/clipboard
+npm i b4a bare-fs bare-rpc corestore autopass @react-native-clipboard/clipboard graceful-goodbye
 ```
 
 ```bash
@@ -211,6 +211,7 @@ Add the following code to `backend/backend.mjs`:
 import RPC from 'bare-rpc'
 import fs from 'bare-fs'
 import URL from 'bare-url'
+import goodbye from 'graceful-goodbye'
 import { join } from 'bare-path'
 import { RPC_RESET, RPC_MESSAGE } from '../rpc-commands.mjs'
 
@@ -236,7 +237,7 @@ fs.mkdirSync(path)
 const invite = Bare.argv[1]
 const pair = Autopass.pair(new Corestore(path), invite)
 const pass = await pair.finished()
-Bare.on('beforeExit', () => pass.close())
+goodbye(() => pass.close())
 
 await pass.ready()
 

--- a/reference/bare/api.md
+++ b/reference/bare/api.md
@@ -78,21 +78,10 @@ If the process is exited explicitly, such as by calling `Bare.exit()` or as the 
 
 ### `Bare.on('exit', code)`
 
-Emitted before the process or current thread terminates. Additional work must not be scheduled from an `exit` event listener. If the process is forcefully terminated from an `exit` event listener, the remaining listeners will not run.
+Emitted when the process or current thread exits. If the process is forcefully terminated from an `exit` event listener, the remaining listeners will not run.
 
-### `Bare.on('teardown')`
-
-Emitted after the process or current thread has terminated and before the JavaScript environment is torn down. Additional work must not be scheduled from a `teardown` event listener. Bare itself will register `teardown` event listeners to join dangling threads and unload native addons.
-
-> [!IMPORTANT]
->
-> ##### Teardown ordering
->
-> `teardown` listeners **SHOULD** be prepended to have the listeners run in last in, first out order:
->
-> ```js
-> Bare.prependListener('teardown', () => { ... })
-> ```
+> [!CAUTION]
+> Additional work **MUST NOT** be scheduled from an `exit` event listener.
 
 ### `Bare.on('suspend', linger)`
 


### PR DESCRIPTION
Bare's `teardown` is [obsolete](https://github.com/holepunchto/bare/pull/99) and `beforeExit` should be used instead.