### PR TITLE
docs: link how-to method mentions to their reference definitions

### DIFF
--- a/content/how-to/blind-peering/keep-data-available-with-blind-peering.mdx
+++ b/content/how-to/blind-peering/keep-data-available-with-blind-peering.mdx
@@ -34,7 +34,7 @@ npm install blind-peering
 
 ## Wire the client
 
-Create the `BlindPeering` client against your swarm's [HyperDHT](/reference/building-blocks/hyperdht) instance (`swarm.dht`) and a [Corestore](/reference/helpers/corestore) namespace, passing the blind peers' public keys as `keys`. Then register the cores or Autobases you want kept available:
+Create the `BlindPeering` client against your swarm's [HyperDHT](/reference/building-blocks/hyperdht) instance ([`swarm.dht`](/reference/building-blocks/hyperswarm#swarmdht)) and a [Corestore](/reference/helpers/corestore) namespace, passing the blind peers' public keys as `keys`. Then register the cores or Autobases you want kept available:
 
 ```js
 import Hyperswarm from 'hyperswarm'

--- a/content/how-to/connect-to-peers/connect-to-many-peers-by-topic-with-hyperswarm.mdx
+++ b/content/how-to/connect-to-peers/connect-to-many-peers-by-topic-with-hyperswarm.mdx
@@ -32,7 +32,7 @@ npm pkg set type="module"
 npm install hyperswarm hypercore-crypto b4a bare-process
 ```
 
