### PR TITLE
docs: add hello-pear-bare boilerplate and unify the template guides

### DIFF
--- a/.github/workflows/watch-boilerplates.yml
+++ b/.github/workflows/watch-boilerplates.yml
@@ -1,0 +1,93 @@
+name: Watch boilerplate upstreams
+
+# The docs vendor read-only snapshots of the hello-pear-* boilerplates under
+# examples/getting-started/ and import code from them with remark-code-import
+# (```js file=<rootDir>/examples/getting-started/<name>/...). GitHub won't let
+# us subscribe to another org's repo events, so instead of a true webhook
+# "watcher" this job polls the upstream default branches on a schedule and opens
+# a tracking issue when a vendored snapshot falls behind upstream — the cue to
+# refresh the files and re-check the imported line ranges.
+#
+# When you refresh a snapshot, bump the matching `pinned` SHA below (and the
+# snapshot's README); the next run sees no drift and auto-closes the issue.
+
+on:
+  schedule:
+    # Weekly, Mondays 09:00 UTC. Boilerplate drift isn't urgent; bump the
+    # cadence here if you want prompter notice.
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    name: check ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: hello-pear-bare
+            repo: holepunchto/hello-pear-bare
+            pinned: c62e69bc47ec8b926587fd6979ab9b7e8a16d6fb
+            path: examples/getting-started/hello-pear-bare
+          - name: hello-pear-electron
+            repo: holepunchto/hello-pear-electron
+            pinned: 9e8085a7ae0313150d05fd9d5ad6c0ba8b297243
+            path: examples/getting-started/hello-pear-electron
+    steps:
+      - name: Compare upstream HEAD to the vendored snapshot
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ matrix.repo }}
+          NAME: ${{ matrix.name }}
+          PINNED: ${{ matrix.pinned }}
+          VENDOR_PATH: ${{ matrix.path }}
+        run: |
+          set -euo pipefail
+
+          branch=$(gh api "repos/${REPO}" --jq '.default_branch')
+          head_sha=$(gh api "repos/${REPO}/commits/${branch}" --jq '.sha')
+          title="Refresh vendored snapshot: ${NAME}"
+
+          # An open tracking issue for this snapshot, if one already exists
+          # (exact title match) — keeps reruns from filing duplicates.
+          existing=$(gh issue list --repo "${GITHUB_REPOSITORY}" --state open --limit 100 \
+            --json number,title \
+            | jq -r --arg t "${title}" 'map(select(.title == $t)) | (.[0].number // empty)')
+
+          if [ "${head_sha}" = "${PINNED}" ]; then
+            echo "${NAME}: in sync (${head_sha})."
+            if [ -n "${existing}" ]; then
+              gh issue close "${existing}" --repo "${GITHUB_REPOSITORY}" \
+                --comment "Vendored snapshot is back in sync with upstream \`${head_sha}\`. Closing."
+            fi
+            exit 0
+          fi
+
+          echo "${NAME}: drift — pinned ${PINNED}, upstream ${head_sha}."
+          if [ -n "${existing}" ]; then
+            echo "Tracking issue #${existing} already open; nothing to do."
+            exit 0
+          fi
+
+          compare="https://github.com/${REPO}/compare/${PINNED}...${head_sha}"
+          body=$(printf '%s\n' \
+            "[\`${REPO}\`](https://github.com/${REPO}) has new commits since the snapshot vendored at \`${VENDOR_PATH}\`." \
+            "" \
+            "- Pinned: \`${PINNED}\`" \
+            "- Upstream \`${branch}\`: \`${head_sha}\`" \
+            "- Changes: ${compare}" \
+            "" \
+            "The docs import code from this snapshot via \`remark-code-import\`. To refresh:" \
+            "" \
+            "1. Copy the imported upstream files into \`${VENDOR_PATH}\` at \`${head_sha}\`." \
+            "2. Re-check the \`#L…\` ranges in the importing \`.mdx\`." \
+            "3. Update the \`pinned\` SHA for \`${NAME}\` in \`.github/workflows/watch-boilerplates.yml\` and the snapshot README." \
+            "" \
+            "_Opened automatically by the Watch boilerplate upstreams workflow._")
+
+          gh issue create --repo "${GITHUB_REPOSITORY}" --title "${title}" --body "${body}"

--- a/content/_snippets/_from-a-template-callout.mdx
+++ b/content/_snippets/_from-a-template-callout.mdx
@@ -1,0 +1,14 @@
+{/*
+  Shared snippet (content/_snippets/) included via Fumadocs <include> by how-tos
+  whose Pear-end (worker) logic works with EITHER boilerplate (desktop or
+  terminal). Carries the cross-platform portability point too, so it REPLACES
+  _pear-end-portability-callout on these guides—one orientation callout, not two.
+  For frontend-specific how-tos, use _frontend-template-callout.mdx instead.
+  See: https://www.fumadocs.dev/docs/markdown#include
+*/}
+
+<Callout type="info">
+
+**Pear-end logic—start from a boilerplate.** The code in this guide lives in the Bare [worker](/explanation/workers): peer-to-peer logic, no UI. The same worker runs unchanged on desktop, terminal, and mobile—only the shell differs (see [Runtime and languages](/explanation/runtime-and-languages)). Start from a boilerplate in [Start from a template](/getting-started/from-a-template)—desktop ([`hello-pear-electron`](/getting-started/from-a-template/start-from-hello-pear-electron)) or terminal ([`hello-pear-bare`](/getting-started/from-a-template/start-from-hello-pear-bare))—and add this capability on top.
+
+</Callout>

--- a/content/_snippets/_frontend-template-callout.mdx
+++ b/content/_snippets/_frontend-template-callout.mdx
@@ -1,0 +1,14 @@
+{/*
+  Shared snippet (content/_snippets/) included via Fumadocs <include> by how-tos
+  that have a frontend (UI), so they build on the desktop boilerplate. Carries a
+  short portability nod too, so it REPLACES _pear-end-portability-callout on these
+  guides—one orientation callout, not two. For how-tos whose logic works with
+  either template, use _from-a-template-callout.mdx instead.
+  See: https://www.fumadocs.dev/docs/markdown#include
+*/}
+
+<Callout type="info">
+
+**Start from the desktop boilerplate.** This guide has a frontend, so it builds on [`hello-pear-electron`](/getting-started/from-a-template/start-from-hello-pear-electron)—the renderer, preload bridge, and Bare [worker](/explanation/workers) it extends. Read [Start from the hello-pear-electron template](/getting-started/from-a-template/start-from-hello-pear-electron) first. The Pear-end logic itself is portable—only the UI is desktop-specific (see [Runtime and languages](/explanation/runtime-and-languages)); the terminal template [`hello-pear-bare`](/getting-started/from-a-template/start-from-hello-pear-bare) has no UI layer. See all starting points in [Start from a template](/getting-started/from-a-template).
+
+</Callout>

--- a/content/_snippets/_hello-pear-electron-callout.mdx
+++ b/content/_snippets/_hello-pear-electron-callout.mdx
@@ -7,6 +7,6 @@
 
 <Callout type="info">
 
