### PR TITLE
docs: annotate how-to code fences for check:examples

### DIFF
--- a/content/how-to/blind-peering/add-blind-peering-to-a-chat-app.mdx
+++ b/content/how-to/blind-peering/add-blind-peering-to-a-chat-app.mdx
@@ -53,7 +53,7 @@ npm install blind-peering
 
 The worker only sees the flags `workers/index.js` declares with [`paparam`](https://www.npmjs.com/package/paparam). Add `--blind-peer-key` to the `command(...)` block so the keys you pass on the command line reach `WorkerTask`—without this, the runtime bails with `UNKNOWN_FLAG: blind-peer-key`:
 
-```diff title="workers/index.js"
+```diff title="workers/index.js" skip="snippet-illustration"
  const cmd = command('pear-chat-blind-peering',
 +  flag('--blind-peer-key|-b <blindPeerKey>', 'Blind peer key').multiple(),
    flag('--invite|-i <invite>', 'Room invite'),
@@ -72,7 +72,7 @@ The worker only sees the flags `workers/index.js` declares with [`paparam`](http
 
 In `workers/worker-task.js`, instantiate [`BlindPeering`](https://www.npmjs.com/package/blind-peering) against the swarm and a [Corestore](/reference/helpers/corestore) namespace, pointing it at the public keys of the blind peers you want to mirror to (L23–L25, reading the keys collected from `opts.blindPeerKey` at L15). Register the room's Autobase once it is open (L36). Close it **before** the room so its connections release cleanly (L55):
 
-```js file=<rootDir>/examples/how-to/blind-peering/add-blind-peering-to-a-chat-app/workers/worker-task.js title="workers/worker-task.js" lineNumbers {1,15,23-25,36,55}
+```js file=<rootDir>/examples/how-to/blind-peering/add-blind-peering-to-a-chat-app/workers/worker-task.js title="workers/worker-task.js" lineNumbers {1,15,23-25,36,55} skip="example-import"
 ```
 The blind peers replicate and seed the room's encrypted [Autobase](/reference/building-blocks/autobase) without holding its read key. Point the client at blind-peer keys you run yourself (the [`blind-peer-cli`](https://github.com/holepunchto/blind-peer-cli) server prints `Listening at <key>` on startup) or shared ones.
 

--- a/content/how-to/blind-peering/keep-data-available-with-blind-peering.mdx
+++ b/content/how-to/blind-peering/keep-data-available-with-blind-peering.mdx
@@ -28,7 +28,7 @@ You point the client at the **public keys** of the blind peers you want to mirro
 
 ## Add the dependency
 
-```sh
+```sh skip="install-instruction"
 npm install blind-peering
 ```
 
@@ -36,7 +36,7 @@ npm install blind-peering
 
 Create the `BlindPeering` client against your swarm's [HyperDHT](/reference/building-blocks/hyperdht) instance (`swarm.dht`) and a [Corestore](/reference/helpers/corestore) namespace, passing the blind peers' public keys as `keys`. Then register the cores or Autobases you want kept available:
 
-```js
+```js skip="snippet-illustration"
 import Hyperswarm from 'hyperswarm'
 import Corestore from 'corestore'
 import BlindPeering from 'blind-peering'
@@ -65,7 +65,7 @@ await blinds.addAutobase(base)
 
 Close the client before the swarm and store so its connections release cleanly:
 
-```js
+```js skip="snippet-illustration"
 await blinds.close()
 await swarm.destroy()
 await store.close()

--- a/content/how-to/connect-to-peers/connect-to-many-peers-by-topic-with-hyperswarm.mdx
+++ b/content/how-to/connect-to-peers/connect-to-many-peers-by-topic-with-hyperswarm.mdx
@@ -34,7 +34,7 @@ npm install hyperswarm hypercore-crypto b4a bare-process
 
 Alter the peer-app/index.js file to the following. Create a single [Hyperswarm](/reference/building-blocks/hyperswarm) instance (L7). On each `connection` event, track the connection and log incoming data from that peer (L13–L20). Broadcast anything typed on stdin to every open connection (L23–L28). Then join a common topic as both client and server—reusing a topic passed on the command line, or generating a fresh one (L31–L32). The `discovery.flushed()` promise resolves once the topic has been announced to the DHT, at which point the topic is logged for other peers to copy (L35–L37).
 
-```javascript file=<rootDir>/examples/how-to/connect-to-peers/connect-to-many-peers-by-topic-with-hyperswarm/peer-app/index.js title="peer-app/index.js" lineNumbers {7,13-20,23-28,31-32,35-37}
+```javascript file=<rootDir>/examples/how-to/connect-to-peers/connect-to-many-peers-by-topic-with-hyperswarm/peer-app/index.js title="peer-app/index.js" lineNumbers {7,13-20,23-28,31-32,35-37} skip="example-import"
 ```
 
 ## Run the swarm

--- a/content/how-to/connect-to-peers/connect-two-peers-by-key-with-hyperdht.mdx
+++ b/content/how-to/connect-to-peers/connect-two-peers-by-key-with-hyperdht.mdx
@@ -49,7 +49,7 @@ Alter `server-app/index.js` to the following.
 
 The server starts a DHT node (L5) and generates a key pair that serves as its identity in the DHT (L8), then derives a hex string `name` from the public key to print and share (L9). `dht.createServer` registers a connection handler (L11–L13) that logs each connecting peer, wires incoming data to the console, and forwards local stdin to the connection (L15–L19). Finally, `server.listen(keyPair)` announces the key on the DHT and logs the public key for the client to copy (L22–L24):
 
-```javascript file=<rootDir>/examples/how-to/connect-to-peers/connect-two-peers-by-key-with-hyperdht/server-app/index.js title="server-app/index.js" lineNumbers {5,8-9,11-13,15-19,22-24}
+```javascript file=<rootDir>/examples/how-to/connect-to-peers/connect-two-peers-by-key-with-hyperdht/server-app/index.js title="server-app/index.js" lineNumbers {5,8-9,11-13,15-19,22-24} skip="example-import"
 ```
 
 ### Run the server
@@ -80,7 +80,7 @@ Alter `client-app/index.js` to the following.
 
 The client reads the server's public key from the command-line argument and fails fast if it is missing (L6–L7), then decodes it from hex (L10). It starts its own DHT node (L12–L13) and calls `dht.connect(publicKey)` to begin hole punching toward the server (L15). The `open` handler logs the connected peer once the link is established (L16–L19), the `data` handler prints incoming messages (L21–L24), and local stdin is written to the connection (L26–L29):
 
-```javascript file=<rootDir>/examples/how-to/connect-to-peers/connect-two-peers-by-key-with-hyperdht/client-app/index.js title="client-app/index.js" lineNumbers {6-7,10,12-13,15,16-19,21-24,26-29}
+```javascript file=<rootDir>/examples/how-to/connect-to-peers/connect-two-peers-by-key-with-hyperdht/client-app/index.js title="client-app/index.js" lineNumbers {6-7,10,12-13,15,16-19,21-24,26-29} skip="example-import"
 ```
 
 ### Run the chat client

--- a/content/how-to/connect-to-peers/host-multiple-rooms-in-one-chat-app.mdx
+++ b/content/how-to/connect-to-peers/host-multiple-rooms-in-one-chat-app.mdx
@@ -43,7 +43,7 @@ In `workers/worker-task.js`, swap the single `ChatRoom` for a `ChatAccount` (L6)
 
 `_open` opens the account (L30–L31), then handles `add-room`, `join-room`, and `add-message` on the pipe (L44–L50). `_close` tears down account → swarm → store (L55–L59):
 
-```js file=<rootDir>/examples/how-to/connect-to-peers/multi-rooms/workers/worker-task.js title="workers/worker-task.js" lineNumbers {6,17-19,21-26,30-31,44-50,55-59}
+```js file=<rootDir>/examples/how-to/connect-to-peers/multi-rooms/workers/worker-task.js title="workers/worker-task.js" lineNumbers {6,17-19,21-26,30-31,44-50,55-59} skip="example-import"
 ```
 
 </Step>
@@ -57,7 +57,7 @@ Create `workers/chat-account.js` modelled on `chat-room.js`. The account is itse
 * On `_open`, the account opens its base, then `openRooms()` materialises one `ChatRoom` per stored entry, each in its own Corestore namespace (`this.store.namespace(id)`) (L156–L168).
 * `addRoom` (L170–L184) and `joinRoom` (L186–L206) spin up a new `ChatRoom`, then append the room metadata to the account base so it survives restarts:
 
-```js file=<rootDir>/examples/how-to/connect-to-peers/multi-rooms/workers/chat-account.js#L156-L206 title="workers/chat-account.js" lineNumbers {156-168,170-184,186-206}
+```js file=<rootDir>/examples/how-to/connect-to-peers/multi-rooms/workers/chat-account.js#L156-L206 title="workers/chat-account.js" lineNumbers {156-168,170-184,186-206} skip="example-import"
 ```
 
 The key change: each room is an independent Autobase in its own namespace, so the account never co-mingles room data. The account base only stores room metadata (id, name, invite, info), encrypted by the account's own Autobase. See [Storage and distribution](/explanation/storage-and-distribution) for the underlying mental model.
@@ -75,7 +75,7 @@ This step touches all three builders in `schema.js`, so it is easiest to follow 
 
 The roomId that the renderer uses to address a specific room is carried on the plain-JSON messages exchanged over the worker pipe, so the schema only needs to persist the room metadata. The new `room` registration looks like this (L26–L34):
 
-```js file=<rootDir>/examples/how-to/connect-to-peers/multi-rooms/schema.js#L26-L34 title="schema.js" lineNumbers {26-34}
+```js file=<rootDir>/examples/how-to/connect-to-peers/multi-rooms/schema.js#L26-L34 title="schema.js" lineNumbers {26-34} skip="example-import"
 ```
 
 Regenerate `spec/` from a **clean** directory:

--- a/content/how-to/manage-identity/add-keet-identity-to-a-chat-app.mdx
+++ b/content/how-to/manage-identity/add-keet-identity-to-a-chat-app.mdx
@@ -50,7 +50,7 @@ npm install keet-identity-key hypercore-crypto
 
 In `workers/index.js`, resolve the mnemonic before constructing `WorkerTask`. A `--mnemonic` flag wins if supplied (L27); otherwise read `identity-mnemonic.txt` from the app storage directory (L28, L30), and if that file does not exist yet, generate a fresh 24-word phrase with [`keet-identity-key`](https://www.npmjs.com/package/keet-identity-key) (L33). Persist it back (L35) so every subsequent start loads the same identity. Treat the mnemonic file as **sensitive**—do not check it into version control, and back it up the way you would a wallet seed.
 
-```js file=<rootDir>/examples/how-to/manage-identity/keet-identity/workers/index.js#L27-L35 title="workers/index.js" lineNumbers {27,28,30,33,35}
+```js file=<rootDir>/examples/how-to/manage-identity/keet-identity/workers/index.js#L27-L35 title="workers/index.js" lineNumbers {27,28,30,33,35} skip="example-import"
 ```
 
 </Step>
@@ -61,7 +61,7 @@ In `workers/index.js`, resolve the mnemonic before constructing `WorkerTask`. A 
 
 Pass the resolved mnemonic into `WorkerTask` as a constructor argument (`new WorkerTask(pipe, storage, mnemonic, cmd.flags)`). In `workers/worker-task.js`, the constructor stores the mnemonic (L16) and builds a `ChatRoomIdentity` room (L24). In `_open`, load the identity from that mnemonic and bootstrap a per-device key pair the identity attests (L34–L36). Each appended message is signed with the device key via `Identity.attestData` (L49–L50), so the worker stamps every line with a verifiable proof—and `_messages` verifies each proof with `Identity.verify` (L68–L71) before forwarding messages to the renderer. The [`pear-chat-identity`](https://github.com/holepunchto/pear-docs/tree/preview/examples/how-to/manage-identity/keet-identity) example keeps the original storage-namespaced Autobase (via `ChatRoomIdentity`) but extends the message schema to carry the proof:
 
-```js file=<rootDir>/examples/how-to/manage-identity/keet-identity/workers/worker-task.js title="workers/worker-task.js" lineNumbers {16,24,34-36,49-50,68-71}
+```js file=<rootDir>/examples/how-to/manage-identity/keet-identity/workers/worker-task.js title="workers/worker-task.js" lineNumbers {16,24,34-36,49-50,68-71} skip="example-import"
 ```
 
 </Step>
@@ -76,7 +76,7 @@ Pass the resolved mnemonic into `WorkerTask` as a constructor argument (`new Wor
 3. Widen `addMessage` to take and persist a `proof` alongside each message (L149–L153).
 Without this file the worker fails to boot with `MODULE_NOT_FOUND: ./chat-room-identity`:
 
-```js file=<rootDir>/examples/how-to/manage-identity/keet-identity/workers/chat-room-identity.js title="workers/chat-room-identity.js" lineNumbers {11,111,114,117,149-153}
+```js file=<rootDir>/examples/how-to/manage-identity/keet-identity/workers/chat-room-identity.js title="workers/chat-room-identity.js" lineNumbers {11,111,114,117,149-153} skip="example-import"
 ```
 
 </Step>
@@ -110,7 +110,7 @@ The worker already verifies every message in `_messages` and stamps `msg.info.ve
 
 In `renderer/app.js`, each message row reads `message.info?.verified` (L43) and renders a verified/unverified badge next to the sender's name (L44–L47), then appends it to the row's metadata line (L53):
 
-```js file=<rootDir>/examples/how-to/manage-identity/keet-identity/renderer/app.js#L43-L54 title="renderer/app.js" lineNumbers {43-47,53}
+```js file=<rootDir>/examples/how-to/manage-identity/keet-identity/renderer/app.js#L43-L54 title="renderer/app.js" lineNumbers {43-47,53} skip="example-import"
 ```
 
 The badge turns green only when the proof on that message validates against the identity that authored it—so a peer replicating the room can see, per line, which messages are provably from a given identity across reinstalls and devices.

--- a/content/how-to/manage-identity/create-a-portable-identity-with-keet-identity-key.mdx
+++ b/content/how-to/manage-identity/create-a-portable-identity-with-keet-identity-key.mdx
@@ -36,7 +36,7 @@ This is purely Pear-end logic: it runs in a [Bare](/reference/modules/bare-modul
 
 ## Add the dependencies
 
-```sh
+```sh skip="install-instruction"
 npm install keet-identity-key hypercore-crypto
 ```
 
@@ -44,7 +44,7 @@ npm install keet-identity-key hypercore-crypto
 
 Generate (or load) a mnemonic (L5), derive the identity from it (L7), then mint a fresh per-device key pair (L11) and bootstrap it—the identity attests the device key and returns a `deviceProof` (L12):
 
-```js file=<rootDir>/examples/how-to/manage-identity/create-a-portable-identity-with-keet-identity-key/index.js#L1-L12 title="index.js" lineNumbers {5,7,11-12}
+```js file=<rootDir>/examples/how-to/manage-identity/create-a-portable-identity-with-keet-identity-key/index.js#L1-L12 title="index.js" lineNumbers {5,7,11-12} skip="example-import"
 ```
 
 Persist the mnemonic, not the device key—a new device re-derives the identity from the same mnemonic and bootstraps a fresh device key of its own.
@@ -53,7 +53,7 @@ Persist the mnemonic, not the device key—a new device re-derives the identity 
 
 Take a payload (L15) and attest it with the device key. The resulting proof (L16) carries the chain back to the identity:
 
-```js file=<rootDir>/examples/how-to/manage-identity/create-a-portable-identity-with-keet-identity-key/index.js#L15-L16 title="index.js" lineNumbers {15-16}
+```js file=<rootDir>/examples/how-to/manage-identity/create-a-portable-identity-with-keet-identity-key/index.js#L15-L16 title="index.js" lineNumbers {15-16} skip="example-import"
 ```
 
 Attach `proof` to whatever you append to your Hypercore/Autobase alongside the payload.
@@ -62,7 +62,7 @@ Attach `proof` to whatever you append to your Hypercore/Autobase alongside the p
 
 Any peer replicating the data can verify it was authored by the expected identity—pass the proof, the payload, and the expected `identityPublicKey`, and `verify` returns truthy only for a valid proof (L19–L21). No shared secret needed:
 
-```js file=<rootDir>/examples/how-to/manage-identity/create-a-portable-identity-with-keet-identity-key/index.js#L19-L22 title="index.js" lineNumbers {19-21}
+```js file=<rootDir>/examples/how-to/manage-identity/create-a-portable-identity-with-keet-identity-key/index.js#L19-L22 title="index.js" lineNumbers {19-21} skip="example-import"
 ```
 
 Because verification only needs the public `identityPublicKey`, you can stamp every message with a proof and let every reader confirm authorship across reinstalls and across machines.

--- a/content/how-to/operate-an-app/github-actions/build-and-sign-in-ci.mdx
+++ b/content/how-to/operate-an-app/github-actions/build-and-sign-in-ci.mdx
@@ -26,7 +26,7 @@ You need:
 
 Create `.github/workflows/build.yml`. Run [`pear-base`](/reference/ci-and-release/github-actions#pear-base) to install Pear, then `make-pear-app` per OS:
 
-```yaml
+```yaml skip="ci-config"
 name: Build desktop app
 
 on:

--- a/content/how-to/operate-an-app/github-actions/publish-with-github-actions.mdx
+++ b/content/how-to/operate-an-app/github-actions/publish-with-github-actions.mdx
@@ -24,7 +24,7 @@ Two properties make this work well in CI:
 - **The `pear://` link is stable.** Because the drive key comes from the secret primary key plus the namespace, every run stages to the same link. You set that link once as your app's `upgrade` field and every push updates it.
 - **The snapshot replaces persistent storage.** `ci/snapshot.json` records each core's length, so the next run only syncs what changed instead of re-uploading the whole drive or persisting a full Corestore between jobs.
 
-```mermaid
+```mermaid skip="diagram"
 flowchart LR
   push["git push to main"] --> action["pear-ci action"]
   action --> snap["fetch ci/snapshot.json"]
@@ -47,7 +47,7 @@ You need:
 
 Generate a random 32-byte key:
 
-```bash
+```bash skip="manual-walkthrough"
 openssl rand -hex 32
 # 9f2c... (64 hex characters)
 ```
@@ -62,7 +62,7 @@ The primary key is the **write key** for your drive—anyone who has it can publ
 
 Create `.github/workflows/pear-ci.yml`:
 
-```yaml
+```yaml skip="ci-config"
 name: Publish with pear-ci
 
 on:
@@ -99,13 +99,13 @@ For the full list of inputs and outputs, see the [`pear-ci` GitHub Action refere
 
 The first run prints the drive key it stages to:
 
-```text
+```text skip="sample-output"
 starting stage for key <drive-key>
 ```
 
 That key is your app's `pear://` link. Set it as the [`upgrade`](/reference/pear/configuration) field so installed builds poll it for updates:
 
-```bash
+```bash skip="manual-walkthrough"
 npm pkg set upgrade=pear://<drive-key>
 ```
 
@@ -115,7 +115,7 @@ This is the same `upgrade` link that the [manual deploy flow](/how-to/operate-an
 
 Before publishing for real, set `dry-run: true` in the workflow. The action computes and logs the file-by-file diff without writing anything to the drive—the same safety check as `pear stage --dry-run`:
 
-```yaml
+```yaml skip="ci-config"
         with:
           primary-key: ${{ secrets.PEAR_PRIMARY_KEY }}
           namespace: my-app

--- a/content/how-to/operate-an-app/migration.mdx
+++ b/content/how-to/operate-an-app/migration.mdx
@@ -39,7 +39,7 @@ Running every app on a single vendor-signed Electron build made shipping trivial
 
 The fastest migration is to scaffold a fresh Electron app that already has `pear-runtime` integrated, then move your code into it. Use the [`hello-pear-electron`](https://github.com/holepunchto/hello-pear-electron) boilerplate:
 
-```bash
+```bash skip="manual-walkthrough"
 git clone https://github.com/holepunchto/hello-pear-electron
 cd hello-pear-electron
 npm install

--- a/content/how-to/store-and-replicate/replicate-and-persist-with-hypercore.mdx
+++ b/content/how-to/store-and-replicate/replicate-and-persist-with-hypercore.mdx
@@ -52,7 +52,7 @@ Create the `writer-app/index.js` file with the following content.
 
 The writer creates a Hyperswarm and destroys it cleanly on `SIGINT` (L8–L9), then opens a local Hypercore backed by `./storage/writer-storage` (L11). `core.key` and `core.discoveryKey` are only available after `core.ready()` resolves, so it awaits that before logging the hex-encoded key readers will need (L14–L15). Every chunk of stdin is appended as its own block (L18). Finally it joins the swarm on the `discoveryKey` and replicates the core to each incoming connection (L22–L23):
 
-```javascript file=<rootDir>/examples/how-to/store-and-replicate/replicate-and-persist-with-hypercore/writer-app/index.js title="writer-app/index.js" lineNumbers {8-9,11,14-15,18,22-23}
+```javascript file=<rootDir>/examples/how-to/store-and-replicate/replicate-and-persist-with-hypercore/writer-app/index.js title="writer-app/index.js" lineNumbers {8-9,11,14-15,18,22-23} skip="example-import"
 ```
 
 ## Create the reader app
@@ -84,7 +84,7 @@ Create the `reader-app/index.js` file with the following content.
 
 Like the writer, the reader sets up a Hyperswarm with `SIGINT` cleanup (L7–L8). It opens its Hypercore with the writer's key passed on the command line (`Bare.argv[2]`), which makes it a read-only replica, and awaits `core.ready()` (L10–L11). It joins the swarm on the same `discoveryKey` and replicates over each connection (L13–L14), then `swarm.flush()` waits until all discoverable peers are connected (L17) before `core.update()` pulls the latest length from the writer (L19). It records the current `core.length` and tails the core from that point with a live read stream, logging each new block as it arrives (L21–L24):
 
-```javascript file=<rootDir>/examples/how-to/store-and-replicate/replicate-and-persist-with-hypercore/reader-app/index.js title="reader-app/index.js" lineNumbers {7-8,10-11,13-14,17,19,21-24}
+```javascript file=<rootDir>/examples/how-to/store-and-replicate/replicate-and-persist-with-hypercore/reader-app/index.js title="reader-app/index.js" lineNumbers {7-8,10-11,13-14,17,19,21-24} skip="example-import"
 ```
 
 ## Run the writer and reader

--- a/content/how-to/store-and-replicate/share-append-only-databases-with-hyperbee.mdx
+++ b/content/how-to/store-and-replicate/share-append-only-databases-with-hyperbee.mdx
@@ -46,7 +46,7 @@ Create the `bee-writer-app/index.js` file with the following content:
 
 A [Corestore](/reference/helpers/corestore) holds the backing core (L8), and a [Hyperswarm](/reference/building-blocks/hyperswarm) replicates it on every connection (L10–L14). The Hyperbee is built on a named core (L17) with UTF-8 key/value encoding (L20–L23). Once the core is ready (L26) it joins the swarm on the core's discovery key (L29), and the writable key is printed only after the topic is announced to the DHT (L32–L34). On the first run (`core.length <= 1`), the dictionary is loaded and inserted in a single atomic batch (L38–L47); on later runs it just re-seeds the existing data (L48–L50).
 
-```javascript file=<rootDir>/examples/how-to/store-and-replicate/share-append-only-databases-with-hyperbee/bee-writer-app/index.js title="bee-writer-app/index.js" lineNumbers {8,10-14,17,20-23,26,29,32-34,38-47}
+```javascript file=<rootDir>/examples/how-to/store-and-replicate/share-append-only-databases-with-hyperbee/bee-writer-app/index.js title="bee-writer-app/index.js" lineNumbers {8,10-14,17,20-23,26,29,32-34,38-47} skip="example-import"
 ```
 ### Save the `dict.json` file
 
@@ -96,7 +96,7 @@ Create the `bee-reader-app/index.js` file with the following content:
 
 The reader takes the writer's public key as a command-line argument (L8–L10) and opens that core through its own [Corestore](/reference/helpers/corestore) (L13), replicated over [Hyperswarm](/reference/building-blocks/hyperswarm) (L15–L19). The core is reopened from the supplied key (L22) and wrapped in a Hyperbee with matching UTF-8 encoding (L25–L28). After `ready()` (L31) it joins the same topic (L37) and reads words from stdin (L39): each query calls `bee.get(word)` and prints the value, downloading only the blocks needed to satisfy it (L41–L48).
 
-```javascript file=<rootDir>/examples/how-to/store-and-replicate/share-append-only-databases-with-hyperbee/bee-reader-app/index.js title="bee-reader-app/index.js" lineNumbers {8-10,13,15-19,22,25-28,31,37,39,41-48}
+```javascript file=<rootDir>/examples/how-to/store-and-replicate/share-append-only-databases-with-hyperbee/bee-reader-app/index.js title="bee-reader-app/index.js" lineNumbers {8-10,13,15-19,22,25-28,31,37,39,41-48} skip="example-import"
 ```
 
 ### Run the `bee-reader-app`
@@ -151,7 +151,7 @@ Create the `core-reader-app/index.js` file with the following content:
 
 This app treats the Hyperbee purely as a Hypercore. It imports Hyperbee's `Node` encoding directly so it can decode tree nodes (L6), takes the writer's key as an argument (L8–L10), and opens the core through a [Corestore](/reference/helpers/corestore) (L13) replicated over [Hyperswarm](/reference/building-blocks/hyperswarm) (L15–L19). The core is reopened from the key and made ready (L22–L24), then joins the topic and waits for the swarm to flush (L27–L28). After pulling the latest metadata with `core.update()` (L31), it fetches the last block by sequence number (L33–L34) and logs it both raw and decoded through `Node.decode` (L37–L38).
 
-```javascript file=<rootDir>/examples/how-to/store-and-replicate/share-append-only-databases-with-hyperbee/core-reader-app/index.js title="core-reader-app/index.js" lineNumbers {6,8-10,13,15-19,22-24,27-28,31,33-34,37-38}
+```javascript file=<rootDir>/examples/how-to/store-and-replicate/share-append-only-databases-with-hyperbee/core-reader-app/index.js title="core-reader-app/index.js" lineNumbers {6,8-10,13,15-19,22-24,27-28,31,33-34,37-38} skip="example-import"
 ```
 
 ### Run the `core-reader-app`

--- a/content/how-to/store-and-replicate/work-with-many-hypercores-using-corestore.mdx
+++ b/content/how-to/store-and-replicate/work-with-many-hypercores-using-corestore.mdx
@@ -56,7 +56,7 @@ The `multicore-writer-app` uses a Corestore instance to create three Hypercores,
 * The main core key is logged so it can be passed to the [`multicore-reader-app`](#create-the-multicore-reader-app) (L28).
 * Terminal input is routed by length: short messages append to `core2`, long ones to `core3` (L39–L46).
 
-```javascript file=<rootDir>/examples/how-to/store-and-replicate/work-with-many-hypercores-using-corestore/multicore-writer-app/index.js title="multicore-writer-app/index.js" lineNumbers {7-8,13-15,22-26,28,32,36,39-46}
+```javascript file=<rootDir>/examples/how-to/store-and-replicate/work-with-many-hypercores-using-corestore/multicore-writer-app/index.js title="multicore-writer-app/index.js" lineNumbers {7-8,13-15,22-26,28,32,36,39-46} skip="example-import"
 ```
 
 ## Create the multicore reader app
@@ -86,7 +86,7 @@ This will install the following dependencies:
 
 Create the `multicore-reader-app/index.js` file with the following content. The reader takes the writer's main core key as a command-line argument (L6–L8) and opens its own Corestore (L10–L11). On each connection it replicates the whole store (L17), then gets `core1` from the supplied key, joins the swarm on its discovery key, and flushes discovery (L20–L25). `core.get(0)` then blocks until the writer's first block—the bootstrap key list—has actually replicated; unlike `core.update()` it waits for the data itself, and a timeout surfaces a clear error if the writer is never reachable instead of reading an empty core or hanging (L27–L36). It reads the bootstrap key list from that block (L39) and, for every key, gets the corresponding core and logs each new block as it is appended (L40–L50):
 
-```javascript file=<rootDir>/examples/how-to/store-and-replicate/work-with-many-hypercores-using-corestore/multicore-reader-app/index.js title="multicore-reader-app/index.js" lineNumbers {6-8,10-11,17,20-25,27-36,39,40-50}
+```javascript file=<rootDir>/examples/how-to/store-and-replicate/work-with-many-hypercores-using-corestore/multicore-reader-app/index.js title="multicore-reader-app/index.js" lineNumbers {6-8,10-11,17,20-25,27-36,39,40-50} skip="example-import"
 ```
 
 ## Run the writer and reader

--- a/content/how-to/stream-and-share-media/back-up-photos-in-a-peer-to-peer-app.mdx
+++ b/content/how-to/stream-and-share-media/back-up-photos-in-a-peer-to-peer-app.mdx
@@ -53,12 +53,12 @@ npm install bare-ffmpeg bare-media get-mime-type hyperblobs hypercore-blob-serve
 
 `workers/video-room.js` (`VideoRoom`, shared with the video-stream how-to but extended for images) defines `addVideo` (L181), which checks the MIME type with [`get-mime-type`](https://www.npmjs.com/package/get-mime-type) and rejects anything that is not an image or video (L183–L186). It then streams the full file bytes into a Hyperblobs write stream (L188–L194) and captures the resulting blob id (L195). Only then does it generate a small inline preview—`bare-media` for images, `bare-ffmpeg` for video (L197)—and append the record to the base (L200–L202):
 
-```js file=<rootDir>/examples/how-to/stream-and-share-media/photo-backup/workers/video-room.js#L181-L203 title="workers/video-room.js" lineNumbers {181,183-186,188-194,195,197,200-202}
+```js file=<rootDir>/examples/how-to/stream-and-share-media/photo-backup/workers/video-room.js#L181-L203 title="workers/video-room.js" lineNumbers {181,183-186,188-194,195,197,200-202} skip="example-import"
 ```
 
 The preview is a base64 `data:` URL kept inline in the record's `info`, so the grid can paint immediately without fetching the full blob. Images are resized with `bare-media`: `createPreviewImage` decodes the file, resizes it to a 256×256 bound, and re-encodes it as WebP (L6–L9), then returns the bytes as a base64 `data:` URL (L10):
 
-```js file=<rootDir>/examples/how-to/stream-and-share-media/photo-backup/workers/create-preview-image.js title="workers/create-preview-image.js" lineNumbers {6-9,10}
+```js file=<rootDir>/examples/how-to/stream-and-share-media/photo-backup/workers/create-preview-image.js title="workers/create-preview-image.js" lineNumbers {6-9,10} skip="example-import"
 ```
 
 `workers/create-preview-video.js` is the `bare-ffmpeg` counterpart for video files (a stub in the reference app—wire up `bare-ffmpeg` frame extraction here to generate a video thumbnail). Both preview helpers are worker-side modules (they call `bare-media`/`bare-ffmpeg`), so they live alongside the worker in `workers/`, not in the renderer. Each record stored in the view is `{ id, name, type, blob, info: { preview, ... } }`—small metadata plus a blob id pointing at the full bytes.

--- a/content/how-to/stream-and-share-media/create-a-full-peer-to-peer-filesystem-with-hyperdrive.mdx
+++ b/content/how-to/stream-and-share-media/create-a-full-peer-to-peer-filesystem-with-hyperdrive.mdx
@@ -58,7 +58,7 @@ This will install the following dependencies:
 
 Create the `drive-writer-app/index.js` file with the following content:
 
-```javascript file=<rootDir>/examples/how-to/stream-and-share-media/create-a-full-peer-to-peer-filesystem-with-hyperdrive/drive-writer-app/index.js title="drive-writer-app/index.js" lineNumbers {11-16,19-23,26,31-34,39-42,45-49}
+```javascript file=<rootDir>/examples/how-to/stream-and-share-media/create-a-full-peer-to-peer-filesystem-with-hyperdrive/drive-writer-app/index.js title="drive-writer-app/index.js" lineNumbers {11-16,19-23,26,31-34,39-42,45-49} skip="example-import"
 ```
 
 The `drive-writer-app` creates a [`Corestore`](/reference/helpers/corestore) and replicates it over [`Hyperswarm`](/reference/building-blocks/hyperswarm) so other peers can fetch the data (L11–L16). It wraps the local `./writer-dir` directory in a [`Localdrive`](/reference/helpers/localdrive) and creates the [`Hyperdrive`](/reference/building-blocks/hyperdrive) on top of the store (L19–L23), then waits for it to initialize (L26). After joining the swarm on the drive's discovery key, it prints the drive key that [`drive-reader-app`](#create-the-drive-reader-app) will need (L31–L34). Pressing `Enter` in the terminal triggers a debounced mirror (L39–L42), and `mirrorDrive` copies the contents of `./writer-dir` into the drive (L45–L49).
@@ -99,7 +99,7 @@ This will install the following dependencies:
 
 Create the `drive-reader-app/index.js` file with the following content:
 
-```javascript file=<rootDir>/examples/how-to/stream-and-share-media/create-a-full-peer-to-peer-filesystem-with-hyperdrive/drive-reader-app/index.js title="drive-reader-app/index.js" lineNumbers {10-12,15-21,24-27,32-36,39-42,44-48}
+```javascript file=<rootDir>/examples/how-to/stream-and-share-media/create-a-full-peer-to-peer-filesystem-with-hyperdrive/drive-reader-app/index.js title="drive-reader-app/index.js" lineNumbers {10-12,15-21,24-27,32-36,39-42,44-48} skip="example-import"
 ```
 
 The `drive-reader-app` reads the writer's drive key from the command-line arguments (L10–L12) and replicates a [`Corestore`](/reference/helpers/corestore) over [`Hyperswarm`](/reference/building-blocks/hyperswarm) (L15–L21). It wraps the local `./reader-dir` directory in a [`Localdrive`](/reference/helpers/localdrive) and opens the remote [`Hyperdrive`](/reference/building-blocks/hyperdrive) from that key (L24–L27). It re-runs a debounced mirror whenever new content is appended to the drive's core (L32–L36), joins the swarm as a client and runs the first mirror immediately (L39–L42). `mirrorDrive` copies the contents of the remote drive into `./reader-dir` and logs when each pass completes (L44–L48).
@@ -158,7 +158,7 @@ This will install the following dependencies:
 
 Create the `drive-bee-reader-app/index.js` file with the following content:
 
-```javascript file=<rootDir>/examples/how-to/stream-and-share-media/create-a-full-peer-to-peer-filesystem-with-hyperdrive/drive-bee-reader-app/index.js title="drive-bee-reader-app/index.js" lineNumbers {8-10,12-17,19-21,24,29-37,39,41-49}
+```javascript file=<rootDir>/examples/how-to/stream-and-share-media/create-a-full-peer-to-peer-filesystem-with-hyperdrive/drive-bee-reader-app/index.js title="drive-bee-reader-app/index.js" lineNumbers {8-10,12-17,19-21,24,29-37,39,41-49} skip="example-import"
 ```
 
 Like the reader, this app reads the drive key from the command line (L8–L10) and replicates a [`Corestore`](/reference/helpers/corestore) over [`Hyperswarm`](/reference/building-blocks/hyperswarm) (L12–L17). It opens the [`Hyperdrive`](/reference/building-blocks/hyperdrive) and awaits both `drive.ready()` and `drive.db.ready()` (L19–L21), then reaches into the metadata index directly: file entries live in the `files` sub-[Hyperbee](/reference/building-blocks/hyperbee) (L24). It polls `drive.update()` until the first entry replicates in (L29–L37), looks the same file up through the higher-level `drive.entry()` API (L39), and logs both the raw Hyperbee entry and the `drive.entry()` view side by side (L41–L49).

--- a/content/how-to/stream-and-share-media/share-files-in-a-peer-to-peer-app.mdx
+++ b/content/how-to/stream-and-share-media/share-files-in-a-peer-to-peer-app.mdx
@@ -55,7 +55,7 @@ Create `workers/drive-room.js` (`DriveRoom`) by adapting `chat-room.js`. The pai
 - Each peer owns one **Hyperdrive** (`this.myDrive`) backed by a local `my-drive` folder (`this.myLocalDrive`, a [`localdrive`](https://www.npmjs.com/package/localdrive)). `_uploadMyDrive` (L160) publishes the drive key to the Autobase (L162), joins the swarm on it (L163), and mirrors the folder into the Hyperdrive on a 1-second timer (L165–L166), so dropping a file into `my-drive` publishes it to peers.
 - The Autobase view stores just the **set of drive keys** (`@pear-file-sharing/drives`). `_downloadSharedDrives` (L141) replicates every peer's Hyperdrive: it opens a per-key `LocalDrive` under `shared-drives` (L147), reuses `myDrive` or constructs a peer Hyperdrive from the key (L149), mirrors the drive down on every `append` (L152–L153), and joins the swarm on its discovery key (L156).
 
-```js file=<rootDir>/examples/how-to/stream-and-share-media/file-sharing/workers/drive-room.js#L141-L167 title="workers/drive-room.js" lineNumbers {141,147,149,152-153,156,160,162-163,165-166}
+```js file=<rootDir>/examples/how-to/stream-and-share-media/file-sharing/workers/drive-room.js#L141-L167 title="workers/drive-room.js" lineNumbers {141,147,149,152-153,156,160,162-163,165-166} skip="example-import"
 ```
 
 </Step>
@@ -66,7 +66,7 @@ Create `workers/drive-room.js` (`DriveRoom`) by adapting `chat-room.js`. The pai
 
 `pear-file-sharing` runs two polling loops: `DriveRoom._uploadMyDrive` mirrors the user's `my-drive` folder into the Hyperdrive, and `WorkerTask` rebuilds the file list for the renderer. Both store their timer handles, and `_close` clears them (L62) before the standard room → swarm → store chain (L63–L65). **Do not drop this**, or shutdown leaks an interval timer:
 
-```js file=<rootDir>/examples/how-to/stream-and-share-media/file-sharing/workers/worker-task.js#L61-L66 title="workers/worker-task.js" lineNumbers {62,63-65}
+```js file=<rootDir>/examples/how-to/stream-and-share-media/file-sharing/workers/worker-task.js#L61-L66 title="workers/worker-task.js" lineNumbers {62,63-65} skip="example-import"
 ```
 
 `DriveRoom._close` does the same for its own `uploadInterval`. The [`graceful-goodbye`](https://www.npmjs.com/package/graceful-goodbye) hook in `workers/index.js` is what fires this on SIGINT / IPC end.
@@ -85,12 +85,12 @@ npm run build:db
 
 The worker–renderer transport stays the plain-JSON-over-[`framed-stream`](https://www.npmjs.com/package/framed-stream) pipe in hello-pear-electron—no HRPC. `WorkerTask._open` wires both ends: it parses each plain-JSON message off the pipe (L44–L50), and an `add-file` message copies the chosen file into the `my-drive` folder (L51–L53) where `_uploadMyDrive` picks it up. A 1-second interval starts `_drives` (L56), and the initial invite is written back to the renderer (L58):
 
-```js file=<rootDir>/examples/how-to/stream-and-share-media/file-sharing/workers/worker-task.js#L37-L59 title="workers/worker-task.js" lineNumbers {44-50,51-53,56,58}
+```js file=<rootDir>/examples/how-to/stream-and-share-media/file-sharing/workers/worker-task.js#L37-L59 title="workers/worker-task.js" lineNumbers {44-50,51-53,56,58} skip="example-import"
 ```
 
 `_drives` reads each mirrored drive folder off disk and writes the full list—drive name plus its files as `file://` URIs—back to the renderer as a `drives` message. It walks every known drive (L69), reads its mirrored folder recursively (L74–L77), builds the drive plus its files as `file://` URIs (L84–L85), pins the user's own drive first (L89–L92), and writes the `drives` message over the pipe (L94):
 
-```js file=<rootDir>/examples/how-to/stream-and-share-media/file-sharing/workers/worker-task.js#L68-L95 title="workers/worker-task.js" lineNumbers {69,74-77,84-85,89-92,94}
+```js file=<rootDir>/examples/how-to/stream-and-share-media/file-sharing/workers/worker-task.js#L68-L95 title="workers/worker-task.js" lineNumbers {69,74-77,84-85,89-92,94} skip="example-import"
 ```
 
 </Step>
@@ -101,7 +101,7 @@ The worker–renderer transport stays the plain-JSON-over-[`framed-stream`](http
 
 In the vanilla `renderer/app.js`, render a list grouped by drive—each peer's drive and its files, with the user's own drive pinned first. Add a drag-and-drop zone plus a "browse" file picker that send an `add-file` message over the worker pipe. Use `bridge.getPathForFile(file)` (L35)—backed by `webUtils.getPathForFile`, already exposed in `electron/preload.js` of hello-pear-electron—to turn each picked file into a local path the worker can copy, then send it as an `add-file` message (L36). `renderDrives` builds one card per drive and links each file to its `file://` URI (L43–L100). The drop zone (L111–L115) and the "browse" picker (L117–L120) both feed `addFiles`, and incoming worker messages route `drives`/`invite` events to the renderer (L131–L132):
 
-```js file=<rootDir>/examples/how-to/stream-and-share-media/file-sharing/renderer/app.js title="renderer/app.js" lineNumbers {35,36,43-100,111-115,117-120,131-132}
+```js file=<rootDir>/examples/how-to/stream-and-share-media/file-sharing/renderer/app.js title="renderer/app.js" lineNumbers {35,36,43-100,111-115,117-120,131-132} skip="example-import"
 ```
 
 </Step>

--- a/content/how-to/stream-and-share-media/store-and-serve-large-media-with-hyperblobs.mdx
+++ b/content/how-to/stream-and-share-media/store-and-serve-large-media-with-hyperblobs.mdx
@@ -41,7 +41,7 @@ The writer:
 * streams a local file through `createWriteStream()` (L18–L24)
 * and prints the `{ key, ...id }` payload other peers need (L27–L28):
 
-```javascript file=<rootDir>/examples/how-to/stream-and-share-media/store-and-serve-large-media-with-hyperblobs/writer-app/index.js title="writer-app/index.js" lineNumbers {12-13,16,18-24,27-28}
+```javascript file=<rootDir>/examples/how-to/stream-and-share-media/store-and-serve-large-media-with-hyperblobs/writer-app/index.js title="writer-app/index.js" lineNumbers {12-13,16,18-24,27-28} skip="example-import"
 ```
 
 ## Read or serve the blob on another peer
@@ -54,7 +54,7 @@ The reader:
 
     Option B is what desktop apps use: the worker hands the `link` to the renderer, and the browser streams the media straight from `hypercore-blob-server`, requesting byte ranges as the user scrubs.
 
-```javascript file=<rootDir>/examples/how-to/stream-and-share-media/store-and-serve-large-media-with-hyperblobs/reader-app/index.js title="reader-app/index.js" lineNumbers {9,15-17,20-27,30-33}
+```javascript file=<rootDir>/examples/how-to/stream-and-share-media/store-and-serve-large-media-with-hyperblobs/reader-app/index.js title="reader-app/index.js" lineNumbers {9,15-17,20-27,30-33} skip="example-import"
 ```
 
 ## Tear it down

--- a/content/how-to/stream-and-share-media/stream-a-live-camera-in-a-peer-to-peer-app.mdx
+++ b/content/how-to/stream-and-share-media/stream-a-live-camera-in-a-peer-to-peer-app.mdx
@@ -51,7 +51,7 @@ npm install hyperblobs hypercore-blob-server hypercore-id-encoding
 
 In `workers/index.js` the example fetches the room's pairing invite (L32) and derives a role: anyone who passed `--invite` is a `viewer`, otherwise they own the camera as the `creator` (L33). The worker then surfaces that role so the renderer can branch on it:
 
-```js file=<rootDir>/examples/how-to/stream-and-share-media/live-cam/workers/index.js#L30-L33 title="workers/index.js" lineNumbers {32-33}
+```js file=<rootDir>/examples/how-to/stream-and-share-media/live-cam/workers/index.js#L30-L33 title="workers/index.js" lineNumbers {32-33} skip="example-import"
 ```
 
 The renderer listens for the `role` message and either opens the camera (creator) or plays the replicated fragments (viewer).
@@ -64,7 +64,7 @@ The renderer listens for the `role` message and either opens the camera (creator
 
 `workers/live-cam-room.js` (`LiveCamRoom`) uses Autobase + pairing plumbing, and adds a Hyperblobs core plus a `hypercore-blob-server` (both constructed in the constructor and opened in `_open`). `addFragment` (L194–L208) writes each camera fragment as one blob (L195–L198), then appends a view entry tagged with a `session` id and an incrementing `fragIdx` (L203–L205)—that ordering is what lets viewers reassemble a continuous stream. On the read side, `getVideos` (L178–L192) lazily opens and joins the swarm for each fragment's blob core (L181–L186), attaches a blob-server `link` to every fragment (L188–L190), and returns them sorted by `session` then `fragIdx` (L191) so the renderer can fetch and replay them in order:
 
-```js file=<rootDir>/examples/how-to/stream-and-share-media/live-cam/workers/live-cam-room.js#L178-L208 title="workers/live-cam-room.js" lineNumbers {181-186,188-191,195-198,203-205}
+```js file=<rootDir>/examples/how-to/stream-and-share-media/live-cam/workers/live-cam-room.js#L178-L208 title="workers/live-cam-room.js" lineNumbers {181-186,188-191,195-198,203-205} skip="example-import"
 ```
 
 Pairing still uses [`blind-pairing`](https://www.npmjs.com/package/blind-pairing)—viewers join the creator's swarm via an invite code exactly as in the getting-started chat path.
@@ -77,7 +77,7 @@ Pairing still uses [`blind-pairing`](https://www.npmjs.com/package/blind-pairing
 
 In the creator path (`renderer/app.js`), guard on the pinned mime type (L123–L125)—Chromium reliably encodes WebM/VP8 only (`video/webm; codecs="vp8"`)—then request the camera (L126) and start a `MediaRecorder` on the stream (L132), emitting a chunk every `TIMESLICE_MS` (L147). Video frames are large, so each `dataavailable` chunk is converted to raw bytes and sent over the worker pipe (L140–L141) rather than as JSON—only small control/event messages are JSON-encoded:
 
-```js file=<rootDir>/examples/how-to/stream-and-share-media/live-cam/renderer/app.js#L123-L147 title="renderer/app.js — creator" lineNumbers {123-126,132,140-141,147}
+```js file=<rootDir>/examples/how-to/stream-and-share-media/live-cam/renderer/app.js#L123-L147 title="renderer/app.js — creator" lineNumbers {123-126,132,140-141,147} skip="example-import"
 ```
 
 In the viewer path, each replicated fragment carries an `info.link` from the blob server. The player appends them to a `MediaSource` strictly in `session` + `fragIdx` order—WebM/VP8 is one continuous stream, so a gap or out-of-order append puts the `<video>` element into a permanent error state.

--- a/content/how-to/stream-and-share-media/stream-stored-video-in-a-peer-to-peer-app.mdx
+++ b/content/how-to/stream-and-share-media/stream-stored-video-in-a-peer-to-peer-app.mdx
@@ -53,7 +53,7 @@ npm install hyperblobs hypercore-blob-server hypercore-id-encoding get-mime-type
 
 `workers/video-room.js` (`VideoRoom`) keeps the tutorial's Autobase + pairing, and constructs a Hyperblobs core plus a `hypercore-blob-server`. `addVideo` resolves the file name and checks the MIME type with [`get-mime-type`](https://www.npmjs.com/package/get-mime-type), rejecting anything that is not a `video/*` type (L180–L184). It then pipes the file off disk into a blobs write stream (L186–L192), captures the resulting `blob` descriptor (the blobs core key plus the write stream's byte id, L193), and appends `{ id, name, type, blob, info }` to the base so the view records it (L196–L198):
 
-```js file=<rootDir>/examples/how-to/stream-and-share-media/video-stream/workers/video-room.js#L179-L199 title="workers/video-room.js" lineNumbers {180-184,186-193,196-198}
+```js file=<rootDir>/examples/how-to/stream-and-share-media/video-stream/workers/video-room.js#L179-L199 title="workers/video-room.js" lineNumbers {180-184,186-193,196-198} skip="example-import"
 ```
 
 </Step>
@@ -64,7 +64,7 @@ npm install hyperblobs hypercore-blob-server hypercore-id-encoding get-mime-type
 
 The server speaks HTTP **range requests**, so the player handles seeking without downloading the whole file. `getVideos` reads the stored entries from the view (L164), and for each one whose blobs core it has not seen yet, opens that core and joins its swarm topic on demand (L165–L172). It then maps every entry to attach a playable `info.link` from `blobServer.getLink` before returning to the renderer (L173–L176):
 
-```js file=<rootDir>/examples/how-to/stream-and-share-media/video-stream/workers/video-room.js#L163-L177 title="workers/video-room.js" lineNumbers {164,165-172,173-176}
+```js file=<rootDir>/examples/how-to/stream-and-share-media/video-stream/workers/video-room.js#L163-L177 title="workers/video-room.js" lineNumbers {164,165-172,173-176} skip="example-import"
 ```
 
 </Step>


### PR DESCRIPTION
Makes `check:examples` pass by giving every code fence under `content/how-to` the `example=`/`skip=` meta it requires. 51 fences across 19 files were previously unannotated (the linter is not currently CI-gated, so this had gone unnoticed).

## What changed

Each edit only **appends meta to a fence's opening line** — no rendered content changes.

- **38** `file=` imports → `skip="example-import"`. These display code that already lives in (and is exercised by) the `examples/` tree, so re-running them here would be redundant.
- **13** inline fences get a reason matching the existing vocabulary:

| reason | count |
| --- | --- |
| `snippet-illustration` | 3 |
| `manual-walkthrough` | 3 |
| `ci-config` | 3 |
| `install-instruction` | 2 |
| `sample-output` | 1 |
| `diagram` | 1 |

## Verification

`check:examples:lint` ✅ (0 missing-meta, was 51) · `next build` ✅ · `check:internal-links` ✅

19 files, meta-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)