### PR TITLE
fix section links

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Welcome to the Internet of Peers
 * link - a `pear://` link, a `file://` link or an absolute/relative dir path
 * P2P - Peer-to-Peer
 
-### Legend <a name="legend"></a>
+### Legend<a name="legend"></a>
 
 Throughout the documentation, indications of stability are provided. Some modules are well-established and used widely, making them highly unlikely to ever change. Other modules may be new, experimental, or known to have risks associated with their use.
 
@@ -45,14 +45,14 @@ The following stability indices have been used:
 | <mark style="background-color: #ff4242;">**unstable**</mark>     | May change or be removed without warning                    |
 
 
-## Showcase <a name="showcase"></a>
+## Showcase<a name="showcase"></a>
 
 Peer-to-Peer applications built on, deployed with, running on Pear.
 
 - [Keet](./apps/keet.md): A peer-to-peer chat and video-conferencing application with end-to-end encryption.
 
 
-### Reference <a name="reference"></a>
+### Reference<a name="reference"></a>
 
 Pear is a native point-to-point peer-to-peer capable platform that consists of a runtime binary, an API, userland modules, a command-line interface, an on-demand daemon and an application shell to provide the capabilities to develop & deploy production P2P applications. With JavaScript and beyond.
 
@@ -69,14 +69,14 @@ Pear's runtime binary is built on [Bare](https://github.com/holepunchto/bare), a
 * [Frequently Asked Questions](./reference/faq.md)
 * [Migration](./reference/migration.md)
 
