### PR TITLE
Add pearbook

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Build
+
+on:
+  push: # Trigger on push events (commits pushed to the repo)
+    branches: # Specify branches; use '**' for all branches
+      - add-pear-book
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Node/NPM
+        uses: actions/setup-node@v6
+      - name: Install Pear
+        run: |
+          npm install -g pear
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Run Pearbook
+        run: |
+          pear run pear://runtime
+          pear run --trusted pear://${{ vars.PEAR_BOOK_KEY }} --output pearbook .
+      - name: Checkout new branch
+        run: |
+          git config --global user.email "eric.bauerfeld+pearbot@holepunch.to"
+          git config --global user.name "Eric's Pearbot"
+          git fetch
+          git checkout -b preview
+          git add pearbook
+          git commit -m "Publish"
+          git branch --set-upstream-to=origin/preview preview
+          git pull --rebase --prune
+          git push -u -f origin preview

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,9 +1,9 @@
-name: Build
+name: Preview
 
 on:
-  push: # Trigger on push events (commits pushed to the repo)
-    branches: # Specify branches; use '**' for all branches
-      - add-pear-book
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -21,7 +21,7 @@ jobs:
         run: |
           pear run pear://runtime
           pear run --trusted pear://${{ vars.PEAR_BOOK_KEY }} --output pearbook .
-      - name: Checkout new branch
+      - name: Push to preview branch
         run: |
           git config --global user.email "eric.bauerfeld+pearbot@holepunch.to"
           git config --global user.name "Eric's Pearbot"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Run Pearbook
-        run: pear-book build . --output pearbook --title="Pear Docs"
+        run: pear-book build .
       - name: Push to preview branch
         run: |
           git config --global user.email "eric.bauerfeld+pearbot@holepunch.to"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -12,15 +12,16 @@ jobs:
     steps:
       - name: Install Node/NPM
         uses: actions/setup-node@v6
-      - name: Install Pear
+      - name: Install Bare
         run: |
-          npm install -g pear
+          npm install -g bare
+      - name: Install Pear Book
+        run: |
+          npm install -g git+https://github.com/holepunchto/pear-book.git
       - name: Checkout
         uses: actions/checkout@v6
       - name: Run Pearbook
-        run: |
-          pear run pear://runtime
-          pear run --trusted pear://${{ vars.PEAR_BOOK_KEY }} --output pearbook .
+        run: pear-book build . --output pearbook --title="Pear Docs"
       - name: Push to preview branch
         run: |
           git config --global user.email "eric.bauerfeld+pearbot@holepunch.to"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if branch is not preview
+        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/preview'
+        run: |
+          echo "This workflow should not be triggered with workflow_dispatch on a branch other than preview"
+          exit 1
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Promote preview to published
+        run: |
+          git config --global user.email "eric.bauerfeld+pearbot@holepunch.to"
+          git config --global user.name "Eric's Pearbot"
+          git fetch
+          git checkout -b published
+          git branch --set-upstream-to=origin/published published
+          git pull --rebase --prune
+          git push -u -f origin published

--- a/.gitignore
+++ b/.gitignore
@@ -126,4 +126,6 @@ package-lock.json
 todo.*
 
 # mac finder meta data
-.DS_Store 
+.DS_Store
+
+.vscode

