### PR TITLE
Fix false-negative template link and em-dash lint errors

### DIFF
--- a/content/getting-started/from-a-template/start-from-hello-pear-bare.mdx
+++ b/content/getting-started/from-a-template/start-from-hello-pear-bare.mdx
@@ -117,9 +117,9 @@ npm run make:darwin-arm64
 
 The template ships a target for every supported platform:
 
-- **macOS** — `darwin-arm64`, `darwin-x64`
-- **Linux** — `linux-arm64`, `linux-x64`
-- **Windows** — `win32-arm64`, `win32-x64`
+- **macOS**: `darwin-arm64`, `darwin-x64`
+- **Linux**: `linux-arm64`, `linux-x64`
+- **Windows**: `win32-arm64`, `win32-x64`
 
 Build each platform's binary on a matching host.
 

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -38,7 +38,7 @@ A four-part type-along that builds a peer-to-peer Electron chat, adds persistenc
 
 [**Start the type-along →**](/getting-started)
 
-Prefer to start from a finished project? [**Start from the `hello-pear-electron` and `hello-pear-bare` templates**](/getting-started/from-a-template/index) clones the boilerplate and walks you through where the frontend, app logic, and preload bridge live before you add a feature end to end.
+Prefer to start from a finished project? [**Start from the `hello-pear-electron` and `hello-pear-bare` templates**](/getting-started/from-a-template) clones the boilerplate and walks you through where the frontend, app logic, and preload bridge live before you add a feature end to end.
 
 ### About Pear—_understand this_
 


### PR DESCRIPTION
## Summary
- Fix a link checker false negative on the home page by pointing the template CTA to `/getting-started/from-a-template` instead of `/getting-started/from-a-template/index`
- Fix `Google.EmDash` lint errors in the hello-pear-bare guide by replacing spaced em dashes with colons in the platform target list

## Test plan
- [ ] Confirm CI link check passes
- [ ] Confirm Vale/`Google.EmDash` lint passes on `start-from-hello-pear-bare.mdx`
- [ ] Verify `/getting-started/from-a-template` resolves correctly in the docs site


Made with [Cursor](https://cursor.com)