-**Full production-ready reference: `hello-pear-electron`.** The complete version of this chat lives at [`holepunchto/hello-pear-electron`](https://github.com/holepunchto/hello-pear-electron)—Holepunch's official Electron template, the same shape [Keet](https://keet.io) and [PearPass](https://pass.pears.com) ship. Clone it any time to see the finished structure or to crib code. For a guided tour of the template, see [Start from the hello-pear-electron template](/getting-started/start-from-hello-pear-electron).
+**Full production-ready reference: `hello-pear-electron`.** The complete version of this chat lives at [`holepunchto/hello-pear-electron`](https://github.com/holepunchto/hello-pear-electron)—Holepunch's official Electron template, the same shape [Keet](https://keet.io) and [PearPass](https://pass.pears.com) ship. Clone it any time to see the finished structure or to crib code. For a guided tour of the template, see [Start from the hello-pear-electron template](/getting-started/from-a-template/start-from-hello-pear-electron).
 
 </Callout>

--- a/content/explanation/pear-desktop-architecture.mdx
+++ b/content/explanation/pear-desktop-architecture.mdx
@@ -73,7 +73,7 @@ The [getting started chat](/getting-started/build-a-peer-to-peer-chat/build-a-pe
 
 ## Where to go next
 
-- [Start from the hello-pear-electron template](/getting-started/start-from-hello-pear-electron)—a hands-on tour of this architecture in the official boilerplate.
+- [Start from the hello-pear-electron template](/getting-started/from-a-template/start-from-hello-pear-electron)—a hands-on tour of this architecture in the official boilerplate.
 - [Release pipeline](/explanation/release-pipeline)—stage, provision, multisig, and diagrams for moving builds between links.
 - [Release pipeline glossary](/explanation/release-pipeline#glossary)—terminology in one table.
 - [Storage and distribution](/explanation/storage-and-distribution)—Pear-wide layout versus per-app `dir`.

--- a/content/getting-started/from-a-template/index.mdx
+++ b/content/getting-started/from-a-template/index.mdx
@@ -1,0 +1,39 @@
+---
+title: "Start from a template"
+description: >-
+  Two official Pear boilerplates to start from—hello-pear-electron for desktop
+  GUI apps and hello-pear-bare for standalone terminal binaries, both with
+  peer-to-peer over-the-air updates. Pick the one that matches what you're shipping.
+docType: getting-started
+schemaType: TechArticle
+---
+
+import { Cards, Card } from 'fumadocs-ui/components/card'
+
+The fastest way to a production-shaped app is to clone an official boilerplate and learn where each piece lives. Both embed [`pear-runtime`](/reference/pear/runtime) for peer-to-peer over-the-air updates—pick the one that matches what you're shipping.
+
+<Cards>
+  <Card
+    href="/getting-started/from-a-template/start-from-hello-pear-electron"
+    title="hello-pear-electron (desktop)"
+    description="An Electron GUI app: renderer ↔ main ↔ Bare worker behind a preload bridge. The shape Keet and PearPass ship."
+  />
+  <Card
+    href="/getting-started/from-a-template/start-from-hello-pear-bare"
+    title="hello-pear-bare (terminal)"
+    description="A standalone Bare executable: CLIs, daemons, and tools with no GUI and no peer dependencies."
+  />
+</Cards>
+
+## Which one?
+
+- **Building a desktop GUI?** Start from [hello-pear-electron](/getting-started/from-a-template/start-from-hello-pear-electron)—it ships a renderer and the preload bridge that connects your UI to peer-to-peer logic in a Bare worker.
+- **Building a CLI, daemon, or other headless tool?** Start from [hello-pear-bare](/getting-started/from-a-template/start-from-hello-pear-bare)—it compiles to a single standalone binary per OS and architecture.
+
+Both share the same peer-to-peer core: the [Bare](/reference/modules/bare-modules) runtime, [`pear-runtime`](/reference/pear/runtime) for updates, and the [Hyperswarm](/reference/building-blocks/hyperswarm) + [Corestore](/reference/helpers/corestore) stack. Your peer-to-peer logic is portable between them—only the shell (GUI versus terminal) changes. See [Runtime and languages](/explanation/runtime-and-languages).
+
+## Where to go next
+
+- [Build a peer-to-peer chat](/getting-started/build-a-peer-to-peer-chat/build-a-peer-to-peer-chat)—build the desktop app up from scratch instead of cloning.
+- [Pear desktop application architecture](/explanation/pear-desktop-architecture)—the renderer/main/worker model behind the Electron template.
+- [Runtime and languages](/explanation/runtime-and-languages)—where Bare and the runtimes fit across desktop, terminal, and mobile.

--- a/content/getting-started/from-a-template/start-from-hello-pear-bare.mdx
+++ b/content/getting-started/from-a-template/start-from-hello-pear-bare.mdx
@@ -1,0 +1,186 @@
+---
+title: "Start from the hello-pear-bare template"
+description: >-
+  An alternative getting started path for terminal apps: clone the
+  hello-pear-bare boilerplate and learn how a standalone Bare process wires
+  pear-runtime over-the-air updates, Corestore, and Hyperswarm—then build it
+  into a cross-platform binary.
+docType: getting-started
+schemaType: TechArticle
+---
+
+This is the terminal counterpart to [Start from the hello-pear-electron template](/getting-started/from-a-template/start-from-hello-pear-electron). Instead of a desktop window, you start from a finished command-line boilerplate and learn how a single [Bare](/reference/modules/bare-modules) process wires peer-to-peer updates and replication—then ship it as a standalone binary.
+
+[`holepunchto/hello-pear-bare`](https://github.com/holepunchto/hello-pear-bare) is Holepunch's official boilerplate for peer-to-peer terminal applications. Where the Electron template embeds [`pear-runtime`](/reference/pear/runtime) into Electron, this template embeds it into [Bare](/reference/modules/bare-modules), the zero-core embeddable JavaScript runtime. The application and runtime compile into a single standalone executable per OS and architecture with no peer dependencies—no Node.js, and no Bare or Pear CLI required on the user's machine.
+
+With this shape you can build CLIs, REPLs, TUIs, services and daemons, or transport hooks—anything headless—and ship it with peer-to-peer over-the-air (OTA) updates. The upcoming Pear CLI v3 is built on this same architecture: a Bare standalone executable that updates itself peer-to-peer through `pear-runtime`.
+
+Take this path when you want to distribute a terminal app as a single executable and update it over the air.
+If you want to build a desktop app instead, follow the [hello-pear-electron template](/getting-started/from-a-template/start-from-hello-pear-electron).
+
+## Clone and run
+
+### 1. Clone the repository
+
+Clone the repository and install dependencies with the following commands:
+
+```bash
+git clone https://github.com/holepunchto/hello-pear-bare
+cd hello-pear-bare
+npm install
+```
+
+### 2. Create a valid `upgrade` link
+
+The template ships with a placeholder `upgrade` link in `package.json`. Until you replace it, startup fails with `INVALID_URL`. Create a real link with [`pear touch`](/reference/pear/cli#pear-touch-flags):
+
+```bash
+pear touch
+```
+
+This prints a link, for example: `pear://qxenz5wmspmryjc13m9yzsqj1conqotn8fb4ocbufwtz9mtbqq5o`.
+
+### 3. Set the `upgrade` link in `package.json`
+
+Set the `upgrade` field in `package.json` to the link you just created:
+
+```json
+"upgrade": "pear://qxenz5wmspmryjc13m9yzsqj1conqotn8fb4ocbufwtz9mtbqq5o"
+```
+
+### 4. Run the app
+
+`npm start` runs `bare bin.js --no-updates`: the process starts in development mode with over-the-air updates disabled, so a live release never swaps the binary while you work.
+
+```bash
+npm start
+```
+
+To exercise the updater locally, opt back in:
+
+```bash
+npm start -- --updates
+```
+
+## Map the template
+
+| Path | What it is | Do you edit it? |
+| --- | --- | --- |
+| [`bin.js`](https://github.com/holepunchto/hello-pear-bare/blob/main/bin.js) | The entrypoint—CLI flag parsing, the storage path, and the Corestore + Hyperswarm + `pear-runtime` updater wiring. | Yes—this is your app. |
+| [`package.json`](https://github.com/holepunchto/hello-pear-bare/blob/main/package.json) | App metadata, scripts, the `upgrade` link, and the per-platform `make:*` build targets. | Yes—branding and release link. |
+| [`scripts/make.js`](https://github.com/holepunchto/hello-pear-bare/blob/main/scripts/make.js) | Detects the host OS and architecture and runs the matching `make:` target. | Rarely. |
+| [`test/index.js`](https://github.com/holepunchto/hello-pear-bare/blob/main/test/index.js) | The [`brittle`](https://github.com/holepunchto/brittle) test entry, run by `npm test`. | Yes—your tests. |
+
+Unlike the Electron template, there's no renderer, preload bridge, or separate worker. A single Bare process in `bin.js` owns everything.
+
+## How it's wired
+
+`bin.js` runs as a single [Bare](/reference/modules/bare-modules) process. It parses two flags with [`paparam`](https://github.com/holepunchto/paparam):
+
+```js file=<rootDir>/examples/getting-started/hello-pear-bare/bin.js#L13-L17 title="bin.js"
+```
+
+Then it picks a storage directory, opens a [Corestore](/reference/helpers/corestore) and a [Hyperswarm](/reference/building-blocks/hyperswarm), and constructs the [`pear-runtime`](/reference/pear/runtime) instance from the `upgrade` link and version in `package.json`. In development (launched with `bare`) storage is a temporary directory; a packaged binary uses the persistent per-app directory from [`bare-storage`](/reference/modules/bare-modules), and `--storage` overrides both—see [Storage and distribution](/explanation/storage-and-distribution):
+
+```js file=<rootDir>/examples/getting-started/hello-pear-bare/bin.js#L21-L45 title="bin.js"
+```
+
+When updates are enabled, it replicates the store on every swarm connection and joins the update drive's discovery key as a client to pull new releases:
+
+```js file=<rootDir>/examples/getting-started/hello-pear-bare/bin.js#L58-L63 title="bin.js"
+```
+
+The updater runs on `pear.updater`: on an `updated` event it applies the downloaded release with `applyUpdate()`, and `SIGHUP`, `SIGINT`, `SIGQUIT`, and `SIGTERM` handlers close `pear` cleanly before exit. For the model behind these updates, see [Runtime](/reference/pear/runtime#updates).
+
+```mermaid
+flowchart LR
+  cli["bin.js (Bare process)"] --> updater["pear-runtime updater"]
+  cli --> store["Corestore"]
+  cli --> swarm["Hyperswarm"]
+  updater --> swarm
+  swarm <-->|"replicate update drive"| peers((seeding peers))
+```
+
+## Build a standalone binary
+
+[`bare-build`](https://github.com/holepunchto/bare-build) compiles `bin.js` and its dependencies into a single standalone executable with no peer dependencies—users don't need Node.js, Bare, or the Pear CLI installed. Build for your current host with:
+
+```bash
+npm run make
+```
+
+`scripts/make.js` detects your OS and architecture and runs the matching target, writing the binary to `out/<platform>-<arch>`. To build for a specific target—for example, in CI—call that target directly:
+
+```bash
+npm run make:darwin-arm64
+```
+
+The template ships a target for every supported platform:
+
+- **macOS** — `darwin-arm64`, `darwin-x64`
+- **Linux** — `linux-arm64`, `linux-x64`
+- **Windows** — `win32-arm64`, `win32-x64`
+
+Build each platform's binary on a matching host.
+
+## Install over the air
+
+Distribute the executable through the usual channels—a download on your website, `apt`, or Homebrew.
+You can also install it peer-to-peer: once your `upgrade` link is [seeding](/explanation/availability-and-blind-peering#seeding-with-pear-seed) a release, pull it directly with the preview [`pear install`](/reference/pear/cli#pear-install) command:
+
+```bash
+npx pear-install pear://<key>
+```
+
+After the first install, new releases reach users through the swarm—no reinstall needed. For how staging and seeding work, see [Deploy your application](/how-to/operate-an-app/manual-deployment/deployment) and [Installing applications](/explanation/storage-and-distribution#installing-applications).
+
+## Example: add a flag
+
+The boilerplate is a minimal CLI plus updater, and `bin.js` is where your logic goes. Flags are parsed with `paparam`, so adding one is a two-line change. Add a `--name` flag to the command definition:
+
+```diff
+ const cmd = command(
+   appName,
+   flag('--storage <dir>', 'custom storage directory for pear-runtime'),
+-  flag('--no-updates', 'disable OTA updates for this run')
++  flag('--no-updates', 'disable OTA updates for this run'),
++  flag('--name <name>', 'who to greet on startup')
+ )
+```
+
+Then log the greeting after the other startup logs:
+
+```diff
+ console.log(`${appName} v${pkg.version}`)
+ console.log(`Updates: ${updates === false ? 'disabled' : 'enabled'}`)
++
++if (cmd.flags.name) console.log(`Hello, ${cmd.flags.name}!`)
+```
+
+Run `npm start -- --name YourName`, and the process greets you on boot. From here, build real peer-to-peer features on the `store` and `swarm` the template already creates: 
+* open a [Corestore](/reference/helpers/corestore) core, 
+* join a [Hyperswarm](/reference/building-blocks/hyperswarm) topic, and 
+* run your protocol. 
+
+Reuse the same storage directory so your data lands alongside the updater's—see [Storage and distribution](/explanation/storage-and-distribution).
+
+## Customize for your brand
+
+Before you ship, set your identity in `package.json`:
+
+- `name`, `productName`, `description`, `author`, and `license`.
+- the `upgrade` `pear://` link (see [Create a valid upgrade link](#2-create-a-valid-upgrade-link)).
+
+`bin.js` reads `productName || name` for both the binary name and the persistent storage directory, so set these before your first release. Then build with `npm run make` and release with [Deploy your application](/how-to/operate-an-app/manual-deployment/deployment).
+
+## Where to go next
+
+- [Start from a template](/getting-started/from-a-template)—both boilerplates, side by side.
+- [Start from the hello-pear-electron template](/getting-started/from-a-template/start-from-hello-pear-electron)—the desktop counterpart, with a renderer, preload bridge, and Bare worker.
+- [Runtime and languages](/explanation/runtime-and-languages)—where Bare fits among Pear's runtimes.
+- [Bare modules](/reference/modules/bare-modules)—the Bare standard library this template builds on.
+- [Runtime](/reference/pear/runtime)—the `pear-runtime` API behind the updater.
+- [Migrate from pear run to pear-runtime](/how-to/operate-an-app/migration)—if you're moving an existing app onto `pear-runtime`.
+- [Publish with GitHub Actions](/how-to/operate-an-app/github-actions/publish-with-github-actions)—stage a stable `pear://` link on every push with the `pear-ci` action.
+- [Deploy your application](/how-to/operate-an-app/manual-deployment/deployment)—the full-control manual path for staging, provisioning, and release lines.
+- [Seeding with `pear seed`](/explanation/availability-and-blind-peering#seeding-with-pear-seed)—keep your `pear://` link online so peers can fetch releases.

--- a/content/getting-started/from-a-template/start-from-hello-pear-electron.mdx
+++ b/content/getting-started/from-a-template/start-from-hello-pear-electron.mdx
@@ -56,14 +56,14 @@ npm start
 
 | Path | What it is | Do you edit it? |
 | --- | --- | --- |
-| `renderer/` | The frontend—`index.html` plus `app.js`, plain DOM with no bundler. | Yes—this is your UI. |
-| `workers/main.js` | The app logic—a [Bare](/reference/modules/bare-modules) worker that owns the swarm, storage, and updater. | Yes—this is your backend. |
-| `electron/main.js` | The Electron main process. Spawns the worker and proxies messages; you rarely change it. | Occasionally. |
-| `electron/preload.js` | Exposes the safe `window.bridge` API to the renderer. | Only to add typed methods. |
-| `package.json` | App metadata, scripts, and the `upgrade` link. | Yes—branding and release link. |
-| `forge.config.js` | Electron Forge packagers, makers, and signing hooks. | For packaging and signing. |
-| `build/` | Icons and per-OS manifests (`AppxManifest.xml`, entitlements, Flatpak/Snap metadata). | Yes—brand assets. |
-| `pear.json` | Multisig config placeholder for production releases. | At production time. |
+| [`renderer/`](https://github.com/holepunchto/hello-pear-electron/tree/main/renderer) | The frontend—`index.html` plus `app.js`, plain DOM with no bundler. | Yes—this is your UI. |
+| [`workers/main.js`](https://github.com/holepunchto/hello-pear-electron/blob/main/workers/main.js) | The app logic—a [Bare](/reference/modules/bare-modules) worker that owns the swarm, storage, and updater. | Yes—this is your backend. |
+| [`electron/main.js`](https://github.com/holepunchto/hello-pear-electron/blob/main/electron/main.js) | The Electron main process. Spawns the worker and proxies messages; you rarely change it. | Occasionally. |
+| [`electron/preload.js`](https://github.com/holepunchto/hello-pear-electron/blob/main/electron/preload.js) | Exposes the safe `window.bridge` API to the renderer. | Only to add typed methods. |
+| [`package.json`](https://github.com/holepunchto/hello-pear-electron/blob/main/package.json) | App metadata, scripts, and the `upgrade` link. | Yes—branding and release link. |
+| [`forge.config.js`](https://github.com/holepunchto/hello-pear-electron/blob/main/forge.config.js) | Electron Forge packagers, makers, and signing hooks. | For packaging and signing. |
+| [`build/`](https://github.com/holepunchto/hello-pear-electron/tree/main/build) | Icons and per-OS manifests (`AppxManifest.xml`, entitlements, Flatpak/Snap metadata). | Yes—brand assets. |
+| [`pear.json`](https://github.com/holepunchto/hello-pear-electron/blob/main/pear.json) | Multisig config placeholder for production releases. | At production time. |
 
 The three pieces you care about day to day are:
 - `renderer/` (view)
@@ -94,9 +94,7 @@ The boilerplate ships a "hello" round-trip you can trace on boot:
 
 Your UI lives in `renderer/`. `index.html` is a static shell loaded by the main process; `renderer/app.js` is loaded as an ES module and drives the DOM:
 
-```js
-const bridge = window.bridge
-document.getElementById('v').innerText += bridge.pkg().version
+```js file=<rootDir>/examples/getting-started/hello-pear-electron/renderer/app.js#L1-L4 title="renderer/app.js"
 ```
 
 There is no framework or build step—bring your own (React, Vue, plain DOM) by editing these files. The only rule is: the renderer talks to the rest of the app **only** through `window.bridge`. It has no Node or Bare access of its own, which is what keeps the renderer sandboxed.
@@ -109,21 +107,7 @@ The full production bridge—including how `window.bridge` is assembled—is wal
 
 Everything peer-to-peer lives in `workers/main.js`, which runs in Bare (not Node). The main process passes the configuration as positional arguments to `PearRuntime.run()`:
 
-```js
-const pipe = new FramedStream(Bare.IPC)
-
-const updaterConfig = {
-  dir: Bare.argv[2],       // application storage directory
-  app: Bare.argv[3],       // packaged app path
-  updates: Bare.argv[4] !== 'false',
-  version: Bare.argv[5],
-  upgrade: Bare.argv[6],   // pear:// upgrade link
-  name: Bare.argv[7]
-}
-
-const store = new Corestore(path.join(updaterConfig.dir, 'pear-runtime/corestore'))
-const swarm = new Hyperswarm()
-const pear = new PearRuntime({ ...updaterConfig, swarm, store })
+```js file=<rootDir>/examples/getting-started/hello-pear-electron/workers/main.js#L8-L21 title="workers/main.js"
 ```
 
 This is where you add your [Corestore](/reference/helpers/corestore) cores, join [Hyperswarm](/reference/building-blocks/hyperswarm) topics, and run your protocols. Pass `pear.storage` (in this case `Bare.argv[2]`, the storage path) as the storage root so your data lands in the same per-app directory Pear manages—see [Storage and distribution](/explanation/storage-and-distribution). For why the logic belongs here rather than in the renderer, see [Workers](/explanation/workers).
@@ -238,4 +222,9 @@ Then build and release with [Build desktop distributables](/how-to/operate-an-ap
 - [Pear desktop application architecture](/explanation/pear-desktop-architecture)—the conceptual model behind the renderer/main/worker split.
 - [Workers](/explanation/workers)—why peer-to-peer logic lives in a Bare worker and where the boundary should sit.
 - [Reshape into a production app](/getting-started/build-a-peer-to-peer-chat/reshape-into-a-production-app)—the hello-pear-electron-shaped scaffold with an Autobase-backed room, blind-pairing invites, and a vanilla HTML renderer.
+- [Start from a template](/getting-started/from-a-template)—both boilerplates, side by side.
+- [Start from the hello-pear-bare template](/getting-started/from-a-template/start-from-hello-pear-bare)—the terminal counterpart: a standalone Bare CLI with OTA updates and no GUI.
+- [Publish with GitHub Actions](/how-to/operate-an-app/github-actions/publish-with-github-actions)—stage a stable `pear://` link on every push with the `pear-ci` action.
+- [Build and sign desktop apps in CI](/how-to/operate-an-app/github-actions/build-and-sign-in-ci)—build, sign, and notarize macOS, Windows, and Linux distributables on hosted runners.
+- [Seeding with `pear seed`](/explanation/availability-and-blind-peering#seeding-with-pear-seed)—keep your `pear://` link online so peers can fetch releases.
 - [Deploy your application](/how-to/operate-an-app/manual-deployment/deployment)—stage, seed, and release your build.

--- a/content/getting-started/index.mdx
+++ b/content/getting-started/index.mdx
@@ -11,15 +11,20 @@ Build a peer-to-peer desktop chat app with [Pear](https://docs.pears.com), then 
 
 There are two ways in. Start from the finished template and learn your way around it, or build the same app up from scratch across a four-part path.
 
-## Start from the template
+## Start from a template
 
-The fastest way to a production-shaped app: clone the official boilerplate and learn where each piece lives.
+The fastest way to a production-shaped app: clone an official boilerplate and learn where each piece lives. Pick the one that matches what you're shipping—a desktop GUI app or a standalone terminal binary.
 
 <Cards>
   <Card
-    href="/getting-started/start-from-hello-pear-electron"
-    title="Start from the hello-pear-electron template"
-    description="Clone the boilerplate, map renderer ↔ main ↔ worker, and add a feature end to end."
+    href="/getting-started/from-a-template/start-from-hello-pear-electron"
+    title="hello-pear-electron (desktop)"
+    description="Clone the Electron boilerplate, map renderer ↔ main ↔ worker, and add a feature end to end."
+  />
+  <Card
+    href="/getting-started/from-a-template/start-from-hello-pear-bare"
+    title="hello-pear-bare (terminal)"
+    description="Clone the standalone Bare boilerplate: pear-runtime OTA updates and cross-platform binaries, no GUI."
   />
 </Cards>
 

--- a/content/how-to/blind-peering/keep-data-available-with-blind-peering.mdx
+++ b/content/how-to/blind-peering/keep-data-available-with-blind-peering.mdx
@@ -15,7 +15,7 @@ A peer-to-peer core is only available while a peer that has it is online. [Blind
 
 This is purely Pear-end logic: it lives in a [Bare](/reference/modules/bare-modules) worker (or any Bare/Node process) and never touches a UI.
 
-<include>../../_snippets/_pear-end-portability-callout.mdx</include>
+<include>../../_snippets/_from-a-template-callout.mdx</include>
 
 ## Two roles
 

--- a/content/how-to/connect-to-peers/connect-to-many-peers-by-topic-with-hyperswarm.mdx
+++ b/content/how-to/connect-to-peers/connect-to-many-peers-by-topic-with-hyperswarm.mdx
@@ -18,7 +18,7 @@ In [Connect two peers by key with HyperDHT](/how-to/connect-to-peers/connect-two
 we needed to explicitly indicate which peer was the server and which was the client.
 By using Hyperswarm, we create two peers, have them join a common topic, and let the swarm deal with connections.
 
-<include>../../_snippets/_pear-end-portability-callout.mdx</include>
+<include>../../_snippets/_from-a-template-callout.mdx</include>
 
 ## Create the `peer-app` project
 

--- a/content/how-to/connect-to-peers/connect-two-peers-by-key-with-hyperdht.mdx
+++ b/content/how-to/connect-to-peers/connect-two-peers-by-key-with-hyperdht.mdx
@@ -21,10 +21,10 @@ For example, Keet implements its relaying system wherein other call participants
 Use the HyperDHT to create a basic CLI chat app where a client peer connects to a server peer by public key.
 The example consists of two applications: [`client-app`](#create-the-client-app) and [`server-app`](#create-the-server-app).
 
-<include>../../_snippets/_pear-end-portability-callout.mdx</include>
+<include>../../_snippets/_from-a-template-callout.mdx</include>
 
 <Callout type="info">
-This guide is a terminal-only walkthrough. For the **desktop equivalent**—the same peer connection wired into an Electron + Bare worker shell—follow the [Getting Started path](/getting-started), which builds a `pear://` chat app on top of the [`hello-pear-electron` template](/getting-started/start-from-hello-pear-electron).
+This guide is a terminal-only walkthrough. For the **desktop equivalent**—the same peer connection wired into an Electron + Bare worker shell—follow the [Getting Started path](/getting-started), which builds a `pear://` chat app on top of the [`hello-pear-electron` template](/getting-started/from-a-template/start-from-hello-pear-electron).
 </Callout>
 
 ## Create the server app

--- a/content/how-to/index.mdx
+++ b/content/how-to/index.mdx
@@ -11,14 +11,14 @@ If you want to look up a CLI flag, an API, or a config field, that's **[Referenc
 
 ## Start here
 
-Many recipes below build on one of two starting points. Chat-focused guides extend the **`pear-chat` scaffold** (Electron shell, Bare worker, Autobase-backed chat room) built step by step in the **[Getting Started](/getting-started)** path—see [Reshape into a production app](/getting-started/build-a-peer-to-peer-chat/reshape-into-a-production-app). Guides that don't need chat start from the bare **[`hello-pear-electron` template](/getting-started/start-from-hello-pear-electron)** (the same Electron + Bare worker shell, without the chat room). Each guide states its base up front. If you're new, work through Getting Started first so you understand each piece before adapting it.
+Many recipes below build on one of two starting points. Chat-focused guides extend the **`pear-chat` scaffold** (Electron shell, Bare worker, Autobase-backed chat room) built step by step in the **[Getting Started](/getting-started)** path—see [Reshape into a production app](/getting-started/build-a-peer-to-peer-chat/reshape-into-a-production-app). Guides that don't need chat start from one of the boilerplates in **[Start from a template](/getting-started/from-a-template)**—desktop ([`hello-pear-electron`](/getting-started/from-a-template/start-from-hello-pear-electron)) or terminal ([`hello-pear-bare`](/getting-started/from-a-template/start-from-hello-pear-bare)). Each guide states its base up front. If you're new, work through Getting Started first so you understand each piece before adapting it.
 
 ## In this section
 
 - [Manage installed applications](/how-to/manage-installed-applications)—list installed Pear apps and reset their storage.
 - [Troubleshoot common issues](/how-to/troubleshooting)—fixes for common Pear and Bare development issues.
 
-Several guides below extend a base scaffold—either the `pear-chat` app from the [Getting Started path](/getting-started/build-a-peer-to-peer-chat/reshape-into-a-production-app) or the [hello-pear-electron template](/getting-started/start-from-hello-pear-electron)—with one capability at a time. They teach **Pear-end logic**—the code in the Bare [worker](/explanation/workers), not the UI—so the same worker is portable across desktop, mobile, and terminal; only the UI half changes per platform (see [Runtime and languages](/explanation/runtime-and-languages)).
+Several guides below extend a base scaffold—either the `pear-chat` app from the [Getting Started path](/getting-started/build-a-peer-to-peer-chat/reshape-into-a-production-app) or a boilerplate from [Start from a template](/getting-started/from-a-template)—with one capability at a time. They teach **Pear-end logic**—the code in the Bare [worker](/explanation/workers), not the UI—so the same worker is portable across desktop, mobile, and terminal; only the UI half changes per platform (see [Runtime and languages](/explanation/runtime-and-languages)).
 
 ### Connecting peers
 

--- a/content/how-to/manage-identity/create-a-portable-identity-with-keet-identity-key.mdx
+++ b/content/how-to/manage-identity/create-a-portable-identity-with-keet-identity-key.mdx
@@ -22,7 +22,7 @@ With the identity, you can sign data on any device and anyone can verify it was 
 This is purely Pear-end logic: it runs in a [Bare](/reference/modules/bare-modules) worker (or any Bare/Node process) and never touches a UI.
 </Callout>
 
-<include>../../_snippets/_pear-end-portability-callout.mdx</include>
+<include>../../_snippets/_from-a-template-callout.mdx</include>
 
 ## The model
 

--- a/content/how-to/operate-an-app/migration.mdx
+++ b/content/how-to/operate-an-app/migration.mdx
@@ -46,7 +46,7 @@ npm install
 npm start
 ```
 
-Move your HTML, JS, CSS, assets, and dependencies into the template's structure. For a guided tour of where each piece goes, see [Start from the hello-pear-electron template](/getting-started/start-from-hello-pear-electron).
+Move your HTML, JS, CSS, assets, and dependencies into the template's structure. For a guided tour of where each piece goes, see [Start from the hello-pear-electron template](/getting-started/from-a-template/start-from-hello-pear-electron).
 
 The build directory layout `pear-runtime` expects is produced by the [`pear build`](https://github.com/holepunchto/hello-pear-electron#build-deploy-directory) command (Pear v2.5.0+). Your `package.json` needs an `upgrade` field set to the application's `pear://` link—see [Configuration](/reference/pear/configuration#packagejson).
 
@@ -97,7 +97,7 @@ See [Deploy your application](/how-to/operate-an-app/manual-deployment/deploymen
 ## See also
 
 - [`pear-runtime` reference](/reference/pear/runtime)—the module that replaces the global `pear run` API.
-- [Start from the hello-pear-electron template](/getting-started/start-from-hello-pear-electron)—clone-first tour of the boilerplate to migrate into.
+- [Start from a template](/getting-started/from-a-template)—the desktop and terminal boilerplates to migrate into.
 - [Deploy your application](/how-to/operate-an-app/manual-deployment/deployment)—the stage → provision → multisig production flow.
 - [Runtime and languages](/explanation/runtime-and-languages)—why the runtime moved out of the CLI and into a library.
 - [Configuration](/reference/pear/configuration#packagejson)—where the `upgrade` link and entrypoint are declared.

--- a/content/how-to/store-and-replicate/replicate-and-persist-with-hypercore.mdx
+++ b/content/how-to/store-and-replicate/replicate-and-persist-with-hypercore.mdx
@@ -20,7 +20,7 @@ It has a secure transport protocol, making it easy to build fast and scalable pe
 The following example consists of two Pear Terminal Applications: [`writer-app`](#create-the-writer-app) and [`reader-app`](#create-the-reader-app).
 When these two applications are opened, two peers are created and connected to each other. Hypercore stores the data entered into the command line.
 
-<include>../../_snippets/_pear-end-portability-callout.mdx</include>
+<include>../../_snippets/_from-a-template-callout.mdx</include>
 
 ## Create the writer app
 

--- a/content/how-to/store-and-replicate/share-append-only-databases-with-hyperbee.mdx
+++ b/content/how-to/store-and-replicate/share-append-only-databases-with-hyperbee.mdx
@@ -9,7 +9,7 @@ schemaType: TechArticle
 It provides a key/value-store API with methods to insert and get key/value pairs, perform atomic batch insertions, and create sorted iterators.
 This guide uses [Corestore](/reference/helpers/corestore) and [Hyperswarm](/reference/building-blocks/hyperswarm) to manage and replicate the underlying core; see [Work with many Hypercores using Corestore](/how-to/store-and-replicate/work-with-many-hypercores-using-corestore) if those concepts are unfamiliar.
 
-<include>../../_snippets/_pear-end-portability-callout.mdx</include>
+<include>../../_snippets/_from-a-template-callout.mdx</include>
 
 This guide consists of three applications:
 * [`bee-writer-app`](#create-the-bee-writer-app) - stores 100k entries from a given dictionary file into a Hyperbee instance.

--- a/content/how-to/store-and-replicate/work-with-many-hypercores-using-corestore.mdx
+++ b/content/how-to/store-and-replicate/work-with-many-hypercores-using-corestore.mdx
@@ -12,7 +12,7 @@ An append-only log like Hypercore is powerful on its own, but it's most useful a
 
 In [Replicate and persist with Hypercore](/how-to/store-and-replicate/replicate-and-persist-with-hypercore), only a single Hypercore instance was replicated. But in this guide, you'll replicate a single Corestore instance, which will internally manage the replication of a collection of Hypercores. You'll achieve this with two Pear Terminal Applications: [`multicore-writer-app`](#create-the-multicore-writer-app) and [`multicore-reader-app`](#create-the-multicore-reader-app).
 
-<include>../../_snippets/_pear-end-portability-callout.mdx</include>
+<include>../../_snippets/_from-a-template-callout.mdx</include>
 
 <Callout type="info">
 **Use one Corestore instance per application.** Multiple Corestores over the same storage cause file-locking errors and duplicate core storage. A single Corestore:

--- a/content/how-to/stream-and-share-media/back-up-photos-in-a-peer-to-peer-app.mdx
+++ b/content/how-to/stream-and-share-media/back-up-photos-in-a-peer-to-peer-app.mdx
@@ -11,9 +11,7 @@ import { Steps, Step } from 'fumadocs-ui/components/steps'
 
 This guide shows you how to **back up photos peer-to-peer** by adapting the [`hello-pear-electron`](https://github.com/holepunchto/hello-pear-electron) scaffold to decode local images with [`bare-ffmpeg`](https://www.npmjs.com/package/bare-ffmpeg)/[`bare-media`](https://www.npmjs.com/package/bare-media) and push them into a [Hyperblobs](https://www.npmjs.com/package/hyperblobs) store. The reference implementation is [`pear-photo-backup`](https://github.com/holepunchto/pear-docs/tree/preview/examples/how-to/stream-and-share-media/photo-backup).
 
-<include>../../_snippets/_pear-end-portability-callout.mdx</include>
-
-This is a **delta-only** how-to. The shared scaffold is explained in the [Start from the hello-pear-electron template](/getting-started/start-from-hello-pear-electron) tutorial—read it first.
+<include>../../_snippets/_frontend-template-callout.mdx</include>
 
 - [Stream a live camera in a peer-to-peer app](/how-to/stream-and-share-media/stream-a-live-camera-in-a-peer-to-peer-app)—the sibling how-to that establishes the same Hyperblobs + blob-server pattern for live frames.
 

--- a/content/how-to/stream-and-share-media/create-a-full-peer-to-peer-filesystem-with-hyperdrive.mdx
+++ b/content/how-to/stream-and-share-media/create-a-full-peer-to-peer-filesystem-with-hyperdrive.mdx
@@ -22,7 +22,7 @@ When the writer modifies its drive—adding, removing, or changing files—the r
 
 These tools handle all interactions between Hyperdrives and the local filesystem.
 
-<include>../../_snippets/_pear-end-portability-callout.mdx</include>
+<include>../../_snippets/_from-a-template-callout.mdx</include>
 
 <Callout type="info">
 

--- a/content/how-to/stream-and-share-media/share-files-in-a-peer-to-peer-app.mdx
+++ b/content/how-to/stream-and-share-media/share-files-in-a-peer-to-peer-app.mdx
@@ -11,9 +11,7 @@ import { Steps, Step } from 'fumadocs-ui/components/steps'
 
 This guide shows you how to **swap the [`hello-pear-electron`](https://github.com/holepunchto/hello-pear-electron) room for a [Hyperdrive](/reference/building-blocks/hyperdrive)** so peers share files instead of messages. The reference implementation is [`pear-file-sharing`](https://github.com/holepunchto/pear-docs/tree/preview/examples/how-to/stream-and-share-media/file-sharing).
 
-<include>../../_snippets/_pear-end-portability-callout.mdx</include>
-
-This is a **delta-only** how-to. The shared Electron + PearRuntime + Bare worker scaffold—with plain-JSON messages over a [`framed-stream`](https://www.npmjs.com/package/framed-stream) pipe and a vanilla HTML renderer—is explained in the [Start from the hello-pear-electron template](/getting-started/start-from-hello-pear-electron) tutorial—read it first.
+<include>../../_snippets/_frontend-template-callout.mdx</include>
 
 - [Create a full peer-to-peer filesystem with Hyperdrive](/how-to/stream-and-share-media/create-a-full-peer-to-peer-filesystem-with-hyperdrive)—the building block this guide layers a desktop UI on top of.
 

--- a/content/how-to/stream-and-share-media/store-and-serve-large-media-with-hyperblobs.mdx
+++ b/content/how-to/stream-and-share-media/store-and-serve-large-media-with-hyperblobs.mdx
@@ -15,7 +15,7 @@ A [Hypercore](/reference/building-blocks/hypercore) is an append-only log of sma
 
 This is purely Pear-end logic: it runs in a [Bare](/reference/modules/bare-modules) worker (or any Bare/Node process) and never touches a UI.
 
-<include>../../_snippets/_pear-end-portability-callout.mdx</include>
+<include>../../_snippets/_from-a-template-callout.mdx</include>
 
 ## How addressing works
 

--- a/content/how-to/stream-and-share-media/stream-a-live-camera-in-a-peer-to-peer-app.mdx
+++ b/content/how-to/stream-and-share-media/stream-a-live-camera-in-a-peer-to-peer-app.mdx
@@ -11,9 +11,7 @@ import { Steps, Step } from 'fumadocs-ui/components/steps'
 
 This guide shows you how to **stream a live camera feed peer-to-peer** by adapting the [`hello-pear-electron`](https://github.com/holepunchto/hello-pear-electron) scaffold to push camera frames through [Hyperblobs](https://www.npmjs.com/package/hyperblobs) and serve them via [`hypercore-blob-server`](https://www.npmjs.com/package/hypercore-blob-server). The reference implementation is [`pear-live-cam`](https://github.com/holepunchto/pear-docs/tree/preview/examples/how-to/stream-and-share-media/live-cam).
 
-<include>../../_snippets/_pear-end-portability-callout.mdx</include>
-
-This is a **delta-only** how-to. The shared scaffold is explained in the [Start from the hello-pear-electron template](/getting-started/start-from-hello-pear-electron) tutorial—read it first.
+<include>../../_snippets/_frontend-template-callout.mdx</include>
 
 ## Before you begin
 

--- a/content/how-to/stream-and-share-media/stream-stored-video-in-a-peer-to-peer-app.mdx
+++ b/content/how-to/stream-and-share-media/stream-stored-video-in-a-peer-to-peer-app.mdx
@@ -11,9 +11,7 @@ import { Steps, Step } from 'fumadocs-ui/components/steps'
 
 This guide shows you how to **stream a stored video file peer-to-peer** by adapting the [`hello-pear-electron`](https://github.com/holepunchto/hello-pear-electron) scaffold to publish video blobs through [Hyperblobs](https://www.npmjs.com/package/hyperblobs) and serve them with [`hypercore-blob-server`](https://www.npmjs.com/package/hypercore-blob-server). The reference implementation is [`pear-video-stream`](https://github.com/holepunchto/pear-docs/tree/preview/examples/how-to/stream-and-share-media/video-stream).
 
-<include>../../_snippets/_pear-end-portability-callout.mdx</include>
-
-This is a **delta-only** how-to. The shared scaffold is explained in the [Start from the hello-pear-electron template](/getting-started/start-from-hello-pear-electron) tutorial—read it first.
+<include>../../_snippets/_frontend-template-callout.mdx</include>
 
 - [Stream a live camera in a peer-to-peer app](/how-to/stream-and-share-media/stream-a-live-camera-in-a-peer-to-peer-app)—the live counterpart that builds on the same blob plumbing.
 

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -43,7 +43,7 @@ A four-part type-along that builds a peer-to-peer Electron chat, adds persistenc
 
 [**Start the type-along →**](/getting-started)
 
-Prefer to start from a finished project? [**Start from the `hello-pear-electron` template**](/getting-started/start-from-hello-pear-electron) clones the boilerplate and walks you through where the frontend, app logic, and preload bridge live before you add a feature end to end.
+Prefer to start from a finished project? [**Start from the `hello-pear-electron` template**](/getting-started/from-a-template/start-from-hello-pear-electron) clones the boilerplate and walks you through where the frontend, app logic, and preload bridge live before you add a feature end to end.
 
 ### About Pear—_understand this_
 
@@ -86,7 +86,7 @@ Module pages call out a stability indicator. The four levels:
 Starter paths in these docs (desktop, macOS / Linux / Windows):
 
 - [Getting started](/getting-started)—type-along chat, persistence, then ship and update.
-- [Start from the `hello-pear-electron` template](/getting-started/start-from-hello-pear-electron)—clone the boilerplate and learn your way around it, then add a feature end to end.
+- [Start from the `hello-pear-electron` template](/getting-started/from-a-template/start-from-hello-pear-electron)—clone the boilerplate and learn your way around it, then add a feature end to end.
 - [Pear desktop application architecture](/explanation/pear-desktop-architecture)—how Electron, Bare workers, storage, and OTA fit together.
 - [Release pipeline](/explanation/release-pipeline)—stage → provision → multisig and release lines.
 

--- a/content/reference/pear/cli.mdx
+++ b/content/reference/pear/cli.mdx
@@ -396,7 +396,7 @@ The database contains metadata stored on this device used by the Pear runtime.
 `pear init` has been removed from the Pear CLI—in current Pear (v2.6.5) it exits with `ERR_LEGACY: pear init has been removed`.
 
 <Callout type="info">
-To scaffold a project, clone the official template instead—[`holepunchto/hello-pear-electron`](https://github.com/holepunchto/hello-pear-electron)—and follow [Start from the hello-pear-electron template](/getting-started/start-from-hello-pear-electron).
+To scaffold a project, clone the official template instead—[`holepunchto/hello-pear-electron`](https://github.com/holepunchto/hello-pear-electron)—and follow [Start from the hello-pear-electron template](/getting-started/from-a-template/start-from-hello-pear-electron).
 </Callout>
 
 ## `pear install <link>`

--- a/examples/getting-started/hello-pear-bare/README.md
+++ b/examples/getting-started/hello-pear-bare/README.md
@@ -1,0 +1,9 @@
+# hello-pear-bare (documentation snapshot)
+
+Vendored from [holepunchto/hello-pear-bare](https://github.com/holepunchto/hello-pear-bare) at commit `c62e69b`.
+
+`bin.js` backs the code imports in `content/getting-started/from-a-template/start-from-hello-pear-bare.mdx`
+(via `file=<rootDir>/examples/getting-started/hello-pear-bare/bin.js#L…`).
+
+This is a partial, documentation-only snapshot — not a runnable app. To refresh, copy the
+upstream file for the new commit and re-check the imported line ranges in the MDX.

--- a/examples/getting-started/hello-pear-bare/bin.js
+++ b/examples/getting-started/hello-pear-bare/bin.js
@@ -1,0 +1,85 @@
+const { command, flag } = require('paparam')
+const storageAPI = require('bare-storage')
+const pkg = require('./package.json')
+const os = require('bare-os')
+const { isWindows } = require('which-runtime')
+const path = require('bare-path')
+const Corestore = require('corestore')
+const Hyperswarm = require('hyperswarm')
+const PearRuntime = require('pear-runtime')
+
+const appName = pkg.productName || pkg.name
+
+const cmd = command(
+  appName,
+  flag('--storage <dir>', 'custom storage directory for pear-runtime'),
+  flag('--no-updates', 'disable OTA updates for this run')
+)
+
+cmd.parse(global.Bare.argv.slice(2))
+
+const updates = cmd.flags.updates
+const isDev = path.basename(Bare.argv[0] || '').startsWith('bare')
+const storage = cmd.flags.storage || (isDev ? null : path.join(storageAPI.persistent(), appName))
+const dir = storage || path.join(os.tmpdir(), 'pear', appName)
+const store = new Corestore(path.join(dir, 'pear-runtime', 'corestore'))
+const swarm = new Hyperswarm()
+
+console.log(`${appName} v${pkg.version}`)
+console.log(`Updates: ${updates === false ? 'disabled' : 'enabled'}`)
+
+function getRunningAppPath() {
+  if (isDev) return null
+  return os.execPath()
+}
+
+const pear = new PearRuntime({
+  dir,
+  app: getRunningAppPath(),
+  updates,
+  version: pkg.version,
+  upgrade: pkg.upgrade,
+  name: isWindows ? appName + '.exe' : appName,
+  store,
+  swarm
+})
+
+if (updates !== false) {
+  pear.updater.on('updating', () => console.log('[updater] getting new update'))
+
+  pear.updater.on('updating-delta', (d) => console.log('[updater]', d))
+
+  pear.updater.on('updated', async () => {
+    console.log('[updater] update complete... appling')
+    await pear.updater.applyUpdate()
+    console.log('[updater] applied update, restart to run latest version')
+  })
+
+  swarm.on('connection', (connection) => store.replicate(connection))
+
+  swarm.join(pear.updater.drive.core.discoveryKey, {
+    client: true,
+    server: false
+  })
+}
+
+pear.on('error', (err) => {
+  console.error('[pear-runtime:error]', err)
+})
+
+let tearingDown = false
+async function teardown(code = 0) {
+  if (tearingDown) return
+  tearingDown = true
+  try {
+    await pear?.close()
+  } catch {}
+  global.Bare.exit(code)
+}
+
+global.Bare.on('SIGHUP', () => teardown(129))
+global.Bare.on('SIGINT', () => teardown(130))
+global.Bare.on('SIGQUIT', () => teardown(131))
+global.Bare.on('SIGTERM', () => teardown(143))
+
+console.log('CLI ready. Press Ctrl+C to stop.')

--- a/examples/getting-started/hello-pear-electron/README.md
+++ b/examples/getting-started/hello-pear-electron/README.md
@@ -1,0 +1,10 @@
+# hello-pear-electron (documentation snapshot)
+
+Vendored from [holepunchto/hello-pear-electron](https://github.com/holepunchto/hello-pear-electron) at commit `9e8085a`.
+
+`renderer/app.js` and `workers/main.js` back the code imports in
+`content/getting-started/from-a-template/start-from-hello-pear-electron.mdx`
+(via `file=<rootDir>/examples/getting-started/hello-pear-electron/…#L…`).
+
+This is a partial, documentation-only snapshot — not a runnable app. To refresh, copy the
+upstream files for the new commit and re-check the imported line ranges in the MDX.

--- a/examples/getting-started/hello-pear-electron/renderer/app.js
+++ b/examples/getting-started/hello-pear-electron/renderer/app.js
@@ -1,0 +1,63 @@
+const bridge = window.bridge
+const decoder = new TextDecoder('utf-8')
+
+document.getElementById('v').innerText += bridge.pkg().version
+
+function showUpdateReady() {
+  document.getElementById('v').innerText = 'Update ready!'
+  const btn = document.getElementById('update-btn')
+  btn.style.display = 'inline-block'
+  btn.onclick = async () => {
+    btn.disabled = true
+    btn.innerText = 'Updating...'
+    try {
+      await bridge.applyUpdate()
+      await bridge.appAfterUpdate()
+    } catch (err) {
+      document.getElementById('v').innerText = 'Update failed: ' + err.message
+      btn.style.display = 'none'
+    }
+  }
+}
+
+function onWorkerUpdaterEvent(name) {
+  if (name === 'updating') {
+    document.getElementById('v').innerText = 'UPDATING...'
+    return
+  }
+  if (name === 'updated') showUpdateReady()
+}
+
+const workers = {
+  main: '/workers/main.js'
+}
+
+bridge.startWorker(workers.main)
+let sentHello = false
+
+const offWorkerStdout = bridge.onWorkerStdout(workers.main, (data) => {
+  console.log('worker stdout', '[', workers.main, ']:', decoder.decode(data))
+})
+
+const offWorkerStderr = bridge.onWorkerStderr(workers.main, (data) => {
+  console.error('worker stderr', '[', workers.main, ']:', decoder.decode(data))
+})
+
+const offWorkerIpc = bridge.onWorkerIPC(workers.main, (data) => {
+  const message = decoder.decode(data)
+  console.log('worker ipc', '[', workers.main, ']:', message)
+  onWorkerUpdaterEvent(message)
+
+  if (!sentHello) {
+    sentHello = true
+    bridge.writeWorkerIPC(workers.main, 'Hello from renderer')
+  }
+})
+
+const offWorkerExit = bridge.onWorkerExit(workers.main, (code) => {
+  console.log('Worker exited with code', code)
+  offWorkerStdout()
+  offWorkerStderr()
+  offWorkerIpc()
+  offWorkerExit()
+})

--- a/examples/getting-started/hello-pear-electron/workers/main.js
+++ b/examples/getting-started/hello-pear-electron/workers/main.js
@@ -1,0 +1,51 @@
+const PearRuntime = require('pear-runtime')
+const Hyperswarm = require('hyperswarm')
+const Corestore = require('corestore')
+const goodbye = require('graceful-goodbye')
+const FramedStream = require('framed-stream')
+const path = require('bare-path')
+
+const pipe = new FramedStream(Bare.IPC)
+
+const updaterConfig = {
+  dir: Bare.argv[2],
+  app: Bare.argv[3],
+  updates: Bare.argv[4] !== 'false',
+  version: Bare.argv[5],
+  upgrade: Bare.argv[6],
+  name: Bare.argv[7]
+}
+
+const store = new Corestore(path.join(updaterConfig.dir, 'pear-runtime/corestore'))
+const swarm = new Hyperswarm()
+const pear = new PearRuntime({ ...updaterConfig, swarm, store })
+
+pear.updater.on('error', console.error)
+if (updaterConfig.updates !== false) {
+  swarm.on('connection', (connection) => store.replicate(connection))
+  swarm.join(pear.updater.drive.core.discoveryKey, {
+    client: true,
+    server: false
+  })
+}
+
+console.log('Application storage:', pear.storage)
+
+pear.updater.on('updating', () => pipe.write('updating'))
+pear.updater.on('updated', () => pipe.write('updated'))
+
+goodbye(async () => {
+  await swarm.destroy()
+  await pear.close()
+  await store.close()
+})
+
+pipe.on('data', async (data) => {
+  const message = data.toString()
+  if (message === 'pear:applyUpdate') {
+    await pear.updater.applyUpdate()
+    pipe.write('pear:updateApplied')
+  } else console.log(message)
+})
+
+pipe.write('Hello from worker')

--- a/src/lib/custom-tree.ts
+++ b/src/lib/custom-tree.ts
@@ -38,9 +38,25 @@ export const customTree: Node[] = [
         ],
       },
       {
-        type: 'page',
-        name: 'Start from the hello-pear-electron template',
-        url: '/getting-started/start-from-hello-pear-electron',
+        type: 'folder',
+        name: 'Start from a template',
+        index: {
+          type: 'page',
+          name: 'Start from a template',
+          url: '/getting-started/from-a-template',
+        },
+        children: [
+          {
+            type: 'page',
+            name: 'Start from the hello-pear-electron template',
+            url: '/getting-started/from-a-template/start-from-hello-pear-electron',
+          },
+          {
+            type: 'page',
+            name: 'Start from the hello-pear-bare template',
+            url: '/getting-started/from-a-template/start-from-hello-pear-bare',
+          },
+        ],
       },
     ],
   },


### PR DESCRIPTION
## Summary

Adds **hello-pear-bare** as a second getting-started boilerplate alongside hello-pear-electron, and groups both under a new **Start from a template** section.

## Changes

### New "Start from a template" section
- [`getting-started/from-a-template/index.mdx`](https://pear-docs-preview-iimt7-branch-feat-add-hello-pear-ba.kinsta.page/getting-started/from-a-template/) — section landing (both boilerplates + a "which one?" guide).
- [`getting-started/from-a-template/start-from-hello-pear-bare.mdx`](https://pear-docs-preview-iimt7-branch-feat-add-hello-pear-ba.kinsta.page/getting-started/from-a-template/start-from-hello-pear-bare/) — the new terminal/Bare guide.
- Moved the hello-pear-electron guide into the folder; updated all internal links and the sidebar.

### Code blocks sourced from the upstream repos
- Vendored the imported files under `examples/getting-started/hello-pear-{bare,electron}/` (committed snapshots — **no submodules**, so no deploy/CI change) and import them via `remark-code-import`. Each snapshot README records its upstream commit.

### Watcher workflow
- `.github/workflows/watch-boilerplates.yml` — a weekly cron that opens a tracking issue when either upstream boilerplate moves past the vendored snapshot (the cue to refresh it).

### Unified template callouts
- Two reusable snippets: `_from-a-template-callout` (works with either template → section index) and `_frontend-template-callout` (frontend how-tos → hello-pear-electron).
- Folded the Pear-end portability note into them, so each how-to carries **one** orientation callout instead of two; applied across the how-tos by class.

### Misc
- Folded the "Hello Pear Boilerplates" announcement into the bare guide (use cases, single-binary value prop, distribution channels, community links).

## Checks
- `check:internal-links` ✅, `check:doctypes` ✅
- Verified locally that code imports resolve and the unified callouts render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)