--- a/.pear-book.json
+++ b/.pear-book.json
@@ -1,4 +1,5 @@
 {
+  "title": "Pear Docs",
   "aliases": {
     "howto": "howtos"
   }

--- a/.pear-book.json
+++ b/.pear-book.json
@@ -1,6 +1,7 @@
 {
   "title": "Pear Docs",
   "aliases": {
-    "howto": "howtos"
+    "/howto": "/howtos",
+    "/guide": "/guides"
   }
 }

--- a/.pear-book.json
+++ b/.pear-book.json
@@ -1,0 +1,5 @@
+{
+  "aliases": {
+    "howto": "howtos"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Welcome to the Internet of Peers
 
 Peer-to-Peer applications built on, deployed with, running on Pear.
 
-| <a href="https://keet.io" data-pear="pear://keet" title="Encrypted peer-to-peer message, audio & video chat"><img src="assets/keet.svg" alt="Encrypted peer-to-peer message, audio & video chat"></a> | <a href="https://pass.pears.com" data-pear="pear://pass" title="Secure peer-to-peer password & secrets manager"><img src="assets/pearpass.svg" alt="Secure peer-to-peer password & secrets manager"></a> | &nbsp; | &nbsp; | &nbsp; |
+|       |       |       |       |       |
 | :---: | :---: | :---: | :---: | :---: |
+| <a href="https://keet.io" data-pear="pear://keet" title="Encrypted peer-to-peer message, audio & video chat"><img src="assets/keet.svg" alt="Encrypted peer-to-peer message, audio & video chat"></a> | <a href="https://pass.pears.com" data-pear="pear://pass" title="Secure peer-to-peer password & secrets manager"><img src="assets/pearpass.svg" alt="Secure peer-to-peer password & secrets manager"></a> | &nbsp; | &nbsp; | &nbsp; |
 | <a href="https://keet.io" data-pear="pear://keet" title="Encrypted peer-to-peer message, audio & video chat"><strong>Keet</strong></a> | <a href="https://pass.pears.com" data-pear="pear://pass" title="Secure peer-to-peer password & secrets manager"><strong>PearPass</strong></a> | &nbsp; | &nbsp; | &nbsp; |
 
 ### Terms

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -6,9 +6,9 @@
 
 * [Pear CLI](./reference/cli.md)
 * [Pear Application Configuration](./reference/configuration.md)
-* [Bare Overview](./reference/bare-overview.md)
 * [API](./reference/api.md)
 * [Templates](./reference/templates.md)
+* [Bare Overview](./reference/bare-overview.md)
 * [Node.js Compatibility](./reference/node-compat.md)
 * [Recommended Practices](./reference/recommended-practices.md)
 * [Troubleshooting](./reference/troubleshooting.md)

--- a/guide/getting-started.md
+++ b/guide/getting-started.md
@@ -4,7 +4,7 @@ Pear Runtime can be installed via [npm](https://www.npmjs.com/).
 
 Since `npm` (or equivalent package manager) is needed to install application dependencies this guide will walk through installing `pear` with `npm`.
 
-{% embed url="https://www.youtube.com/watch?v=y2G97xz78gU" %} Build with Pear - Episode 01: Developing with Pear {% embeded %}
+[![Build with Pear - Episode 01: Developing with Pear](https://img.youtube.com/vi/y2G97xz78gU/0.jpg)](https://www.youtube.com/watch?v=y2G97xz78gU)
 
 ## Requirements
 

--- a/guide/making-a-pear-desktop-app.md
+++ b/guide/making-a-pear-desktop-app.md
@@ -4,7 +4,7 @@ This guide demonstrates how to build a peer-to-peer chat application.
 
 It continues where [Starting a Pear Desktop Project](./starting-a-pear-desktop-project.md) left off.
 
-{% embed url="https://www.youtube.com/watch?v=y2G97xz78gU" %} Build with Pear - Episode 01: Developing with Pear {% embeded %}
+[![Build with Pear - Episode 01: Developing with Pear](https://img.youtube.com/vi/y2G97xz78gU/0.jpg)](https://www.youtube.com/watch?v=y2G97xz78gU)
 
 ## Step 1. HTML Structure and CSS Styles
 
@@ -155,10 +155,10 @@ Start by defining the app's layout in `index.html`:
 </html>
 ```
 
-**Note**: To make the `<pear-ctrl>` element draggable in Pear applications, wrap it in another element that uses the following CSS property: 
+**Note**: To make the `<pear-ctrl>` element draggable in Pear applications, wrap it in another element that uses the following CSS property:
 ```css
 -webkit-app-region : drag;
-``` 
+```
 This non-standard CSS property tells the application that this element should act as a draggable region for the entire window.
 
 Running `pear run --dev .` should show
@@ -174,7 +174,7 @@ Install the development dependencies using:
 ```
 npm install
 ```
-This will install the following: 
+This will install the following:
 - [pear-interface](https://github.com/holepunchto/pear-interface) for documentation and auto-completion inside editor.
 - [brittle](https://github.com/holepunchto/brittle) a TAP framework for testing.
 
@@ -198,12 +198,12 @@ Replace `app.js` with
 ``` js
 
 // For interactive documentation and code auto-completion in editor
-/** @typedef {import('pear-interface')} */ 
+/** @typedef {import('pear-interface')} */
 
 /* global Pear */
 import Hyperswarm from 'hyperswarm'   // Module for P2P networking and connecting peers
 import crypto from 'hypercore-crypto' // Cryptographic functions for generating the key in app
-import b4a from 'b4a'                 // Module for buffer-to-string and vice-versa conversions 
+import b4a from 'b4a'                 // Module for buffer-to-string and vice-versa conversions
 const { teardown, updates } = Pear    // Functions for cleanup and updates
 
 const swarm = new Hyperswarm()
@@ -285,7 +285,7 @@ function onMessageAdded (from, message) {
 
 ## Step 4. Chat
 
-Open two app instances by running `pear run --dev .` in two terminals. 
+Open two app instances by running `pear run --dev .` in two terminals.
 
 In the first app, click on `Create`. A random topic will appear at the top.
 

--- a/guide/making-a-pear-terminal-app.md
+++ b/guide/making-a-pear-terminal-app.md
@@ -4,7 +4,7 @@ This guide demonstrates how to build a peer-to-peer chat application.
 
 It continues where [Starting a Pear Terminal Project](./starting-a-pear-terminal-project.md) left off.
 
-{% embed url="https://www.youtube.com/watch?v=UoGJ7PtAwtI" %} Build with Pear - Episode 04: Pear Terminal Applications {% embeded %}
+[![Build with Pear - Episode 04: Pear Terminal Applications](https://img.youtube.com/vi/UoGJ7PtAwtI/0.jpg)](https://www.youtube.com/watch?v=UoGJ7PtAwtI)
 
 ## Step 1. Install modules
 
@@ -12,7 +12,7 @@ Install the development dependencies using:
 ```
 npm install
 ```
-This will install the following: 
+This will install the following:
 - [pear-interface](https://github.com/holepunchto/pear-interface) for documentation and auto-completion inside editors.
 - [brittle](https://github.com/holepunchto/brittle) a TAP framework for testing.
 
@@ -32,11 +32,11 @@ Replace `index.js` with
 ``` js
 
 // For interactive documentation and code auto-completion in editor
-/** @typedef {import('pear-interface')} */ 
+/** @typedef {import('pear-interface')} */
 
 /* global Pear */
 import Hyperswarm from 'hyperswarm'   // Module for P2P networking and connecting peers
-import b4a from 'b4a'                 // Module for buffer-to-string and vice-versa conversions 
+import b4a from 'b4a'                 // Module for buffer-to-string and vice-versa conversions
 import crypto from 'hypercore-crypto' // Cryptographic functions for generating the key in app
 import readline from 'bare-readline'  // Module for reading user input in terminal
 import tty from 'bare-tty'            // Module to control terminal behavior

--- a/guide/releasing-a-pear-app.md
+++ b/guide/releasing-a-pear-app.md
@@ -4,7 +4,7 @@ Pear applications are stored in an append-only log ([hypercore](https://github.c
 
 Each version is identified by `<fork>.<length>.<key>`. The length corresponds to the length of the application's append-only log at the time.
 
-{% embed url="https://www.youtube.com/watch?v=OTwY_avUPyI" %} Build with Pear - Episode 03: Releasing Pear Applications {% embeded %}
+[![Build with Pear - Episode 03: Releasing Pear Applications](https://img.youtube.com/vi/OTwY_avUPyI/0.jpg)](https://www.youtube.com/watch?v=OTwY_avUPyI)
 
 `pear run <link>` opens the application.
 

--- a/guide/sharing-a-pear-app.md
+++ b/guide/sharing-a-pear-app.md
@@ -2,7 +2,7 @@
 
 Applications can be shared with peers by seeding them to the network from an efficient local data structure (a [hypercore](https://github.com/holepunchto/hypercore)). We call the mirroring of a local file system into the Pear platform Application Storage "staging". Seeding is sharing an app from a machine over the Distributed Hash Table (DHT) (via [hyperswarm](https://github.com/holepunchto/hyperswarm)) so that other peers can replicate, consume and reseed the application.
 
-{% embed url="https://www.youtube.com/watch?v=BEadqmp7lA0" %} Build with Pear - Episode 02: Sharing Pear Applications {% embeded %}
+[![Build with Pear - Episode 02: Sharing Pear Applications](https://img.youtube.com/vi/BEadqmp7lA0/0.jpg)](https://www.youtube.com/watch?v=BEadqmp7lA0)
 
 This guide can either follow on from, [Making a Pear Desktop Application](./making-a-pear-desktop-app.md), [Making a Pear Terminal Application](./making-a-pear-terminal-app.md), or get setup quickly with the following:
 
@@ -105,9 +105,9 @@ Be sure that software is trusted before running it
 
 Type "TRUST" to allow execution or anything else to exit
 
-Trust application? 
+Trust application?
 ```
-The trust dialog is a security mechanism in Pear that appears when the user tries to run an application from an unknown or untrusted key for the first time. In case that the app is run in detached mode, for example, when clicking on a pear link in the browser, the trust dialog is a GUI (Graphical User Interface). 
+The trust dialog is a security mechanism in Pear that appears when the user tries to run an application from an unknown or untrusted key for the first time. In case that the app is run in detached mode, for example, when clicking on a pear link in the browser, the trust dialog is a GUI (Graphical User Interface).
 
 ![Trust dialog](../assets/trust-dialog.png)
 
@@ -128,7 +128,7 @@ The application staging machine that is running the seeding process should show 
 •-• peer join 8054f613d911b990834a0234507447c8ca88f4e778594c0e4fc480a314dc6d62
 ```
 
-The `peer join` line displays the remote public key, in hex, of the peer that executed `pear run` with the application link. 
+The `peer join` line displays the remote public key, in hex, of the peer that executed `pear run` with the application link.
 
 Once the application is closed on the peer machine the seeding output on the original machine will be similar to:
 

--- a/guide/starting-a-pear-desktop-project.md
+++ b/guide/starting-a-pear-desktop-project.md
@@ -2,7 +2,7 @@
 
 This section shows how to generate, configure, and develop a Pear desktop project, in preparation for [Making a Pear Desktop Application](./making-a-pear-desktop-app.md).
 
-{% embed url="https://www.youtube.com/watch?v=y2G97xz78gU" %} Build with Pear - Episode 01: Developing with Pear {% embeded %}
+[![Build with Pear - Episode 01: Developing with Pear](https://img.youtube.com/vi/y2G97xz78gU/0.jpg)](https://www.youtube.com/watch?v=y2G97xz78gU)
 
 ## Step 1. Initialization
 

--- a/guide/starting-a-pear-terminal-project.md
+++ b/guide/starting-a-pear-terminal-project.md
@@ -1,6 +1,6 @@
 # Starting a Pear Terminal Project
 
-{% embed url="https://www.youtube.com/watch?v=UoGJ7PtAwtI" %} Build with Pear - Episode 04: Pear Terminal Applications {% embeded %}
+[![Build with Pear - Episode 04: Pear Terminal Applications](https://img.youtube.com/vi/UoGJ7PtAwtI/0.jpg)](https://www.youtube.com/watch?v=UoGJ7PtAwtI)
 
 ## Step 1. Init
 

--- a/howto/replicate-and-persist-with-hypercore.md
+++ b/howto/replicate-and-persist-with-hypercore.md
@@ -4,7 +4,7 @@ In the HyperDHT How-to ([Connect Two Peers](./connect-two-peers-by-key-with-hype
 
 [`Hypercore`](https://github.com/holepunchto/hypercore) is a secure, distributed append-only log. It is built for sharing enormous datasets and streams of real-time data. It has a secure transport protocol, making it easy to build fast and scalable peer-to-peer applications.
 
-{% embed url="https://www.youtube.com/watch?v=5t2mOi0BeDg" %} Build with Pear - Episode 05: Replication and Persistence {% embeded %}
+[![Build with Pear - Episode 05: Replication and Persistence](https://img.youtube.com/vi/5t2mOi0BeDg/0.jpg)](https://www.youtube.com/watch?v=5t2mOi0BeDg)
 
 In this guide we'll extend the ephemeral chat example in [Connect Many Peers](./connect-to-many-peers-by-topic-with-hyperswarm.md) but using Hypercore to add many significant new features:
 


### PR DESCRIPTION
Adds github actions to build a static site using pearbook.

- Pushes to `main` will trigger a build and push to the branch `preview`
  - `preview` branch will have a folder named "pearbook" with the static site
  - pearbook folder on `preview` can be deployed to `preview-docs.pears.com` on every push to `preview` branch
- `preview` branch can be promoted to `published` via manual dispatch on preview branch
  - pearbook folder on `published` can be deployed to `docs.pears.com` on every push to `published` branch

## Preview


https://github.com/user-attachments/assets/9a71ff6d-4ab9-4668-ae5a-0e88dee3fba8