-Alter the peer-app/index.js file to the following. Create a single [Hyperswarm](/reference/building-blocks/hyperswarm) instance (L7). On each `connection` event, track the connection and log incoming data from that peer (L13–L20). Broadcast anything typed on stdin to every open connection (L23–L28). Then join a common topic as both client and server—reusing a topic passed on the command line, or generating a fresh one (L31–L32). The `discovery.flushed()` promise resolves once the topic has been announced to the DHT, at which point the topic is logged for other peers to copy (L35–L37).
+Alter the peer-app/index.js file to the following. Create a single [Hyperswarm](/reference/building-blocks/hyperswarm) instance (L7). On each `connection` event, track the connection and log incoming data from that peer (L13–L20). Broadcast anything typed on stdin to every open connection (L23–L28). Then join a common topic as both client and server—reusing a topic passed on the command line, or generating a fresh one (L31–L32). The [`discovery.flushed()`](/reference/building-blocks/hyperswarm#await-discoveryflushed) promise resolves once the topic has been announced to the DHT, at which point the topic is logged for other peers to copy (L35–L37).
 
 ```javascript file=<rootDir>/examples/how-to/connect-to-peers/connect-to-many-peers-by-topic-with-hyperswarm/peer-app/index.js title="peer-app/index.js" lineNumbers {7,13-20,23-28,31-32,35-37}
 ```

--- a/content/how-to/connect-to-peers/connect-two-peers-by-key-with-hyperdht.mdx
+++ b/content/how-to/connect-to-peers/connect-two-peers-by-key-with-hyperdht.mdx
@@ -47,7 +47,7 @@ npm install hyperdht b4a bare-process
 
 Alter `server-app/index.js` to the following.
 
-The server starts a DHT node (L5) and generates a key pair that serves as its identity in the DHT (L8), then derives a hex string `name` from the public key to print and share (L9). `dht.createServer` registers a connection handler (L11–L13) that logs each connecting peer, wires incoming data to the console, and forwards local stdin to the connection (L15–L19). Finally, `server.listen(keyPair)` announces the key on the DHT and logs the public key for the client to copy (L22–L24):
+The server starts a DHT node (L5) and generates a key pair that serves as its identity in the DHT (L8), then derives a hex string `name` from the public key to print and share (L9). `dht.createServer` registers a connection handler (L11–L13) that logs each connecting peer, wires incoming data to the console, and forwards local stdin to the connection (L15–L19). Finally, [`server.listen(keyPair)`](/reference/building-blocks/hyperdht#await-serverlistenkeypair) announces the key on the DHT and logs the public key for the client to copy (L22–L24):
 
 ```javascript file=<rootDir>/examples/how-to/connect-to-peers/connect-two-peers-by-key-with-hyperdht/server-app/index.js title="server-app/index.js" lineNumbers {5,8-9,11-13,15-19,22-24}
 ```

--- a/content/how-to/operate-an-app/manual-deployment/troubleshoot-desktop-releases.mdx
+++ b/content/how-to/operate-an-app/manual-deployment/troubleshoot-desktop-releases.mdx
@@ -54,7 +54,7 @@ Restarting the running app is a quick workaround without recompiling: a restart 
 
 ### Worker did not exit cleanly
 
-Bare workers spawned through [`pear-runtime`](https://github.com/holepunchto/pear-runtime) (`PearRuntime.run(...)`, as in the `hello-pear-electron`-shaped `getWorker(...)` helper) are plain OS child processes. Electron does **not** signal them on exit, so any code path that quits without tearing the worker down leaves it running. The worker keeps an exclusive lock on its Corestore directory, and the next launch hangs forever on `await store.ready()`.
+Bare workers spawned through [`pear-runtime`](https://github.com/holepunchto/pear-runtime) (`PearRuntime.run(...)`, as in the `hello-pear-electron`-shaped `getWorker(...)` helper) are plain OS child processes. Electron does **not** signal them on exit, so any code path that quits without tearing the worker down leaves it running. The worker keeps an exclusive lock on its Corestore directory, and the next launch hangs forever on [`await store.ready()`](/reference/helpers/corestore#await-storeready).
 
 Look for the symptom in `ps`:
 

--- a/content/how-to/store-and-replicate/replicate-and-persist-with-hypercore.mdx
+++ b/content/how-to/store-and-replicate/replicate-and-persist-with-hypercore.mdx
@@ -12,7 +12,7 @@ schemaType: TechArticle
 In this guide you'll extend the ephemeral chat example in [Connect Many Peers](/how-to/connect-to-peers/connect-to-many-peers-by-topic-with-hyperswarm) by using Hypercore to add two significant new features:
 
 * **Persistence**: The owner of the Hypercore can add messages at any time, and they'll be persisted to disk. Whenever they come online, readers can replicate these messages over Hyperswarm.
-* **Many Readers:** New messages added to the Hypercore will be broadcast to interested readers. The owner gives each reader a reading capability (`core.key`) and a corresponding discovery key (`core.discoveryKey`). The former is used to authorize the reader, ensuring that they have permission to read messages, and the latter is used to discover the owner (and other readers) on the swarm.
+* **Many Readers:** New messages added to the Hypercore will be broadcast to interested readers. The owner gives each reader a reading capability ([`core.key`](/reference/building-blocks/hypercore#corekey)) and a corresponding discovery key ([`core.discoveryKey`](/reference/building-blocks/hypercore#corediscoverykey)). The former is used to authorize the reader, ensuring that they have permission to read messages, and the latter is used to discover the owner (and other readers) on the swarm.
 
 [`Hypercore`](/reference/building-blocks/hypercore) is a secure, distributed append-only log. It is built for sharing enormous datasets and streams of real-time data. 
 It has a secure transport protocol, making it easy to build fast and scalable peer-to-peer applications.
@@ -50,7 +50,7 @@ This command installs the following dependencies:
 
 Create the `writer-app/index.js` file with the following content.
 
-The writer creates a Hyperswarm and destroys it cleanly on `SIGINT` (L8–L9), then opens a local Hypercore backed by `./storage/writer-storage` (L11). `core.key` and `core.discoveryKey` are only available after `core.ready()` resolves, so it awaits that before logging the hex-encoded key readers will need (L14–L15). Every chunk of stdin is appended as its own block (L18). Finally it joins the swarm on the `discoveryKey` and replicates the core to each incoming connection (L22–L23):
+The writer creates a Hyperswarm and destroys it cleanly on `SIGINT` (L8–L9), then opens a local Hypercore backed by `./storage/writer-storage` (L11). `core.key` and `core.discoveryKey` are only available after [`core.ready()`](/reference/building-blocks/hypercore#await-coreready) resolves, so it awaits that before logging the hex-encoded key readers will need (L14–L15). Every chunk of stdin is appended as its own block (L18). Finally it joins the swarm on the `discoveryKey` and replicates the core to each incoming connection (L22–L23):
 
 ```javascript file=<rootDir>/examples/how-to/store-and-replicate/replicate-and-persist-with-hypercore/writer-app/index.js title="writer-app/index.js" lineNumbers {8-9,11,14-15,18,22-23}
 ```
@@ -82,7 +82,7 @@ This command installs the following dependencies:
 
 Create the `reader-app/index.js` file with the following content.
 
-Like the writer, the reader sets up a Hyperswarm with `SIGINT` cleanup (L7–L8). It opens its Hypercore with the writer's key passed on the command line (`Bare.argv[2]`), which makes it a read-only replica, and awaits `core.ready()` (L10–L11). It joins the swarm on the same `discoveryKey` and replicates over each connection (L13–L14), then `swarm.flush()` waits until all discoverable peers are connected (L17) before `core.update()` pulls the latest length from the writer (L19). It records the current `core.length` and tails the core from that point with a live read stream, logging each new block as it arrives (L21–L24):
+Like the writer, the reader sets up a Hyperswarm with `SIGINT` cleanup (L7–L8). It opens its Hypercore with the writer's key passed on the command line (`Bare.argv[2]`), which makes it a read-only replica, and awaits `core.ready()` (L10–L11). It joins the swarm on the same `discoveryKey` and replicates over each connection (L13–L14), then [`swarm.flush()`](/reference/building-blocks/hyperswarm#await-swarmflush) waits until all discoverable peers are connected (L17) before [`core.update()`](/reference/building-blocks/hypercore#await-coreupdateoptions) pulls the latest length from the writer (L19). It records the current [`core.length`](/reference/building-blocks/hypercore#corelength) and tails the core from that point with a live read stream, logging each new block as it arrives (L21–L24):
 
 ```javascript file=<rootDir>/examples/how-to/store-and-replicate/replicate-and-persist-with-hypercore/reader-app/index.js title="reader-app/index.js" lineNumbers {7-8,10-11,13-14,17,19,21-24}
 ```

--- a/content/how-to/store-and-replicate/share-append-only-databases-with-hyperbee.mdx
+++ b/content/how-to/store-and-replicate/share-append-only-databases-with-hyperbee.mdx
@@ -44,7 +44,7 @@ This will install the following dependencies:
 
 Create the `bee-writer-app/index.js` file with the following content:
 
-A [Corestore](/reference/helpers/corestore) holds the backing core (L8), and a [Hyperswarm](/reference/building-blocks/hyperswarm) replicates it on every connection (L10–L14). The Hyperbee is built on a named core (L17) with UTF-8 key/value encoding (L20–L23). Once the core is ready (L26) it joins the swarm on the core's discovery key (L29), and the writable key is printed only after the topic is announced to the DHT (L32–L34). On the first run (`core.length <= 1`), the dictionary is loaded and inserted in a single atomic batch (L38–L47); on later runs it just re-seeds the existing data (L48–L50).
+A [Corestore](/reference/helpers/corestore) holds the backing core (L8), and a [Hyperswarm](/reference/building-blocks/hyperswarm) replicates it on every connection (L10–L14). The Hyperbee is built on a named core (L17) with UTF-8 key/value encoding (L20–L23). Once the core is ready (L26) it joins the swarm on the core's discovery key (L29), and the writable key is printed only after the topic is announced to the DHT (L32–L34). On the first run ([`core.length <= 1`](/reference/building-blocks/hypercore#corelength)), the dictionary is loaded and inserted in a single atomic batch (L38–L47); on later runs it just re-seeds the existing data (L48–L50).
 
 ```javascript file=<rootDir>/examples/how-to/store-and-replicate/share-append-only-databases-with-hyperbee/bee-writer-app/index.js title="bee-writer-app/index.js" lineNumbers {8,10-14,17,20-23,26,29,32-34,38-47}
 ```
@@ -149,7 +149,7 @@ This will install the following dependencies:
 
 Create the `core-reader-app/index.js` file with the following content:
 
-This app treats the Hyperbee purely as a Hypercore. It imports Hyperbee's `Node` encoding directly so it can decode tree nodes (L6), takes the writer's key as an argument (L8–L10), and opens the core through a [Corestore](/reference/helpers/corestore) (L13) replicated over [Hyperswarm](/reference/building-blocks/hyperswarm) (L15–L19). The core is reopened from the key and made ready (L22–L24), then joins the topic and waits for the swarm to flush (L27–L28). After pulling the latest metadata with `core.update()` (L31), it fetches the last block by sequence number (L33–L34) and logs it both raw and decoded through `Node.decode` (L37–L38).
+This app treats the Hyperbee purely as a Hypercore. It imports Hyperbee's `Node` encoding directly so it can decode tree nodes (L6), takes the writer's key as an argument (L8–L10), and opens the core through a [Corestore](/reference/helpers/corestore) (L13) replicated over [Hyperswarm](/reference/building-blocks/hyperswarm) (L15–L19). The core is reopened from the key and made ready (L22–L24), then joins the topic and waits for the swarm to flush (L27–L28). After pulling the latest metadata with [`core.update()`](/reference/building-blocks/hypercore#await-coreupdateoptions) (L31), it fetches the last block by sequence number (L33–L34) and logs it both raw and decoded through `Node.decode` (L37–L38).
 
 ```javascript file=<rootDir>/examples/how-to/store-and-replicate/share-append-only-databases-with-hyperbee/core-reader-app/index.js title="core-reader-app/index.js" lineNumbers {6,8-10,13,15-19,22-24,27-28,31,33-34,37-38}
 ```

--- a/content/how-to/store-and-replicate/work-with-many-hypercores-using-corestore.mdx
+++ b/content/how-to/store-and-replicate/work-with-many-hypercores-using-corestore.mdx
@@ -22,7 +22,7 @@ In [Replicate and persist with Hypercore](/how-to/store-and-replicate/replicate-
 - Requires only one replication stream per peer connection.
 - Simplifies referring to Hypercores by name.
 
-If named cores collide across components, namespace them (`store.namespace('a')`)—retrieving cores by `key` is unaffected by namespacing.
+If named cores collide across components, namespace them ([`store.namespace('a')`](/reference/helpers/corestore#const-namespacedstore--storenamespacename-options))—retrieving cores by `key` is unaffected by namespacing.
 </Callout>
 
 ## Create the multicore writer app
@@ -52,7 +52,7 @@ Create the `multicore-writer-app/index.js` file with the following content:
 The `multicore-writer-app` uses a Corestore instance to create three Hypercores, which are then replicated with other peers using `Hyperswarm`:
 * One Corestore and one Hyperswarm back the whole app (L7–L8). `core1` bootstraps the system—its first block records the keys of `core2` and `core3` (L22–L26), so a reader only needs `core1`'s key to discover the rest. Writing the bootstrap list before announcing on the swarm ensures `core1.get(0)` resolves as soon as a reader connects.
 * The three named cores are created up front (L13–L15); names map to local key pairs and are never sent to readers.
-* Only `core1`'s discovery key is announced on the swarm (L32)—`core2` and `core3` ride along because `store.replicate(conn)` replicates every loaded core over a single stream (L36).
+* Only `core1`'s discovery key is announced on the swarm (L32)—`core2` and `core3` ride along because [`store.replicate(conn)`](/reference/helpers/corestore#const-stream--storereplicateisinitiatororstream-options) replicates every loaded core over a single stream (L36).
 * The main core key is logged so it can be passed to the [`multicore-reader-app`](#create-the-multicore-reader-app) (L28).
 * Terminal input is routed by length: short messages append to `core2`, long ones to `core3` (L39–L46).
 
@@ -84,7 +84,7 @@ This will install the following dependencies:
 
 ### Add the multicore reader app logic
 
-Create the `multicore-reader-app/index.js` file with the following content. The reader takes the writer's main core key as a command-line argument (L6–L8) and opens its own Corestore (L10–L11). On each connection it replicates the whole store (L17), then gets `core1` from the supplied key, joins the swarm on its discovery key, and flushes discovery (L20–L25). `core.get(0)` then blocks until the writer's first block—the bootstrap key list—has actually replicated; unlike `core.update()` it waits for the data itself, and a timeout surfaces a clear error if the writer is never reachable instead of reading an empty core or hanging (L27–L36). It reads the bootstrap key list from that block (L39) and, for every key, gets the corresponding core and logs each new block as it is appended (L40–L50):
+Create the `multicore-reader-app/index.js` file with the following content. The reader takes the writer's main core key as a command-line argument (L6–L8) and opens its own Corestore (L10–L11). On each connection it replicates the whole store (L17), then gets `core1` from the supplied key, joins the swarm on its discovery key, and flushes discovery (L20–L25). [`core.get(0)`](/reference/building-blocks/hypercore#await-coregetindex-options) then blocks until the writer's first block—the bootstrap key list—has actually replicated; unlike [`core.update()`](/reference/building-blocks/hypercore#await-coreupdateoptions) it waits for the data itself, and a timeout surfaces a clear error if the writer is never reachable instead of reading an empty core or hanging (L27–L36). It reads the bootstrap key list from that block (L39) and, for every key, gets the corresponding core and logs each new block as it is appended (L40–L50):
 
 ```javascript file=<rootDir>/examples/how-to/store-and-replicate/work-with-many-hypercores-using-corestore/multicore-reader-app/index.js title="multicore-reader-app/index.js" lineNumbers {6-8,10-11,17,20-25,27-36,39,40-50}
 ```

--- a/content/how-to/stream-and-share-media/create-a-full-peer-to-peer-filesystem-with-hyperdrive.mdx
+++ b/content/how-to/stream-and-share-media/create-a-full-peer-to-peer-filesystem-with-hyperdrive.mdx
@@ -17,7 +17,7 @@ In this guide, you will create three Pear Terminal Applications:
 
 When the writer modifies its drive—adding, removing, or changing files—the reader's local copy updates to match. To do this, you need two additional tools:
 
-* [`MirrorDrive`](/reference/helpers/mirrordrive): the diff-and-sync engine that mirrors one drive into another (used here via `local.mirror(drive)` and `drive.mirror(local)`), and
+* [`MirrorDrive`](/reference/helpers/mirrordrive): the diff-and-sync engine that mirrors one drive into another (used here via `local.mirror(drive)` and [`drive.mirror(local)`](/reference/building-blocks/hyperdrive#const-mirror--drivemirrorout-options)), and
 * [`LocalDrive`](/reference/helpers/localdrive): a local filesystem adapter that exposes a Hyperdrive-like interface over a directory on disk.
 
 These tools handle all interactions between Hyperdrives and the local filesystem.
@@ -132,8 +132,8 @@ printf 'hello from hyperdrive\n' > writer-dir/hello.txt
 
 ## Inspect the Hyperdrive as a Hyperbee
 
-`Hyperdrive` exposes its metadata index as `drive.db`, which is the underlying Hyperbee backing the file structure.
-You can inspect that Hyperbee directly when you want to see the raw file-entry metadata that `drive.entry()` wraps, or when you want to access the metadata index directly.
+`Hyperdrive` exposes its metadata index as [`drive.db`](/reference/building-blocks/hyperdrive#drivedb), which is the underlying Hyperbee backing the file structure.
+You can inspect that Hyperbee directly when you want to see the raw file-entry metadata that [`drive.entry()`](/reference/building-blocks/hyperdrive#const-entry--await-driveentrypath-options) wraps, or when you want to access the metadata index directly.
 
 ### Create the `drive-bee-reader-app` directory and add dependencies
 
@@ -161,7 +161,7 @@ Create the `drive-bee-reader-app/index.js` file with the following content:
 ```javascript file=<rootDir>/examples/how-to/stream-and-share-media/create-a-full-peer-to-peer-filesystem-with-hyperdrive/drive-bee-reader-app/index.js title="drive-bee-reader-app/index.js" lineNumbers {8-10,12-17,19-21,24,29-37,39,41-49}
 ```
 
-Like the reader, this app reads the drive key from the command line (L8–L10) and replicates a [`Corestore`](/reference/helpers/corestore) over [`Hyperswarm`](/reference/building-blocks/hyperswarm) (L12–L17). It opens the [`Hyperdrive`](/reference/building-blocks/hyperdrive) and awaits both `drive.ready()` and `drive.db.ready()` (L19–L21), then reaches into the metadata index directly: file entries live in the `files` sub-[Hyperbee](/reference/building-blocks/hyperbee) (L24). It polls `drive.update()` until the first entry replicates in (L29–L37), looks the same file up through the higher-level `drive.entry()` API (L39), and logs both the raw Hyperbee entry and the `drive.entry()` view side by side (L41–L49).
+Like the reader, this app reads the drive key from the command line (L8–L10) and replicates a [`Corestore`](/reference/helpers/corestore) over [`Hyperswarm`](/reference/building-blocks/hyperswarm) (L12–L17). It opens the [`Hyperdrive`](/reference/building-blocks/hyperdrive) and awaits both [`drive.ready()`](/reference/building-blocks/hyperdrive#await-driveready) and `drive.db.ready()` (L19–L21), then reaches into the metadata index directly: file entries live in the `files` sub-[Hyperbee](/reference/building-blocks/hyperbee) (L24). It polls [`drive.update()`](/reference/building-blocks/hyperdrive#const-updated--await-driveupdateoptions) until the first entry replicates in (L29–L37), looks the same file up through the higher-level `drive.entry()` API (L39), and logs both the raw Hyperbee entry and the `drive.entry()` view side by side (L41–L49).
 
 ### Run the `drive-bee-reader-app`
 

--- a/content/how-to/troubleshooting.mdx
+++ b/content/how-to/troubleshooting.mdx
@@ -19,7 +19,7 @@ Troubleshooting confusing scenarios while developing Pear applications.
 
 - Random NAT networks can take longer as another node may be needed to facilitate the connection. See [Dependencies and network](/explanation/dependencies-and-network) for what's actually happening at the IP level.
 - Not destroying the hyperswarm instance during application teardown so Hyperswarm can unannounce and clean up the [HyperDHT](/reference/building-blocks/hyperdht).
-  It's recommended to clean up the hyperswarm instance with `swarm.destroy()` before exiting the application. This prevents conflicting records in the DHT for the application's peer which cause it take longer to join a topic. See [Connect to many peers by topic with Hyperswarm](/how-to/connect-to-peers/connect-to-many-peers-by-topic-with-hyperswarm) for the full one-instance-per-app pattern.
+  It's recommended to clean up the hyperswarm instance with [`swarm.destroy()`](/reference/building-blocks/hyperswarm#await-swarmdestroy-force---) before exiting the application. This prevents conflicting records in the DHT for the application's peer which cause it take longer to join a topic. See [Connect to many peers by topic with Hyperswarm](/how-to/connect-to-peers/connect-to-many-peers-by-topic-with-hyperswarm) for the full one-instance-per-app pattern.
 - A firewall is blocking the traffic.
   Please let Holepunch know if this is the case.
 


### PR DESCRIPTION
How-tos linked module names (e.g. `[Hypercore](/reference/building-blocks/hypercore)`) but rarely the specific methods they mention in prose. This deep-links the **first mention** of each documented building-block / helper method to its reference anchor.

## Scope

Active building-block / helper APIs only — **22 mentions across 9 how-tos**:

`core.key` · `core.discoveryKey` · `core.ready` · `core.update` · `core.length` · `core.get` · `store.namespace` · `store.replicate` · `store.ready` · `drive.mirror` · `drive.db` · `drive.entry` · `drive.ready` · `drive.update` · `swarm.flush` · `swarm.dht` · `swarm.destroy` · `discovery.flushed` · `server.listen`

First mention per page only, to avoid over-linking. Deliberately **out of scope**: the deprecated Pear/Bare API surface (`Bare.*`, `global.Pear` → `api.mdx`) and config keys (`pear.stage`).

## Verification

`check:internal-links` ✅ — every method anchor resolves · `next build` ✅

9 files, 17 lines, link-only (no prose changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)