### PR TITLE
Edits to About Pear and Platform Foundations

### DIFF
--- a/content/explanation/dependencies-and-network.mdx
+++ b/content/explanation/dependencies-and-network.mdx
@@ -1,22 +1,22 @@
 ---
 title: "Dependencies and network"
-description: "Why Pear ships with NPM as the install path, what your dependencies actually do at runtime, and what your IP discloses on the swarm."
+description: "Why Pear ships with npm as the install path, what your dependencies actually do at runtime, and what your IP discloses on the swarm."
 docType: explanation
 schemaType: WebPage
 ---
 
 Two questions come up enough during onboarding:
 
-- [Why Pear uses NPM at all when applications run on Bare, not Node?](#why-npm-for-dependencies)
+- [Why Pear uses npm at all when applications run on Bare, not Node?](#why-npm-for-dependencies)
 - [What peers can learn about you when you join a swarm?](#what-peers-learn-from-your-ip)
 
 Both answers have the same shape—a deliberate trade-off between developer ergonomics and the platform's clean-room ideals.
 
-## Why NPM for dependencies
+## Why npm for dependencies
 
-NPM is a great package manager for JavaScript, and most JavaScript developers already know how to use it. All of Holepunch's modules—[Hypercore](/reference/building-blocks/hypercore), [Hyperdrive](/reference/building-blocks/hyperdrive), [Hyperbee](/reference/building-blocks/hyperbee), the lot—are published there. Reinventing a peer-to-peer package manager would have meant reinventing every developer's habits at the same time, for very little upside.
+npm is a great package manager for JavaScript, and most JavaScript developers already know how to use it. All of Holepunch's modules—[Hypercore](/reference/building-blocks/hypercore), [Hyperdrive](/reference/building-blocks/hyperdrive), [Hyperbee](/reference/building-blocks/hyperbee), the lot—are published there. Reinventing a peer-to-peer package manager would have meant reinventing every developer's habits at the same time, for very little upside.
 
-The bootstrap relationship is what's interesting: NPM and Node.js are required to **install** Pear initially (`npm install -g pear`), but once the platform is set up neither is needed at runtime. The `pear` command after install is using Bare, not Node, to run your application; NPM was just the delivery mechanism.
+The bootstrap relationship is what's interesting: npm and Node.js are required to **install** Pear initially (`npm install -g pear`), but once the platform is set up neither is needed at runtime. The `pear` command after install is using Bare, not Node, to run your application; npm was just the delivery mechanism.
 
 What dependencies your application declares stays meaningful, though. When you `pear stage`, every dependency in your `package.json` is bundled into the application's hyperdrive and replicated to peers along with your code. A few practical implications follow:
 

--- a/content/explanation/index.mdx
+++ b/content/explanation/index.mdx
@@ -15,9 +15,9 @@ Pages are grouped by topic and ordered roughly from foundational concepts to app
 
 ### Platform foundations
 
+- [Peer-to-peer, demystified](/explanation/peer-to-peer-demystified)—hole punching, public-key identity, and the roles of HyperDHT and Hyperswarm.
 - [Runtime and languages](/explanation/runtime-and-languages)—JavaScript on Bare, native addons for other languages, and the Pear-end pattern for cross-platform apps.
 - [Dependencies and network](/explanation/dependencies-and-network)—why NPM is the install path, the runtime relationship to Node, and what your IP discloses on a swarm.
-- [Peer-to-peer, demystified](/explanation/peer-to-peer-demystified)—hole punching, public-key identity, and the roles of HyperDHT and Hyperswarm.
 
 ### Storing & replicating data
 

--- a/content/explanation/runtime-and-languages.mdx
+++ b/content/explanation/runtime-and-languages.mdx
@@ -36,7 +36,7 @@ Because the Pear-end never imports DOM APIs and never assumes a particular UI fr
 
 This split is what powers Keet's identical experience across phones, laptops, and terminals: one Pear-end, three UIs.
 
-The [`pear-runtime`](/reference/pear/runtime) library is what wires the two halves together: the UI host embeds it to spawn the Pear-end as a Bare worker, manage peer-to-peer storage, and apply over-the-air updates. At the time of writing it is **not yet supported on mobile**. Pear v2 lands the same Pear-end / UI separation as a built-in default, at which point parity follows. If you have an app on the global `pear run` API, see [Migrate from pear run to pear-runtime](/how-to/operate-an-app/migration).
+The [`pear-runtime`](/reference/pear/runtime) library is what wires the two halves together: the UI host embeds it to spawn the Pear-end as a Bare worker, manage peer-to-peer storage, and apply over-the-air updates. At the time of writing it is **not yet supported on mobile**. Pear v3 lands the same Pear-end / UI separation as a built-in default, at which point parity follows. If you have an app on the global `pear run` API, see [Migrate from pear run to pear-runtime](/how-to/operate-an-app/migration).
 
 ## Workers carry the Pear-end
 

--- a/content/explanation/runtime-and-languages.mdx
+++ b/content/explanation/runtime-and-languages.mdx
@@ -36,7 +36,7 @@ Because the Pear-end never imports DOM APIs and never assumes a particular UI fr
 
 This split is what powers Keet's identical experience across phones, laptops, and terminals: one Pear-end, three UIs.
 
-The [`pear-runtime`](/reference/pear/runtime) library is what wires the two halves together: the UI host embeds it to spawn the Pear-end as a Bare worker, manage peer-to-peer storage, and apply over-the-air updates. At the time of writing it is **not yet supported on mobile**. Pear v3 lands the same Pear-end / UI separation as a built-in default, at which point parity follows. If you have an app on the global `pear run` API, see [Migrate from pear run to pear-runtime](/how-to/operate-an-app/migration).
+The [`pear-runtime`](/reference/pear/runtime) library is what wires the two halves together: the UI host embeds it to spawn the Pear-end as a Bare worker, manage peer-to-peer storage, and apply over-the-air updates. At the time of writing it is **not yet supported on mobile**. Pear v2 lands the same Pear-end / UI separation as a built-in default, at which point parity follows. If you have an app on the global `pear run` API, see [Migrate from pear run to pear-runtime](/how-to/operate-an-app/migration).
 
 ## Workers carry the Pear-end
 


### PR DESCRIPTION
Some small tweaks:

- npm is lowercase officially
- Re-order Platform foundations sub pages on index so that they match sidebar 
-  ~~Refer to Pear v3 rather than v2~~ I was wrong about this one, have undone.