-### Examples <a name="examples"></a>
+### Examples<a name="examples"></a>
 
 - [Pear Terminal](https://github.com/holepunchto/pear/tree/main/examples/terminal)
 - [Pear Desktop (Electron)](https://github.com/holepunchto/pear/tree/main/examples/desktop)
 - [Bare Android](https://github.com/holepunchto/bare-android)
 - [Bare iOS](https://github.com/holepunchto/bare-ios)
 
-### Guides <a name="guides"></a>
+### Guides<a name="guides"></a>
 
 Guides on using Pear Runtime to build and share peer-to-peer applications.
 
@@ -90,7 +90,7 @@ Guides on using Pear Runtime to build and share peer-to-peer applications.
 * [Making a Bare Mobile Application](./guide/making-a-bare-mobile-app.md)
 * [Creating a `pear init` Template](./guide/creating-a-pear-init-template.md)
 
-### How-tos <a name="howtos"></a>
+### How-tos<a name="howtos"></a>
 
 Collection of How-tos using the essential peer-to-peer building-blocks in Pear applications.
 
@@ -101,12 +101,12 @@ Collection of How-tos using the essential peer-to-peer building-blocks in Pear a
 * [How to share append-only databases with Hyperbee](./howto/share-append-only-databases-with-hyperbee.md)
 * [How to create a full peer-to-peer filesystem with Hyperdrive](./howto/create-a-full-peer-to-peer-filesystem-with-hyperdrive.md)
 
-### Pear Modules <a name="pear-modules"></a>
+### Pear Modules<a name="pear-modules"></a>
 
-The `Pear` global API is minimal and not intended as a standard library. 
-Application & Integration libraries are supplied via installable modules prefixed with `pear-`. 
+The `Pear` global API is minimal and not intended as a standard library.
+Application & Integration libraries are supplied via installable modules prefixed with `pear-`.
 
-#### Application Libraries <a name="application-libraries"></a>
+#### Application Libraries<a name="application-libraries"></a>
 
 Pear modules related directly to application environment.
 
@@ -117,12 +117,12 @@ Pear modules related directly to application environment.
 | [pear-messages](https://github.com/holepunchto/pear-messages)                 | Receive object messages that match a given object pattern            | ![Windows][1] ![MacOS][2] ![Linux][3]                            | <mark style="background-color:#80ff80;">**stable**</mark>  |
 | [pear-pipe](https://github.com/holepunchto/pear-pipe)                         | Parent-app-connected pipe, the other end of pear-run pipe            | ![Windows][1] ![MacOS][2] ![Linux][3]                            | <mark style="background-color:#80ff80;">**stable**</mark>  |
 | [pear-run](https://github.com/holepunchto/pear-run)                           | Run Pear child app by link. Returns a pipe to the child pipe         | ![Windows][1] ![MacOS][2] ![Linux][3]                            | <mark style="background-color:#80ff80;">**stable**</mark>  |
-| [pear-updates](https://github.com/holepunchto/pear-updates)                   | Receive platform and application update notifications                | ![Windows][1] ![MacOS][2] ![Linux][3]                            | <mark style="background-color:#80ff80;">**stable**</mark>  | 
+| [pear-updates](https://github.com/holepunchto/pear-updates)                   | Receive platform and application update notifications                | ![Windows][1] ![MacOS][2] ![Linux][3]                            | <mark style="background-color:#80ff80;">**stable**</mark>  |
 | [pear-user-dirs](https://github.com/holepunchto/pear-user-dirs)               | Get the path of user-specific directories                            | ![Windows][1] ![MacOS][2] ![Linux][3]                            | <mark style="background-color:#80ff80;">**stable**</mark>  |
 | [pear-versions](https://github.com/holepunchto/pear-versions)                 | Platform, Application and Runtime versions                           | ![Windows][1] ![MacOS][2] ![Linux][3]                            | <mark style="background-color:#80ff80;">**stable**</mark>  |
 | [pear-wakeups](https://github.com/holepunchto/pear-wakeups)                   | Receive wakeup events, including link clicks external to app         | ![Windows][1] ![MacOS][2] ![Linux][3]                            | <mark style="background-color:#80ff80;">**stable**</mark>  |
 
-#### User Interface Libraries <a name="user-interface-libraries"></a>| 
+#### User Interface Libraries<a name="user-interface-libraries"></a>|
 
 Pear modules that supply User Interface runtime capabilities.
 
@@ -131,7 +131,7 @@ Pear modules that supply User Interface runtime capabilities.
 | [pear-electron](https://github.com/holepunchto/pear-electron)                 | Pear User-Interface Library for Electron"                            | ![Windows][1] ![MacOS][2] ![Linux][3]                            | <mark style="background-color:#80ff80;">**stable**</mark>  |
 | [pear-bridge](https://github.com/holepunchto/pear-bridge)                     | Local HTTP bridge for pear-electron applications                     | ![Windows][1] ![MacOS][2] ![Linux][3]                            | <mark style="background-color:#80ff80;">**stable**</mark>  |
 
-#### Common Libraries <a name="common-libraries"></a>
+#### Common Libraries<a name="common-libraries"></a>
 
 Pear modules for general usage, including applications per case.
 
@@ -147,8 +147,8 @@ Pear modules for general usage, including applications per case.
 | [pear-seed](https://github.com/holepunchto/pear-seed)                         | Seed or reseed a Pear app drive by link                              | ![Windows][1] ![MacOS][2] ![Linux][3]                            | <mark style="background-color:#80ff80;">**stable**</mark>  |
 | [pear-stage](https://github.com/holepunchto/pear-stage)                       | Synchronize from-disk to app drive peer-to-peer                      | ![Windows][1] ![MacOS][2] ![Linux][3]                            | <mark style="background-color:#80ff80;">**stable**</mark>  |
 | [pear-stamp](https://github.com/holepunchto/pear-stamp)                       | Interleave locals into a template, sync and stream                   | ![Windows][1] ![MacOS][2] ![Linux][3]                            | <mark style="background-color:#80ff80;">**stable**</mark>  |
-    
-#### Developer Libraries <a name="developer-libraries"></a>
+
+#### Developer Libraries<a name="developer-libraries"></a>
 
 Pear modules to assist with developing & debugging
 
@@ -157,7 +157,7 @@ Pear modules to assist with developing & debugging
 | [pear-inspect](https://github.com/holepunchto/pear-inspect)                   | Securely enable remote debugging protocol over Hyperswarm            | ![Windows][1] ![MacOS][2] ![Linux][3] ![Android][4] ![iOS][5]   | <mark style="background-color:#80ff80;">**stable**</mark>  |
 | [pear-hotmods](https://github.com/holepunchto/pear-hotmods)                   | For `pear-electron` UI apps. Frontend framework-agnostic live-reload | ![Windows][1] ![MacOS][2] ![Linux][3]                           | <mark style="background-color:#80ff80;">**stable**</mark>  |
 
-#### Integration Libraries <a name="integration-libraries"></a>
+#### Integration Libraries<a name="integration-libraries"></a>
 
 Pear modules for runtime integrations. Such as [pear-electron](https://github.com/holepunchto/pear-electron).
 
@@ -178,11 +178,11 @@ Pear modules for runtime integrations. Such as [pear-electron](https://github.co
 | [pear-terminal](https://github.com/holepunchto/pear-terminal)                 | Terminal User Interface library                                      | ![Windows][1] ![MacOS][2] ![Linux][3]                           | <mark style="background-color:#80ff80;">**stable**</mark>  |
 | [pear-tryboot](https://github.com/holepunchto/pear-tryboot)                   | Used with `pear-ipc`, tries to boot sidecar on connect failure       | ![Windows][1] ![MacOS][2] ![Linux][3]                           | <mark style="background-color:#80ff80;">**stable**</mark>  |
 
-### P2P Modules <a name="p2p-modules"></a>
+### P2P Modules<a name="p2p-modules"></a>
 
-Modules that supply point-to-point peer-to-peer connection and storage capabilities. 
+Modules that supply point-to-point peer-to-peer connection and storage capabilities.
 
-#### Building-Block Libraries <a name="building-blocks"></a>
+#### Building-Block Libraries<a name="building-blocks"></a>
 
 The essential building-blocks for building powerful P2P applications using Pear.
 
@@ -195,7 +195,7 @@ The essential building-blocks for building powerful P2P applications using Pear.
 | [hyperdht](https://github.com/holepunchto/hyperdht)      | The Distributed Hash Table (DHT) powering Hyperswarm                                | ![Windows][1] ![MacOS][2] ![Linux][3] ![Android][4] ![iOS][5]      | <mark style="background-color:#80ff80;">**stable**</mark> |
 | [hyperswarm](https://github.com/holepunchto/hyperswarm)  | A high-level API for finding and connecting to peers by topic                       | ![Windows][1] ![MacOS][2] ![Linux][3] ![Android][4] ![iOS][5]      | <mark style="background-color:#80ff80;">**stable**</mark> |
 
-#### Helper Libraries <a name="helpers"></a>
+#### Helper Libraries<a name="helpers"></a>
 
 Helper modules can be used together with the building-blocks to create cutting-edge P2P tools and application-modules.
 
@@ -208,9 +208,9 @@ Helper modules can be used together with the building-blocks to create cutting-e
 | [compact-encoding](https://github.com/holepunchto/compact-encoding)                 | Binary encoding schemes for efficient parser-serializers.           | ![Windows][1] ![MacOS][2] ![Linux][3] ![Android][4] ![iOS][5]   | <mark style="background-color:#80ff80;">**stable**</mark> |
 | [protomux](https://github.com/holepunchto/protomux)                                 | Multiplex multiple message oriented protocols over a stream         | ![Windows][1] ![MacOS][2] ![Linux][3] ![Android][4] ![iOS][5]   | <mark style="background-color:#80ff80;">**stable**</mark> |
 
-### Bare Modules <a name="bare-modules"></a>
+### Bare Modules<a name="bare-modules"></a>
 
-Pear's native runtime is [Bare](https://github.com/holepunchto/bare). The `Bare` global API is minimal and not intended as a standard library. 
+Pear's native runtime is [Bare](https://github.com/holepunchto/bare). The `Bare` global API is minimal and not intended as a standard library.
 Standard runtime functionality is provided via a installable modules. prefixed with `bare-`.
 
 | Module                                                                        | Description                                                          | Systems    <!-- NOTE: 4 em-space chars prevent icon wrapping --> | Stability                                                  |
@@ -224,7 +224,7 @@ Standard runtime functionality is provided via a installable modules. prefixed w
 | [bare-channel](https://github.com/holepunchto/bare-channel)                   | Inter-thread messaging for JavaScript                                | ![Windows][1] ![MacOS][2] ![Linux][3] ![Android][4] ![iOS][5]      |  <mark style="background-color:#80ff80;">**stable**</mark> |
 | [bare-console](https://github.com/holepunchto/bare-console)                   | WHATWG debugging console for JavaScript                              | ![Windows][1] ![MacOS][2] ![Linux][3] ![Android][4] ![iOS][5]      |  <mark style="background-color:#80ff80;">**stable**</mark> |
 | [bare-crypto](https://github.com/holepunchto/bare-crypto)                     | Cryptographic primitives for JavaScript                              | ![Windows][1] ![MacOS][2] ![Linux][3] ![Android][4] ![iOS][5]      |  <mark style="background-color:#80ff80;">**stable**</mark> |
-| [bare-daemon](https://github.com/holepunchto/bare-daemon)                     | Create and manage daemon processes in JavaScript                     | ![Windows][1] ![MacOS][2] ![Linux][3]                              |  <mark style="background-color:#80ff80;">**stable**</mark> | 
+| [bare-daemon](https://github.com/holepunchto/bare-daemon)                     | Create and manage daemon processes in JavaScript                     | ![Windows][1] ![MacOS][2] ![Linux][3]                              |  <mark style="background-color:#80ff80;">**stable**</mark> |
 | [bare-dgram](https://github.com/holepunchto/bare-dgram)                       | Native UDP for JavaScript                                            | ![Windows][1] ![MacOS][2] ![Linux][3] ![Android][4] ![iOS][5]      |  <mark style="background-color:#80ff80;">**stable**</mark> |
 | [bare-dns](https://github.com/holepunchto/bare-dns)                           | Domain name resolution for JavaScript                                | ![Windows][1] ![MacOS][2] ![Linux][3] ![Android][4] ![iOS][5]      |  <mark style="background-color:#80ff80;">**stable**</mark> |
 | [bare-encoding](https://github.com/holepunchto/bare-encoding)                 | WHATWG text encoding interfaces for JavaScript                       | ![Windows][1] ![MacOS][2] ![Linux][3] ![Android][4] ![iOS][5]      |  <mark style="background-color:#80ff80;">**stable**</mark> |
@@ -255,7 +255,7 @@ Standard runtime functionality is provided via a installable modules. prefixed w
 | [bare-semver](https://github.com/holepunchto/bare-semver)                     | Minimal semantic versioning library for Bare                         | ![Windows][1] ![MacOS][2] ![Linux][3] ![Android][4] ![iOS][5]      |  <mark style="background-color:#80ff80;">**stable**</mark> |
 | [bare-signals](https://github.com/holepunchto/bare-signals)                   | Native signal handling for JavaScript                                | ![Windows][1] ![MacOS][2] ![Linux][3] ![Android][4] ![iOS][5]      |  <mark style="background-color:#80ff80;">**stable**</mark> |
 | [bare-stream](https://github.com/holepunchto/bare-stream)                     | Streaming data for JavaScript                                        | ![Windows][1] ![MacOS][2] ![Linux][3] ![Android][4] ![iOS][5]      |  <mark style="background-color:#80ff80;">**stable**</mark> |
-| [bare-structured-clone](https://github.com/holepunchto/bare-structured-clone) | Structured cloning algorithm for JavaScript                          | ![Windows][1] ![MacOS][2] ![Linux][3] ![Android][4] ![iOS][5]      |  <mark style="background-color:#80ff80;">**stable**</mark> | 
+| [bare-structured-clone](https://github.com/holepunchto/bare-structured-clone) | Structured cloning algorithm for JavaScript                          | ![Windows][1] ![MacOS][2] ![Linux][3] ![Android][4] ![iOS][5]      |  <mark style="background-color:#80ff80;">**stable**</mark> |
 | [bare-subprocess](https://github.com/holepunchto/bare-subprocess)             | Native process spawning for JavaScript                               | ![Windows][1] ![MacOS][2] ![Linux][3]                              |  <mark style="background-color:#80ff80;">**stable**</mark> |
 | [bare-tcp](https://github.com/holepunchto/bare-tcp)                           | Native TCP sockets for JavaScript                                    | ![Windows][1] ![MacOS][2] ![Linux][3] ![Android][4] ![iOS][5]      |  <mark style="background-color:#80ff80;">**stable**</mark> |
 | [bare-timers](https://github.com/holepunchto/bare-timers)                     | Native timers for JavaScript                                         | ![Windows][1] ![MacOS][2] ![Linux][3] ![Android][4] ![iOS][5]      |  <mark style="background-color:#80ff80;">**stable**</mark> |
@@ -271,7 +271,7 @@ Standard runtime functionality is provided via a installable modules. prefixed w
 
 Compatibility modules for Node.js builtins in Bare can be found in [bare-node](https://github.com/holepunchto/bare-node).
 
-### Tools <a name="tools"></a>
+### Tools<a name="tools"></a>
 
 Beyond the [Pear CLI](./reference/cli.md) these ecosystem P2P CLI tools are additionally useful for day-to-day development and operations.
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -73,7 +73,7 @@
 
 * [Tool List](./README.md#tools)
 
-### Examples <a name="examples"></a>
+### Examples<a name="examples"></a>
 
 - [Pear Terminal](https://github.com/holepunchto/pear/tree/main/examples/terminal)
 - [Pear Desktop (Electron)](https://github.com/holepunchto/pear/tree/main/examples/desktop)

--- a/reference/api.md
+++ b/reference/api.md
@@ -5,40 +5,40 @@ Pear is built on [Bare](https://github.com/holepunchto/bare). Pear applications 
 * [global.Pear](#pear)
 * [global.Bare](#bare)
 
-## `global.Pear` <a name="pear"></a>
+## `global.Pear`<a name="pear"></a>
 
 <mark style="background-color: #8484ff;">**stable**</mark>
 
 The Pear Platform API is made available globally as `Pear`.
 
-The `Pear` API is designed to be as minimal as possible. 
+The `Pear` API is designed to be as minimal as possible.
 
 The majority of capabilities are supplied via [Pear Modules](../README.md#pear-modules).
 
-### `Pear.app <Object>` <a name="#pear-app"></a>
+### `Pear.app <Object>`<a name="#pear-app"></a>
 
 Contains application information. Supersedes `Pear.config`.
 
-#### `Pear.app.key <Buffer|null>` <a name="pear-app-key"></a>
+#### `Pear.app.key <Buffer|null>`<a name="pear-app-key"></a>
 
 A buffer of the application key. If running from disk, `Pear.app.key` is null.
 
-#### `Pear.app.length <Integer>` <a name="pear-app-length"></a>
+#### `Pear.app.length <Integer>`<a name="pear-app-length"></a>
 
 The application drive length. The application version consists of `Pear.app.key`, `Pear.app.length` and `Pear.app.fork`.
 
-#### `Pear.app.fork <Integer>` <a name="pear-app-fork"></a>
+#### `Pear.app.fork <Integer>`<a name="pear-app-fork"></a>
 
 The application drive fork count. A fork is where the append-only log of the drive is truncated.
 
 The application version consists of `Pear.app.key`, `Pear.app.length` and `Pear.app.fork`.
 
-#### `Pear.app.alias <String|null>` <a name="pear-app-alias"></a>
+#### `Pear.app.alias <String|null>`<a name="pear-app-alias"></a>
 
 Given an application that is run from a pear:// link with an alias it, contains that alias.
 For example the `Pear.app.alias` for `pear run pear://keet` would be `keet`.
 
-#### `Pear.app.dev <Boolean>` <a name="pear-app-dev"></a>
+#### `Pear.app.dev <Boolean>`<a name="pear-app-dev"></a>
 
 Whether the application is in development mode.
 
@@ -53,23 +53,23 @@ const fromDisk = Pear.app.key === null
 const isDev = fromDisk && Pear.app.dev
 ```
 
-#### `Pear.app.name <String>` <a name="pear-app-name"></a>
+#### `Pear.app.name <String>`<a name="pear-app-name"></a>
 
 Application name.
 
-#### `Pear.app.main <String>` <a name="pear-app-main"></a>
+#### `Pear.app.main <String>`<a name="pear-app-main"></a>
 
 Application entry file.
 
-#### `Pear.app.channel <String|null>` <a name="pear-app-channel"></a>
+#### `Pear.app.channel <String|null>`<a name="pear-app-channel"></a>
 
 Application release/staging channel.
 
-#### `Pear.app.storage <String>` <a name="pear-app-storage"></a>
+#### `Pear.app.storage <String>`<a name="pear-app-storage"></a>
 
 Application storage path
 
-#### `Pear.app.options <Object>` <a name="pear-app-options"></a>
+#### `Pear.app.options <Object>`<a name="pear-app-options"></a>
 
 Configuration options.
 The `pear` configuration object as supplied via an applications `package.json` file.
@@ -78,15 +78,15 @@ The `pear` configuration object as supplied via an applications `package.json` f
 
 * [Configuration](./configuration.md)
 
-#### `Pear.app.env <Object>` <a name="pear-app-env"></a>
+#### `Pear.app.env <Object>`<a name="pear-app-env"></a>
 
 The environment variables that an application was started with, as key-value pairs in an object.
 
-#### `Pear.app.flags <Object>` <a name="pear-app-flags"></a>
+#### `Pear.app.flags <Object>`<a name="pear-app-flags"></a>
 
 Parsed command-line flag values as supplied when an application was started.
 
-#### `Pear.app.checkout <String>` <a name="pear-app-checkout"></a>
+#### `Pear.app.checkout <String>`<a name="pear-app-checkout"></a>
 
 The value of the [`pear run --checkout`](./cli.md#pear-run) flag. Same as [`Pear.app.flags.checkout`](#pear-app-checkout).
 
@@ -95,15 +95,15 @@ The value of the [`pear run --checkout`](./cli.md#pear-run) flag. Same as [`Pear
 * [`pear run`](./cli.md#pear-run)
 * [`Pear.app.flags`](./#pear-app-flags)
 
-#### `Pear.app.storage <String>` <a name="pear-app-storage"></a>
+#### `Pear.app.storage <String>`<a name="pear-app-storage"></a>
 
 Application storage path.
 
-#### `Pear.app.args <Array>` <a name="pear-app-args"></a>
+#### `Pear.app.args <Array>`<a name="pear-app-args"></a>
 
 Command-line application arguments passed like `pear run --dev . --some arg`.
 
-#### `Pear.app.release <Number>` <a name="pear-app-release"></a>
+#### `Pear.app.release <Number>`<a name="pear-app-release"></a>
 
 The current release length as marked by the `pear release` command.
 
@@ -111,7 +111,7 @@ The current release length as marked by the `pear release` command.
 
 * [`pear release`](./cli.md#pear-release)
 
-#### `Pear.app.link <String>` <a name="pear-app-link"></a>
+#### `Pear.app.link <String>`<a name="pear-app-link"></a>
 
 The link that was passed to `pear run` with alias resolved to key.
 
@@ -121,7 +121,7 @@ Includes any potential pathname, query or fragment.
 
 * [`pear run`](./cli.md)
 
-#### `Pear.app.links <Object|Array>` <a name="pear-app-links"></a>
+#### `Pear.app.links <Object|Array>`<a name="pear-app-links"></a>
 
 Holds trusted Pear application links and domains as specified in the `links` field inside `package.json`.
 
@@ -129,11 +129,11 @@ Holds trusted Pear application links and domains as specified in the `links` fie
 * [pear.links](./configuration.md#pear-links)
 * [`pear run`](./cli.md#pear-run)
 
-#### `Pear.app.routes <String>` <a name="pear-app-routes"></a>
+#### `Pear.app.routes <String>`<a name="pear-app-routes"></a>
 
 The configuration provided [`pear.routes`](./configuration.md#pear-routes) mapping object.
 
-#### `Pear.app.entrypoint <String>` <a name="pear-app-entrypoint"></a>
+#### `Pear.app.entrypoint <String>`<a name="pear-app-entrypoint"></a>
 
 The link pathname (`pear://<key>/<pathname>`), after any route mappings have been applied per [`pear.routes`](./configuration.md#pear-routes).
 
@@ -145,19 +145,19 @@ Only `Pear.app.entrypoint` supports route-mapping via the [`pear.routes`](./conf
 * [`Pear.app.routes`](#pear-app-routes)
 * [`pear.routes`](./configuration.md#pear-routes)
 
-#### `Pear.app.fragment <String>` <a name="pear-app-fragment"></a>
+#### `Pear.app.fragment <String>`<a name="pear-app-fragment"></a>
 
 The link hash, without the leading `#`.
 
 Given `pear://<key>/<pathname>#frag` `Pear.app.fragment` would be `frag`.
 
-#### `Pear.app.query <String>` <a name="pear-app-query"></a>
+#### `Pear.app.query <String>`<a name="pear-app-query"></a>
 
 The link query string, without the leading `?`.
 
 Given `pear://<key>/<pathname>?qs` `Pear.app.query` would be `qs`.
 
-#### `Pear.app.route <String>` <a name="pear-app-route"></a>
+#### `Pear.app.route <String>`<a name="pear-app-route"></a>
 
 The link pathname (`pear://<key>/<pathname>`), prior to any route mappings being applied.
 
@@ -169,7 +169,7 @@ Includes the leading `/`, e.g given `pear://foo/bar/baz`, `Pear.app.route` would
 * [`Pear.app.routes`](#pear-app-routes)
 * [`pear.routes`](./configuration.md#pear-routes)
 
-#### `Pear.app.linkData <String>` <a name="pear-app-linkData"></a>
+#### `Pear.app.linkData <String>`<a name="pear-app-linkData"></a>
 
 Holds just the data portion of a Pear link.
 
@@ -188,7 +188,7 @@ Legacy but still supported. Prefer `Pear.app.entrypoint` or `Pear.app.route`.
 * [Pear.app.link](#pear-app-link)
 * [`pear run`](./cli.md#pear-run)
 
-#### `Pear.app.checkpoint <Any>` <a name="pear-app-checkpoint"></a>
+#### `Pear.app.checkpoint <Any>`<a name="pear-app-checkpoint"></a>
 
 Holds state as set by `Pear.checkpoint()`. When an application restarts it will hold the most recent value passed to `Pear.checkpoint()`.
 
@@ -202,33 +202,33 @@ The returned `Promise` will resolve once the checkpoint has been successfully st
 
 * [Pear.checkpoint()](#pear-checkpoint-any)
 
-#### `Pear.app.release <Integer>` <a name="pear-app-release"></a>
+#### `Pear.app.release <Integer>`<a name="pear-app-release"></a>
 
 Application release sequence integer.
 
-#### `Pear.app.flags <Object>` <a name="pear-app-flags"></a>
+#### `Pear.app.flags <Object>`<a name="pear-app-flags"></a>
 
 Parsed `pear run` flags.
 
-#### `Pear.app.applink <String>`  <a name="pear-app-applink"></a>
+#### `Pear.app.applink <String>` <a name="pear-app-applink"></a>
 
 Pear application link. May be a `pear://` link or a local directory.
 
-#### `Pear.app.dir <String>`  <a name="pear-app-dir"></a>
+#### `Pear.app.dir <String>` <a name="pear-app-dir"></a>
 
 The current working directory of `pear run` when the application was started.
 
-#### `Pear.app.dht.nodes <Array<Object>>` <a name="pear-app-dht-nodes"></a>
+#### `Pear.app.dht.nodes <Array<Object>>`<a name="pear-app-dht-nodes"></a>
 
 A list of known [DHT](https://github.com/holepunchto/hyperdht) nodes of the form `{ host: <String>, port: <Number> }`. The nodes are set when the Pear application is started.
 
 Unless started with a custom set of bootstrap nodes, Pear caches known nodes to speed up connecting to the swarm and to make it more resilient.
 
-#### `Pear.app.dht.bootstrap <Array<Object>>`  <a name="pear-app-dht-bootstrap"></a>
+#### `Pear.app.dht.bootstrap <Array<Object>>` <a name="pear-app-dht-bootstrap"></a>
 
 A list of custom bootstrap nodes Pear is started with of the form `{ host: <String>, port: <Number> }`.
 
-#### `Pear.app.assets  <String>` <a name="pear-app-assets"></a>
+#### `Pear.app.assets  <String>`<a name="pear-app-assets"></a>
 
 Advanced / integration purposes.
 
@@ -236,7 +236,7 @@ Per [`pear-assets`](./configuration.md#pear-assets) configuration assets are fet
 
 Takes the form `{ [namespace]: { link <String>, ns <String>, path <String>, name <String>, only <Array<String>>, bytes <Integer> } }`. `namespace` is per the property name on the assets object. By convention, should be describe the asset type, for example: `ui`.
 
-* `link` - Configuration supplied `pear://<fork>.<length>.<key>` 
+* `link` - Configuration supplied `pear://<fork>.<length>.<key>`
 * `ns` - Namespace - same as the property name
 * `path` - The path that Pear stored the asset to on-disk
 * `name` - Configuration supplied name
@@ -262,30 +262,30 @@ Example:
 }
 ```
 
-#### `Pear.app.prerunning <Boolean>` <a name="pear-app-prerunning"></a>
+#### `Pear.app.prerunning <Boolean>`<a name="pear-app-prerunning"></a>
 
 Whether the current application is a [`pre`](./configuration.md#pear-pre) script.
 
-#### `Pear.app.startId <String>` <a name="pear-app-startid"></a>
+#### `Pear.app.startId <String>`<a name="pear-app-startid"></a>
 
 Advanced. Integration purposes.
 
 The application start identifier. Can be used to register a [`pear-ipc`](https://github.com/holepunchto/pear-ipc) client to an applicaiton, with
 `ipc.identify()`
 
-#### `Pear.app.swapDir <String>` <a name="pear-app-swapdir"></a>
+#### `Pear.app.swapDir <String>`<a name="pear-app-swapdir"></a>
 
 Advanced. Integration purposes.
 
 The active swap directory with Pear platform directory.
 
-#### `Pear.app.pearDir <String>` <a name="pear-app-peardir"></a>
+#### `Pear.app.pearDir <String>`<a name="pear-app-peardir"></a>
 
 Advanced. Integration purposes.
 
 Pear platform directory.
 
-### `Pear.checkpoint(<Any>) => Promise` <a name="pear-checkpoint"></a>
+### `Pear.checkpoint(<Any>) => Promise`<a name="pear-checkpoint"></a>
 
 Stores state that will be available as `Pear.app.checkpoint` next time the application starts.
 
@@ -297,7 +297,7 @@ The returned `Promise` will resolve once the checkpoint has been successfully st
 
 * [Pear.app.checkpoint](#pear--config-checkpoint-any)
 
-### `Pear.teardown(fn <Async Function|Function>)` <a name="pear-teardown"></a>
+### `Pear.teardown(fn <Async Function|Function>)`<a name="pear-teardown"></a>
 
 Register application clean-up handlers to be called when an application begins to unload.
 
@@ -307,19 +307,19 @@ Functions supplied to teardown will be executed in order of registration when
 an application begins to unload. Any promise returned from each supplied function
 will be waited upon until resolution before calling the next teardown handler.
 
-### `Pear.argv` <a name="pear-argv"></a>
+### `Pear.argv`<a name="pear-argv"></a>
 
 The command line arguments passed to the process when launched.
 
-### `Pear.pid` <a name="pear-pid"></a>
+### `Pear.pid`<a name="pear-pid"></a>
 
 The ID of the current process.
 
-### `Pear.exitCode` <a name="pear-exitcode"></a>
+### `Pear.exitCode`<a name="pear-exitcode"></a>
 
 The code that will be returned once the process exits. If the process is exited using `Bare.exit()` without specifying a code, `Bare.exitCode` is used.
 
-### `Pear.exit(code)` <a name="pear-exit"></a>
+### `Pear.exit(code)`<a name="pear-exit"></a>
 
 Exits the process with the provided exit code. Follows Pear teardown flow, whereas `Bare.exit()` does not.
 
@@ -376,7 +376,7 @@ Deprecated. Use [`pear-restart`](https://github.com/holepunchto/pear-restart).
 
 Deprecated. Use [`Pear.app`](#pear-app).
 
-### <mark style="background-color: #ffffa2;">**DEPRECATED**</mark> `Pear.messages([ pattern ], [ listener ]) -> Iterable` 
+### <mark style="background-color: #ffffa2;">**DEPRECATED**</mark> `Pear.messages([ pattern ], [ listener ]) -> Iterable`
 
 Deprecated. Use [`pear-messages`](https://github.com/holepunchto/pear-messages).
 
@@ -402,7 +402,7 @@ Deprecated. Use [`pear-versions`](https://github.com/holepunchto/pear-versions).
 
 Deprecated. Use `location.reload()` in Desktop apps. No reload in terminal apps.
 
-### <mark style="background-color: #ffffa2;">**DEPRECATED**</mark> `Pear.updates(listener <Async Function|Function>) =>streamx.Readable` 
+### <mark style="background-color: #ffffa2;">**DEPRECATED**</mark> `Pear.updates(listener <Async Function|Function>) =>streamx.Readable`
 
 Deprecated. Use [`pear-updates`](https://github.com/holepunchto/pear-updates).
 
@@ -410,19 +410,19 @@ Deprecated. Use [`pear-updates`](https://github.com/holepunchto/pear-updates).
 
 Deprecated. No-op. Do not use.
 
-### <mark style="background-color: #ffffa2;">**DEPRECATED**</mark> `Pear.wakeups(listener <Async Function|Function>) =>streamx.Readable` 
+### <mark style="background-color: #ffffa2;">**DEPRECATED**</mark> `Pear.wakeups(listener <Async Function|Function>) =>streamx.Readable`
 
 Deprecated. Use [`pear-updates`](https://github.com/holepunchto/pear-wakeups).
 
-### <mark style="background-color: #ffffa2;">**DEPRECATED**</mark> `Pear.badge(count <Integer|null>) =>Promise<Boolean>` 
+### <mark style="background-color: #ffffa2;">**DEPRECATED**</mark> `Pear.badge(count <Integer|null>) =>Promise<Boolean>`
 
 Deprecated. Use [`pear-electron ui.app.badge()`](https://github.com/holepunchto/pear-electron#const-success--await-appbadgecount-integernull).
 
-### <mark style="background-color: #ffffa2;">**DEPRECATED**</mark> `Pear.tray(options <Object>, listener <AsyncFunction|Function>) => Promise<untray()>` 
+### <mark style="background-color: #ffffa2;">**DEPRECATED**</mark> `Pear.tray(options <Object>, listener <AsyncFunction|Function>) => Promise<untray()>`
 
 Deprecated. Use [`pear-electron ui.app.tray()`](https://github.com/holepunchto/pear-electron#const-untray--await-apptrayoptions-object-listener-function).
 
-### <mark style="background-color: #ffffa2;">**DEPRECATED**</mark> `const win = new Pear.Window(entry <String>, options<Object>)` 
+### <mark style="background-color: #ffffa2;">**DEPRECATED**</mark> `const win = new Pear.Window(entry <String>, options<Object>)`
 
 Deprecated. Use [`pear-electron ui.Window`](https://github.com/holepunchto/pear-electron#const-win--new-uiwindowentry-string-options-object).
 
@@ -430,7 +430,7 @@ Deprecated. Use [`pear-electron ui.Window`](https://github.com/holepunchto/pear-
 
 Deprecated. Use [`pear-electron ui.View`](https://github.com/holepunchto/pear-electron#const-view--new-uiviewoptions-object).
 
-## `global.Bare` <a name="bare"></a>
+## `global.Bare`<a name="bare"></a>
 
 <mark style="background-color: #8484ff;">**stable**</mark>
 
@@ -440,134 +440,134 @@ The `Bare` API is designed to be as minimal as possible.
 
 The majority of capabilities are supplied via [Bare Modules](../README.md#bare-modules).
 
-### `Bare.platform` <a name="bare-platform"></a>
+### `Bare.platform`<a name="bare-platform"></a>
 
 The identifier of the operating system for which Bare was compiled. The possible values are `android`, `darwin`, `ios`, `linux`, and `win32`.
 
-### `Bare.arch` <a name="bare-arch"></a>
+### `Bare.arch`<a name="bare-arch"></a>
 
 The identifier of the processor architecture for which Bare was compiled. The possible values are `arm`, `arm64`, `ia32`, `mips`, `mipsel`, and `x64`.
 
-### `Bare.simulator` <a name="bare-simulator"></a>
+### `Bare.simulator`<a name="bare-simulator"></a>
 
 Whether or not Bare was compiled for a simulator.
 
-### `Bare.argv` <a name="bare-argv"></a>
+### `Bare.argv`<a name="bare-argv"></a>
 
 The command line arguments passed to the process when launched.
 
-### `Bare.pid` <a name="bare-pid"></a>
+### `Bare.pid`<a name="bare-pid"></a>
 
 The ID of the current process.
 
-### `Bare.exitCode` <a name="bare-exitcode"></a>
+### `Bare.exitCode`<a name="bare-exitcode"></a>
 
 The code that will be returned once the process exits. If the process is exited using `Bare.exit()` without specifying a code, `Bare.exitCode` is used.
 
-### `Bare.suspended` <a name="bare-suspended"></a>
+### `Bare.suspended`<a name="bare-suspended"></a>
 
 Whether or not the process is currently suspended.
 
-### `Bare.exiting` <a name="bare-exiting"></a>
+### `Bare.exiting`<a name="bare-exiting"></a>
 
 Whether or not the process is currently exiting.
 
-### `Bare.version` <a name="bare-version"></a>
+### `Bare.version`<a name="bare-version"></a>
 
 The Bare version string.
 
-### `Bare.versions` <a name="bare-versions"></a>
+### `Bare.versions`<a name="bare-versions"></a>
 
 An object containing the version strings of Bare and its dependencies.
 
-### `Bare.exit([code])` <a name="bare-exit"></a>
+### `Bare.exit([code])`<a name="bare-exit"></a>
 
 Immediately terminate the process or current thread with an exit status of `code` which defaults to `Bare.exitCode`.
 
-### `Bare.suspend([linger])` <a name="bare-suspend"></a>
+### `Bare.suspend([linger])`<a name="bare-suspend"></a>
 
 Suspend the process and all threads. This will emit a `suspend` event signalling that all work should stop immediately. When all work has stopped and the process would otherwise exit, an `idle` event will be emitted. If the process is not resumed from an `idle` event listener, the loop will block until the process is resumed.
 
-### `Bare.idle()` <a name="bare-idle"></a>
+### `Bare.idle()`<a name="bare-idle"></a>
 
 Immediately suspend the event loop and trigger the `idle` event.
 
-### `Bare.resume()` <a name="bare-resume"></a>
+### `Bare.resume()`<a name="bare-resume"></a>
 
 Resume the process and all threads after suspension. This can be used to cancel suspension after the `suspend` event has been emitted and up until all `idle` event listeners have run.
 
-### `Bare.on('uncaughtException', err)` <a name="bare-on-uncaught-exception"></a>
+### `Bare.on('uncaughtException', err)`<a name="bare-on-uncaught-exception"></a>
 
 Emitted when a JavaScript exception is thrown within an execution context without being caught by any exception handlers within that execution context. By default, uncaught exceptions are printed to `stderr` and the processes aborted. Adding an event listener for the `uncaughtException` event overrides the default behavior.
 
-### `Bare.on('unhandledRejection', reason, promise)` <a name="bare-on-unhandled-rejection"></a>
+### `Bare.on('unhandledRejection', reason, promise)`<a name="bare-on-unhandled-rejection"></a>
 
 Emitted when a JavaScript promise is rejected within an execution context without that rejection being handled within that execution context. By default, unhandled rejections are printed to `stderr` and the process aborted. Adding an event listener for the `unhandledRejection` event overrides the default behavior.
 
-### `Bare.on('beforeExit', code)` <a name="bare-on-beforeexit"></a>
+### `Bare.on('beforeExit', code)`<a name="bare-on-beforeexit"></a>
 
 Emitted when the loop runs out of work and before the process or current thread exits. This provides a chance to schedule additional work and keep the process from exiting. If additional work is scheduled, `beforeExit` will be emitted again once the loop runs out of work.
 
 If the process is exited explicitly, such as by calling `Bare.exit()` or as the result of an uncaught exception, the `beforeExit` event will not be emitted.
 
-### `Bare.on('exit', code)` <a name="bare-on-exit"></a>
+### `Bare.on('exit', code)`<a name="bare-on-exit"></a>
 
 Emitted when the process or current thread exits. If the process is forcefully terminated from an `exit` event listener, the remaining listeners will not run.
 
 > [!CAUTION]
 > Additional work **MUST NOT** be scheduled from an `exit` event listener.
 
-### `Bare.on('suspend', linger)` <a name="bare-on-suspend"></a>
+### `Bare.on('suspend', linger)`<a name="bare-on-suspend"></a>
 
 Emitted when the process or current thread is suspended. Any in-progress or outstanding work, such as network activity or file system access, should be deferred, cancelled, or paused when the `suspend` event is emitted and no additional work should be scheduled.
 
-### `Bare.on('idle')` <a name="bare-on-idle"></a>
+### `Bare.on('idle')`<a name="bare-on-idle"></a>
 
 Emitted when the process or current thread becomes idle after suspension. After all handlers have run, the event loop will block and no additional work be performed until the process is resumed. An `idle` event listener may call `Bare.resume()` to cancel the suspension.
 
-### `Bare.on('resume')` <a name="bare-on-resume"></a>
+### `Bare.on('resume')`<a name="bare-on-resume"></a>
 
 Emitted when the process or current thread resumes after suspension. Deferred and paused work should be continued when the `resume` event is emitted and new work may again be scheduled.
 
-## `Bare.Addon` <a name="bare-addon"></a>
+## `Bare.Addon`<a name="bare-addon"></a>
 
 The `Bare.Addon` namespace provides support for loading native addons, which are typically written in C/C++ and distributed as shared libraries.
 
-### `const addon = Addon.load(url[, options])` <a name="bare-addon-load"></a>
+### `const addon = Addon.load(url[, options])`<a name="bare-addon-load"></a>
 
 Load a static or dynamic native addon identified by `url`. If `url` is not a static native addon, Bare will instead look for a matching dynamic object library.
 
 Options are reserved.
 
-### `const unloaded = Addon.unload(url[, options])` <a name="bare-addon-unload"></a>
+### `const unloaded = Addon.unload(url[, options])`<a name="bare-addon-unload"></a>
 
 Unload a dynamic native addon identified by `url`. If the function returns `true`, the addon was unloaded from memory. If it instead returns `false`, the addon is still in use by one or more threads and will only be unloaded from memory when those threads either exit or explicitly unload the addon.
 
 Options are reserved.
 
-### `const url = Addon.resolve(specifier, parentURL[, options])` <a name="bare-addon-resolve"></a>
+### `const url = Addon.resolve(specifier, parentURL[, options])`<a name="bare-addon-resolve"></a>
 
 Resolve a native addon specifier by searching for a static native addon or dynamic object library matching `specifier` imported from `parentURL`.
 
 Options are reserved.
 
-## `Bare.Thread` <a name="bare-thread"></a>
+## `Bare.Thread`<a name="bare-thread"></a>
 
 The `Bare.Thread` provides support for lightweight threads. Threads are similar to workers in Node.js, but provide only minimal API surface for creating and joining threads.
 
-### `Thread.isMainThread` <a name="bare-thread-ismainthread"></a>
+### `Thread.isMainThread`<a name="bare-thread-ismainthread"></a>
 
 `true` if the current thread is the main thread.
 
-### `Thread.self` <a name="bare-thread-self"></a>
+### `Thread.self`<a name="bare-thread-self"></a>
 
 A reference to the current thread as a `ThreadProxy` object. Will be `null` on the main thread.
 
-### `Thread.self.data` <a name="bare-self-data"></a>
+### `Thread.self.data`<a name="bare-self-data"></a>
 
 A copy of or, if shared, reference to the `data` buffer that was passed to the current thread on creation. Will be `null` if no buffer was passed.
 
-### `const thread = new Thread([filename][, options][, callback])` <a name="bare-new-thread"></a>
+### `const thread = new Thread([filename][, options][, callback])`<a name="bare-new-thread"></a>
 
 Start a new thread that will run the contents of `filename`. If `callback` is provided, its function body will be treated as the contents of `filename` and invoked on the new thread with `Thread.self.data` passed as an argument.
 
@@ -586,22 +586,22 @@ Options include:
 }
 ```
 
-### `const thread = Thread.create([filename][, options][, callback])` <a name="bare-thread-create"></a>
+### `const thread = Thread.create([filename][, options][, callback])`<a name="bare-thread-create"></a>
 
 Convenience method for the `new Thread()` constructor.
 
-### `thread.joined` <a name="bare-new-thread-joined"></a>
+### `thread.joined`<a name="bare-new-thread-joined"></a>
 
 Whether or not the thread has been joined with the current thread.
 
-### `thread.join()` <a name="bare-new-thread-join"></a>
+### `thread.join()`<a name="bare-new-thread-join"></a>
 
 Block and wait for the thread to exit.
 
-### `thread.suspend([linger])` <a name="bare-new-thread-suspend"></a>
+### `thread.suspend([linger])`<a name="bare-new-thread-suspend"></a>
 
 Suspend the thread. Equivalent to calling `Bare.suspend()` from within the thread.
 
-### `thread.resume()` <a name="bare-new-thread-resume"></a>
+### `thread.resume()`<a name="bare-new-thread-resume"></a>
 
 Resume the thread. Equivalent to calling `Bare.resume()` from within the thread.

--- a/reference/cli.md
+++ b/reference/cli.md
@@ -1,10 +1,10 @@
-# Command Line Interface (CLI) 
+# Command Line Interface (CLI)
 
 <mark style="background-color: #8484ff;">**stable**</mark>
 
 The Command Line Interface is the primary interface for Pear Development.
 
-## `pear init [flags] <link|type=desktop> [dir]` <a name="pear-init"></a>
+## `pear init [flags] <link|type=desktop> [dir]`<a name="pear-init"></a>
 
 Create initial project files.
 
@@ -22,8 +22,8 @@ Template can also be initialized from a pear:// link, the template should contai
 --no-ask                  Suppress permissions dialogs
 --help|-h                 Show help
 ```
-  
-## `pear run [flags] <link|dir> [...app-args]` <a name="pear-run"></a>
+
+## `pear run [flags] <link|dir> [...app-args]`<a name="pear-run"></a>
 
 Run an application from a link or dir.
 
@@ -53,7 +53,7 @@ Run an application from a link or dir.
   --help|-h                      Show help
 ```
 
-### Examples 
+### Examples
 
 ```
 pear run pear://u6c6it1hhb5serppr3tghdm96j1gprtesygejzhmhnk5xsse8kmy
@@ -70,8 +70,8 @@ pear run -t file://path/to/an-app-folder --some app --args
 ```
 pear run pear://keet
 ```
- 
-## `pear stage <channel|link> [dir]` <a name="pear-stage"></a>
+
+## `pear stage <channel|link> [dir]`<a name="pear-stage"></a>
 
 Synchronize local changes to channel or key.
 
@@ -90,8 +90,8 @@ Each time new changes are staged, the length for the channel / link will update,
   --no-ask                    Suppress permissions dialogs
   --help|-h                   Show help
 ```
-  
-## `pear seed <channel|link> [dir]` <a name="pear-seed"></a>
+
+## `pear seed <channel|link> [dir]`<a name="pear-seed"></a>
 
 Seed project or reseed key.
 
@@ -107,7 +107,7 @@ Seeding will sparsely replicate the application. This means the entire history o
   --help|-h                 Show help
 ```
 
-## `pear release <channel|link> [dir]` <a name="pear-release"></a>
+## `pear release <channel|link> [dir]`<a name="pear-release"></a>
 
 Set production release version.
 
@@ -138,7 +138,7 @@ This method doesn't add any file changes so will not show update diffs from the 
 
 The second approach is dumping the files from the previous version and staging and rereleasing the new version. This appends file changes so is heavier than just changing the release pointer, but shows update diffs and fits the [dump-stage-release strategy](../../guide/releasing-a-pear-app.md) approach since updates to the `production` channel are applied by dumping from another channel or link.
 
-## `pear info [link|channel]` <a name="pear-info"></a>
+## `pear info [link|channel]`<a name="pear-info"></a>
 
 
 Read project information.
@@ -156,8 +156,8 @@ Supply no argument to view platform information.
   --no-ask                  Suppress permissions dialogs
   --help|-h                 Show help
 ```
-  
-## `pear dump [flags] <link> <dir>` <a name="pear-dump"></a>
+
+## `pear dump [flags] <link> <dir>`<a name="pear-dump"></a>
 
 Synchronize files from link to dir.
 
@@ -177,8 +177,8 @@ pear dump pear://keet/CHANGELOG.md dump-dir/
   --no-ask                  Suppress permissions dialogs
   --help|-h                 Show help
 ```
-  
-## `pear touch [flags] [channel]` <a name="pear-touch"></a>
+
+## `pear touch [flags] [channel]`<a name="pear-touch"></a>
 
 
 Create Pear link
@@ -192,7 +192,7 @@ This command is useful for creating links for automations that use `pear stage <
   --help|-h   Show help
 ```
 
-## `pear sidecar` <a name="pear-sidecar"></a>
+## `pear sidecar`<a name="pear-sidecar"></a>
 
 
 The Pear Sidecar is a local-running HTTP and IPC server which
@@ -212,7 +212,7 @@ and then becomes the sidecar.
   --help|-h             Show help
 ```
 
-## `pear versions` <a name="pear-versions"></a>
+## `pear versions`<a name="pear-versions"></a>
 
 Output version information.
 
@@ -221,7 +221,7 @@ Output version information.
 --help|-h     Show help
 ```
 
-## `pear shift [flags] <source> <destination>` <a name="pear-shift"></a>
+## `pear shift [flags] <source> <destination>`<a name="pear-shift"></a>
 
 
 Move user application storage between applications.
@@ -233,7 +233,7 @@ Move user application storage between applications.
 --json      Newline delimited JSON output
 ```
 
-## `pear drop [flags] [command]` <a name="pear-drop"></a>
+## `pear drop [flags] [command]`<a name="pear-drop"></a>
 
 Advanced. Permanent data deletion
 
@@ -248,7 +248,7 @@ WARNING: Confirmation will be requested as the storage will be deleted permanent
 --help|-h   Show help
 ```
 
-## `pear gc [flags] [command]` <a name="pear-gc"></a>
+## `pear gc [flags] [command]`<a name="pear-gc"></a>
 
 Perform garbage collection and remove unused resources.
 
@@ -262,7 +262,7 @@ Perform garbage collection and remove unused resources.
   --help|-h     Show help
 ```
 
-## `pear data [flags] [command]` <a name="pear-data"></a>
+## `pear data [flags] [command]`<a name="pear-data"></a>
 
 View database contents.
 
@@ -281,4 +281,4 @@ The database contains metadata stored on this device used by the Pear runtime.
 ```
 
 
-  
+

--- a/reference/configuration.md
+++ b/reference/configuration.md
@@ -2,7 +2,7 @@
 
 <mark style="background-color: #8484ff;">**stable**</mark>
 
-## The `package.json` file <a name="package-json"></a>
+## The `package.json` file<a name="package-json"></a>
 
 A Pear project **must** have a `package.json` file and a main entry file.
 
@@ -18,25 +18,25 @@ The `package.json` `pear` object contains application configuration and is expos
 
 Pear versioning is automatic. The `package.json` file does **not** require a version field, the version field will be ignored.
 
-## The `package.json` `pear` field. <a name="pear"></a>
+## The `package.json` `pear` field.<a name="pear"></a>
 
-### `pear.name <String>` <a name="pear-name"></a>
+### `pear.name <String>`<a name="pear-name"></a>
 
 The name of the application. Overrides `package.json` `name`.
 
-### `pear.stage <Object>` <a name="pear-stage"></a>
+### `pear.stage <Object>`<a name="pear-stage"></a>
 
 Staging configuration options.
 
-#### `pear.stage.entrypoints <Array>` <a name="pear-stage-entrypoints"></a>
+#### `pear.stage.entrypoints <Array>`<a name="pear-stage-entrypoints"></a>
 
 An array of entrypoint paths as staging start-points in addition to (deduped) main entry point.
 
-#### `pear.stage.ignore <Array>` <a name="pear-stage-ignore"></a>
+#### `pear.stage.ignore <Array>`<a name="pear-stage-ignore"></a>
 
 An array of file paths to ignore relative to `package.json` file.
 
-#### `pear.stage.includes <Array>` <a name="pear-stage-includes"></a>
+#### `pear.stage.includes <Array>`<a name="pear-stage-includes"></a>
 
 Explicitly declare paths to include.
 
@@ -45,11 +45,11 @@ Ensures warmup during staging in addition to all `stage.entrypoints` which can i
 When used with `pear stage --compact` command flag `pear.stage.includes` can be used to ensure any files that aren't recognized via JavaScript static analysis - which would be any non-JavaScript files, any files that aren't required/imported or any files that are imported/required using an expression in code - eg `require(getPkgName())` would mean
 whatever is required wouldn't be identified in static analysis so would need to be added to `pear.stage.includes`.
 
-#### `pear.stage.defer <Array>` <a name="pear-stage-defer"></a>
+#### `pear.stage.defer <Array>`<a name="pear-stage-defer"></a>
 
 An array of dependency specifiers, as used with `require` or `import`, to declare it as an uninstalled optional or peer dependency in the dependency tree. Some modules use the pattern: `try { require('a-dep') } catch { fallback() }`, in order to try to include an optional dependency if available. Adding such specifiers (`a-dep` in the example) to the `pear.stage.defer` configuration array let's the static-analysis steps during `pear stage` (compact and warmup phases) step over these cases. If there are a lot of cases like this in an applications dependency tree, it will slow the static-analysis phases down since by default it brute forces and grows a dynamic defers list until there's no MODULE_NOT_FOUND errors left. The `pear stage` command will print out skip hints for these dependencies - add any specifiers identified to `pear.stage.defer`.
 
-### `pear.pre <String>` <a name="pear-pre"></a>
+### `pear.pre <String>`<a name="pear-pre"></a>
 
 A specifier such as `./path/to/pre.js` or `some-module`, or `pear-electron/pre`.
 
@@ -61,7 +61,7 @@ The specifier must point to a script that executes prior to run-from-disk, prior
 
 When a `pre` script is executed, it has a `pipe` available which can be obtained via [`pear-pipe`](https://github.com/holepunchto/pear-pipe). This can be used to modify configuration which is sent as [`compact-encoding`](https://github.com/holepunchto/compact-encoding) `any` encoding (i.e. an encoded object, like JSON). The first encoded object sent to `pipe` is the application configuration. The first response expected on the pre scripts `pipe` by the `pear run` or `pear stage` command is an `any` encoded configuration object. This allows the prescript to send back mutated application configuration back to `pear run` or `pear stage`. The application is then loaded with that mutated confiruation in the case of `pear run`, in the case of `pear stage` the configuration overrides the application drives `manifest` property. The `pear info --manifest <link>` command can be used to view any mutated configuration post-stage.
 
-### `pear.routes <Object|String>` <a name="pear-routes"></a>
+### `pear.routes <Object|String>`<a name="pear-routes"></a>
 
 By default, [`pear run`](./cli.md#pear-run) considers link pathnames to be entrypoints. This means `pear run` can execute any valid file staged to a Pear application. For example `pear run pear://<key>/some/path.js` would run some/path.js if it's valid. In that case [`Pear.app.route`](./api.md#pear-app-route) would contain `/some/path.js` and [`Pear.app.entrypoint`](./api.md#pear-app-entrypoint) would also contain `/some/path.js`.
 
@@ -94,12 +94,12 @@ The `pear.routes` configuration can also be an object where the keys are pathnam
 When `routes: "."` is used in conjuction with [`pear-electron`](https://github.com/holepunchto/pear-electron) and [`pear-bridge` `waypoint` option](https://github.com/holepunchto/pear-bridge/#options) this enables in-app single-page-application routing.
 
 
-### `pear.unrouted <Array>` <a name="pear-unrouted"></a>
+### `pear.unrouted <Array>`<a name="pear-unrouted"></a>
 
 Array of paths to exclude from any routing rules in [`pear.routes`](#pear-routes).
 
 
-### `pear.assets <Object>` <a name="pear-assets"></a>
+### `pear.assets <Object>`<a name="pear-assets"></a>
 
 Asset declarations to fetch and store on disk on behalf of the application.
 
@@ -142,7 +142,7 @@ While assets can be declared directly on the `pear.assets` as described but when
 
 Assets are automatically stored in the platform folder. Use [`Pear.app.assets[namespace].path`](./api.md#pear-app-assets) within the application to get the path to the asset. For example, `Pear.assets.ui.path`.
 
-###  `pear.links <Object|Array>` <a name="pear-links"></a>
+###  `pear.links <Object|Array>`<a name="pear-links"></a>
 
 Storing and managing Pear application links and domains.
 
@@ -161,9 +161,9 @@ Note that this is only for requests that the Pear app makes itself such as loadi
   // ...
   "pear": {
     // accessed at runtime using Pear.config.links[index] eg. Pear.config.links[0] for pear://somePearKey
-    "links": [ 
-      "pear://somePearKey", 
-      "https://example.com" 
+    "links": [
+      "pear://somePearKey",
+      "https://example.com"
     ]
     // OR
     // accessed at runtime using Pear.config.links.name eg. Pear.config.links.myWorker for myWorker
@@ -175,7 +175,7 @@ Note that this is only for requests that the Pear app makes itself such as loadi
 }
 ```
 
-### `pear.gui <Object>` <a name="pear-gui"></a>
+### `pear.gui <Object>`<a name="pear-gui"></a>
 
 Graphical User Interface configuration options.
 

--- a/reference/migration.md
+++ b/reference/migration.md
@@ -133,12 +133,12 @@ Verify in development with
  ```sh
  pear run -d .
  ```
- 
+
 Production equivalent verification:
 
 ```sh
 pear stage check
-``` 
+```
 
 Then per link output from stage command:
 
@@ -150,7 +150,7 @@ If the application starts and operates correctly in any related areas where chan
 
 If the SemVer printed by `pear -v` is 2.x.x then migration verification is complete.
 
-If the SemVer printed by `pear -v` is 1.x.x then these steps need to performed on v2 also. 
+If the SemVer printed by `pear -v` is 1.x.x then these steps need to performed on v2 also.
 
 Switch to v2 with:
 
@@ -201,12 +201,12 @@ Verify in development with
  ```sh
  pear run -d .
  ```
- 
+
 Production equivalent verification:
 
 ```sh
 pear stage check
-``` 
+```
 
 Then per link output from stage command:
 
@@ -224,12 +224,12 @@ pear sidecar --key pqbzjhqyonxprx8hghxexnmctw75mr91ewqw5dxe1zmntfyaddqy
 
 If there's any problems switching back, make sure there are no `pear-runtime` processes running and run `npx pear`.
 
->  ⚠️ **WARNING:** Omitting to switch back to production Pear leaves the system on a release-line that will be ended. 
+>  ⚠️ **WARNING:** Omitting to switch back to production Pear leaves the system on a release-line that will be ended.
 >
 >  **In order to avoid any issues, be sure to switch back to production [ pqbzjhqyonx... ]**
 >
 
-## Compat Mode <a name="compat-mode"></a>
+## Compat Mode<a name="compat-mode"></a>
 
 While v1 Pear APIs will continue to function with deprecation messages, for projects that need a legacy-bridge during overlapping transitional periods, compat-mode can be used to:
 

--- a/reference/troubleshooting.md
+++ b/reference/troubleshooting.md
@@ -3,7 +3,7 @@
 * [Pear](#pear)
 * [Bare](#bare)
 
-## Pear <a name="pear"></a>
+## Pear<a name="pear"></a>
 
 Troubleshooting confusing scenarios while developing Pear applications.
 
@@ -16,8 +16,8 @@ The `Pear.teardown(cb)` callback is triggered whenever the Pear app start to unl
 If after debugging an application it seems the issue is happening in the Pear platform itself, try the following steps to debug the issue:
 
 1. Run pear command with logs enabled `pear --log [command]`.
-2. If no helpful info, run sidecar with logs `pear sidecar --log-level 3`.  
-   If the `pear sidecar` stops after printing `Closing any current Sidecar clients...`, then the current Pear Sidecar process is hanging. Check the next steps for forensics that might explain why, but then kill existing Pear processes.  
+2. If no helpful info, run sidecar with logs `pear sidecar --log-level 3`.
+   If the `pear sidecar` stops after printing `Closing any current Sidecar clients...`, then the current Pear Sidecar process is hanging. Check the next steps for forensics that might explain why, but then kill existing Pear processes.
    _Note_ that this will close any running pear applications such as Keet.
 3. If still no helpful info, check that there are still pear processes running via `ps aux | grep pear` or equivalent method for finding processes by name.
 4. Finally check the crash logs in platform's `current` directory.
@@ -36,7 +36,7 @@ Uncaught (in promise) Error: While lock file: ./pear/app-storage/by-random/.../d
 Means the application is trying to open a RockDB instance on files currently
 locked by another process. This means either:
 
-- An application is trying to open the same storage twice.  
+- An application is trying to open the same storage twice.
   If using `Corestore`, it is recommended to only create only one instance and
   reusing it.
 - There are multiple of processes running for the same application.
@@ -47,8 +47,8 @@ There can be many reasons but here are a few common reasons:
 
 - Random NAT networks can take longer as another node may be needed to facility the connection.
 - Not destroying the hyperswarm instance in the `Pear.teardown()` callback so
-  Hyperswarm can unannounce and clean up the DHT.  
-  It's recommended to clean up the hyperswarm instance with `swarm.destroy()` before exiting the application. This prevents conflicting records in the DHT for the application's peer which cause it take longer to join a topic.  
+  Hyperswarm can unannounce and clean up the DHT.
+  It's recommended to clean up the hyperswarm instance with `swarm.destroy()` before exiting the application. This prevents conflicting records in the DHT for the application's peer which cause it take longer to join a topic.
 
   Example:
   ```js
@@ -58,7 +58,7 @@ There can be many reasons but here are a few common reasons:
   Make sure to unregister the teardown callback if the swarm is destroyed
   prematurely.
 
-- A firewall is blocking the traffic.  
+- A firewall is blocking the traffic.
   Please let Holepunch know if this is the case.
 
 ### Running Bare modules in Pear Desktop Applications
@@ -93,7 +93,7 @@ so a module `fs` can be resolved to `bare-fs` on Bare and `fs` on Node.js.
 
 See [`bare-node`'s "Import maps"](https://github.com/holepunchto/bare-node?tab=readme-ov-file#import-maps) for more details.
 
-## Bare <a name="bare"></a>
+## Bare<a name="bare"></a>
 
 Troubleshooting confusing scenarios while developing Pear applications.
 
@@ -132,9 +132,9 @@ As the error suggests, this is because the native addon cannot be found. This co
 
 A few reasons why an addon may be missing:
 
-- The addon is not available for the current platform and/or architecture.  
+- The addon is not available for the current platform and/or architecture.
   To see what platform and architecture Bare is running on, log `Bare.platform` and `Bare.arch`.
-- The addon wasn't linked ahead of time.  
+- The addon wasn't linked ahead of time.
   Mobile applications require native code to be linked as part of compiling the application.
 
   If developing with `react-native-bare-kit` (including using `bare-expo` as a template), check that the addon was loaded in `node_modules/react-native-bare-kit/ios/addons` for iOS and `node_modules/react-native-bare-kit/android/src/main/addons` for Android. This is where the libraries are linked from.


### PR DESCRIPTION
Space between the header content and the a tag was causing a dash to be rendered in the id and breaking section links. Removing the space fixes the issue.

(video below is from doc view in pear-desktop after the fix)

https://github.com/user-attachments/assets/08dc602e-c845-4463-8071-3a85bd5ac071

