### PR TITLE
Modules stability legend

### DIFF
--- a/content/reference/modules/bare-modules.mdx
+++ b/content/reference/modules/bare-modules.mdx
@@ -11,6 +11,19 @@ Pear's native runtime is [Bare](https://github.com/holepunchto/bare)—a small, 
 
 If you author native addons for Bare, the [Bare native-addon prebuild actions](/reference/ci-and-release/github-actions#bare-native-addon-prebuilds) build and collect prebuilt binaries across platforms in CI.
 
+## Stability legend
+
+Module lists call out a stability indicator. The four levels:
+
+|                           Stability                                |                         Description                         |
+| ------------------------------------------------------------------ | ----------------------------------------------------------- |
+| <mark style={{ backgroundColor: '#7dde9a', padding: '2px 8px', borderRadius: '4px', fontSize: '0.85em', fontWeight: 500 }}>stable</mark>       | Unlikely to change or be removed in the foreseeable future.  |
+| <mark style={{ backgroundColor: '#8484ff', padding: '2px 8px', borderRadius: '4px', fontSize: '0.85em', fontWeight: 500 }}>experimental</mark> | New, untested, or has known issues.                          |
+| <mark style={{ backgroundColor: '#f0e57a', padding: '2px 8px', borderRadius: '4px', fontSize: '0.85em', fontWeight: 500 }}>deprecated</mark>   | Being removed or replaced in the future.                     |
+| <mark style={{ backgroundColor: '#ff4242', padding: '2px 8px', borderRadius: '4px', fontSize: '0.85em', fontWeight: 500 }}>unstable</mark>     | May change or be removed without warning.    
+
+## Modules 
+
 | Module                                                                        | Description                                                          | Systems     | Stability                                                  |
 | ----------------------------------------------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------------------- | ---------------------------------------------------------- |
 | [bare-abort](https://github.com/holepunchto/bare-abort)                       | Cause abnormal program termination and generate a crash report       | <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}><img className="dark:[filter:invert(1)]" src="/windows-light.svg" /> <img className="dark:[filter:invert(1)]" src="/macos-light.svg" /> <img src="/linux.svg" /> <img className="dark:[filter:invert(1)]" src="/android-light.svg" /> <img className="dark:[filter:invert(1)]" src="/ios-light.svg" /></div>      |  <mark style={{ backgroundColor: '#7dde9a', padding: '2px 8px', borderRadius: '4px', fontSize: '0.85em', fontWeight: 500 }}>stable</mark> |

--- a/content/reference/modules/pear-modules.mdx
+++ b/content/reference/modules/pear-modules.mdx
@@ -9,6 +9,17 @@ schemaType: APIReference
 
 The `Pear` global API is minimal and not intended as a standard library. Application and integration libraries are supplied via installable modules prefixed with `pear-`.
 
+## Stability legend
+
+Module lists call out a stability indicator. The four levels:
+
+|                           Stability                                |                         Description                         |
+| ------------------------------------------------------------------ | ----------------------------------------------------------- |
+| <mark style={{ backgroundColor: '#7dde9a', padding: '2px 8px', borderRadius: '4px', fontSize: '0.85em', fontWeight: 500 }}>stable</mark>       | Unlikely to change or be removed in the foreseeable future.  |
+| <mark style={{ backgroundColor: '#8484ff', padding: '2px 8px', borderRadius: '4px', fontSize: '0.85em', fontWeight: 500 }}>experimental</mark> | New, untested, or has known issues.                          |
+| <mark style={{ backgroundColor: '#f0e57a', padding: '2px 8px', borderRadius: '4px', fontSize: '0.85em', fontWeight: 500 }}>deprecated</mark>   | Being removed or replaced in the future.                     |
+| <mark style={{ backgroundColor: '#ff4242', padding: '2px 8px', borderRadius: '4px', fontSize: '0.85em', fontWeight: 500 }}>unstable</mark>     | May change or be removed without warning.                    |
+
 ## Application libraries
 
 Pear modules related directly to the application environment.


### PR DESCRIPTION
This PR moves the module stability legend from the main index to the top of each module list page. 