### PR TITLE
fix: add _redirects catch-all 404 and markdown negotiation

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -27,10 +27,12 @@ const config = {
   // The PRODUCTION redirects come from:
   //   - out/<from>/index.html — meta-refresh + canonical stubs (zero-
   //     config; works on any static host).
-  //   - out/_redirects        — Sevalla / Netlify / Cloudflare-Pages
-  //     compatible 308 rules (true 308s once deployed).
-  // Both are emitted by scripts/generate-redirect-stubs.ts during the
-  // postbuild step. scripts/redirects.ts is the single source of truth.
+  //   - out/_redirects        — Sevalla / Netlify / Cloudflare-Pages rules.
+  //     Follows the qvac docs strategy: public/_redirects is the authored
+  //     source (markdown negotiation, catch-all 404) and is copied into out/
+  //     by `next build`; scripts/generate-redirect-stubs.ts prepends IA 308
+  //     rules ahead of that file during postbuild.
+  // scripts/redirects.ts is the single source of truth for IA redirects.
   // See decisions/0001-adopt-diataxis-ia.md §6.
   async redirects() {
     return [

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,4 @@
+# Catch-all 404 — must be the last rule in out/_redirects.
+# Sevalla serves /404.html for unresolved paths with HTTP 200; this forces
+# a real 404 status while rendering the same page body.
+/*    /404.html    404

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,4 +1,67 @@
-# Catch-all 404 — must be the last rule in out/_redirects.
-# Sevalla serves /404.html for unresolved paths with HTTP 200; this forces
-# a real 404 status while rendering the same page body.
-/*    /404.html    404
+# Markdown content negotiation — serve the `.md` sibling of a page when
+# the client requests it via `Accept: text/markdown`. Home maps to
+# `/index.md`; every other page `/a/b/.../z/` maps to `/a/b/.../z.md`.
+#
+# Three properties of these rules and why they are required:
+#
+#  1. `!` (force) — the source path has an underlying static file (the
+#     HTML page) that would otherwise be served; the force flag is what
+#     lets the rule fire at all.
+#
+#  2. `303` (See Other) — the rule MUST be a 3xx redirect, not a 2xx
+#     rewrite. With a 2xx rewrite the response body for the `.md` content
+#     gets cached by Cloudflare under the page's URL key (Cloudflare does
+#     not honour `Vary: Accept`), poisoning the cache for subsequent
+#     HTML clients. A redirect is fetched anew by the client, so the
+#     Markdown response is cached under the `.md` URL key and the HTML
+#     response stays cached under the page URL key. Among 3xx codes,
+#     `303` is the semantically correct match for content negotiation
+#     ("the representation you asked for lives at another URI").
+#
+#  3. One rule per nesting depth, no splat. `_redirects` placeholders
+#     (`:name`) match a single path segment — verified empirically
+#     against Sevalla (a single `/:slug/` rule served HTML, not Markdown,
+#     for `/ai-capabilities/text-generation/`). Covering the site
+#     therefore requires one rule per depth. The splat form
+#     (`/* /:splat.md`) would be greedy but empirically crashes the
+#     Sevalla edge worker (HTTP 1101) when combined with `Header:Accept`
+#     — bug in their parser. Current site max depth is 3 segments; one
+#     extra level is included as headroom.
+#
+# Loop safety: the source pattern always ends in `/`, the rewrite target
+# always ends in `.md` (no slash). Those two URL spaces are disjoint, so
+# the client's follow-up `GET /foo.md` does not re-match the rule. This
+# only holds because all incoming page requests carry a trailing slash
+# (Sevalla's Pretty URLs normalizes bare paths first) AND because Pretty
+# URLs skips paths whose final segment contains a dot — so `/foo.md` is
+# never normalized into `/foo.md/`, which would otherwise loop.
+/                       /index.md                  303!   Header:Accept=text/markdown
+/:a/                    /:a.md                     303!   Header:Accept=text/markdown
+/:a/:b/                 /:a/:b.md                  303!   Header:Accept=text/markdown
+/:a/:b/:c/              /:a/:b/:c.md               303!   Header:Accept=text/markdown
+/:a/:b/:c/:d/           /:a/:b/:c/:d.md            303!   Header:Accept=text/markdown
+
+# ======================================================================
+# CATCH-ALL 404 — MUST BE THE LAST RULE
+# ----------------------------------------------------------------------
+# Sevalla serves /404.html automatically for unresolved paths, but with
+# HTTP 200, which breaks SEO, link checkers, analytics and HTTP clients.
+# This explicit rule forces a real `404 Not Found` status while still
+# rendering the same /404.html body. Reached in two distinct cases:
+#
+#   1. No static file matches the request AND no earlier rule matches.
+#   2. An earlier `200` rewrite points at a target that doesn't exist
+#      (e.g. `/reference/api/notaversion/` → rewrite to
+#      `/reference/api/notaversion/index.html` which isn't built).
+#      Sevalla's pipeline continues evaluating rules in this case, and
+#      this catch-all gives those orphaned rewrites a clean 404 instead
+#      of falling back to Sevalla's soft-200 default.
+#
+# Known edge case (intentionally not fixed): a direct request to
+# `/404.html` returns 200 because Sevalla's static-file resolution runs
+# before `_redirects` and serves the file as-is, bypassing this rule.
+# `/404.html` is not in the sitemap, not linked from any page, and not
+# referenced in any external surface; practical traffic to it is zero.
+# ======================================================================
+
+/*   /404.html   404

--- a/scripts/check-redirects.ts
+++ b/scripts/check-redirects.ts
@@ -7,6 +7,7 @@
  *   2. The HTML contains `meta http-equiv="refresh"` pointing at the new URL.
  *   3. The HTML contains `link rel="canonical"` pointing at the new URL.
  *   4. out/_redirects contains a line like `<from> <to> 308`.
+ *   5. out/_redirects ends with the catch-all 404 rule from public/_redirects.
  *
  * Designed to be wired into CI alongside check:internal-links so the IA
  * can't drift back. See decisions/0001-adopt-diataxis-ia.md §6.
@@ -38,8 +39,25 @@ function main(): void {
     process.exit(1);
   }
   const redirectsFile = readFileSync(redirectsPath, 'utf-8');
+  const catchAllRule = '/*   /404.html   404';
 
   const failures: Failure[] = [];
+
+  if (!redirectsFile.includes(catchAllRule)) {
+    failures.push({
+      from: catchAllRule,
+      to: '/404.html',
+      reason: 'catch-all 404 rule from public/_redirects is missing',
+    });
+  }
+
+  if (!redirectsFile.trimEnd().endsWith(catchAllRule)) {
+    failures.push({
+      from: catchAllRule,
+      to: '/404.html',
+      reason: 'catch-all 404 rule must be the last active rule in out/_redirects',
+    });
+  }
 
   for (const { from, to } of redirects) {
     const stubPath = join(OUT_DIR, from, 'index.html');

--- a/scripts/generate-llm-md-files.ts
+++ b/scripts/generate-llm-md-files.ts
@@ -2,6 +2,9 @@
  * Post-build: reads `out/llm-md-manifest.json` and writes per-page `.md` files
  * so clients can fetch Markdown via `pageMarkdownUrl()` (e.g. `/ship.md`).
  *
+ * The `Accept: text/markdown` content-negotiation flow is configured in
+ * `public/_redirects` (same strategy as qvac docs).
+ *
  * Run after `next build`: `tsx scripts/generate-llm-md-files.ts`
  */
 import { readFile, writeFile, mkdir, unlink } from 'fs/promises';

--- a/scripts/generate-redirect-stubs.ts
+++ b/scripts/generate-redirect-stubs.ts
@@ -7,22 +7,36 @@
  *
  *   2. A Sevalla / Netlify / Cloudflare-Pages compatible _redirects
  *      file at out/_redirects, with one `<from> <to> 308` line per
- *      entry. Once the next deploy lands, the hosting layer returns
- *      true 308s and the HTML stubs become a fallback.
+ *      entry plus static rules from public/_redirects (e.g. catch-all 404).
  *
  * Both are derived from scripts/redirects.ts to keep a single source
  * of truth. See decisions/0001-adopt-diataxis-ia.md §6.
  */
-import { mkdirSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { buildRedirects, stubHtml } from './redirects';
 
 const OUT_DIR = 'out';
+const STATIC_REDIRECTS_PATH = 'public/_redirects';
+
+/** Active rules from public/_redirects (comments and blank lines skipped). */
+function readStaticRedirects(): string[] {
+  if (!existsSync(STATIC_REDIRECTS_PATH)) {
+    return [];
+  }
+
+  return readFileSync(STATIC_REDIRECTS_PATH, 'utf-8')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith('#'));
+}
 
 function main(): void {
   const redirects = buildRedirects();
 
-  if (redirects.length === 0) {
+  const staticRedirects = readStaticRedirects();
+
+  if (redirects.length === 0 && staticRedirects.length === 0) {
     console.warn('⚠️  No redirects to emit (content/ tree empty?).');
     return;
   }
@@ -38,11 +52,15 @@ function main(): void {
   // _redirects: simple 3-column format (`<from> <to> <status>`) understood
   // by Netlify, Cloudflare Pages, Sevalla, and most static hosts. Each line
   // is a permanent redirect (308 — same semantics as the meta-refresh stub
-  // but without the round-trip).
-  const redirectsFile = redirects.map(({ from, to }) => `${from} ${to} 308`).join('\n') + '\n';
+  // but without the round-trip). Static rules from public/_redirects (e.g.
+  // the catch-all 404) are appended last so they stay after IA redirects.
+  const generatedRedirects = redirects.map(({ from, to }) => `${from} ${to} 308`);
+  const redirectsFile = [...generatedRedirects, ...staticRedirects].join('\n') + '\n';
   writeFileSync(join(OUT_DIR, '_redirects'), redirectsFile);
 
-  console.log(`✅ Wrote ${stubsWritten} redirect stubs and out/_redirects (${redirects.length} rules).`);
+  console.log(
+    `✅ Wrote ${stubsWritten} redirect stubs and out/_redirects (${redirects.length} generated + ${staticRedirects.length} static rules).`,
+  );
 }
 
 main();

--- a/scripts/generate-redirect-stubs.ts
+++ b/scripts/generate-redirect-stubs.ts
@@ -6,37 +6,36 @@
  *      Survives any static host with zero deploy-side config.
  *
  *   2. A Sevalla / Netlify / Cloudflare-Pages compatible _redirects
- *      file at out/_redirects, with one `<from> <to> 308` line per
- *      entry plus static rules from public/_redirects (e.g. catch-all 404).
+ *      file at out/_redirects. Follows the qvac docs strategy:
+ *        - public/_redirects is the authored source (markdown negotiation,
+ *          catch-all 404, etc.) and is copied into out/ by `next build`.
+ *        - This script prepends generated IA 308 rules ahead of that file
+ *          so legacy redirects stay first-match and public/_redirects
+ *          rules (especially the catch-all 404) remain last.
  *
- * Both are derived from scripts/redirects.ts to keep a single source
- * of truth. See decisions/0001-adopt-diataxis-ia.md §6.
+ * IA redirects are derived from scripts/redirects.ts. See
+ * decisions/0001-adopt-diataxis-ia.md §6.
  */
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { buildRedirects, stubHtml } from './redirects';
 
 const OUT_DIR = 'out';
-const STATIC_REDIRECTS_PATH = 'public/_redirects';
+const PUBLIC_REDIRECTS_PATH = 'public/_redirects';
 
-/** Active rules from public/_redirects (comments and blank lines skipped). */
-function readStaticRedirects(): string[] {
-  if (!existsSync(STATIC_REDIRECTS_PATH)) {
-    return [];
+function readPublicRedirects(): string {
+  if (!existsSync(PUBLIC_REDIRECTS_PATH)) {
+    return '';
   }
 
-  return readFileSync(STATIC_REDIRECTS_PATH, 'utf-8')
-    .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0 && !line.startsWith('#'));
+  return readFileSync(PUBLIC_REDIRECTS_PATH, 'utf-8').trimEnd();
 }
 
 function main(): void {
   const redirects = buildRedirects();
+  const publicRedirects = readPublicRedirects();
 
-  const staticRedirects = readStaticRedirects();
-
-  if (redirects.length === 0 && staticRedirects.length === 0) {
+  if (redirects.length === 0 && publicRedirects.length === 0) {
     console.warn('⚠️  No redirects to emit (content/ tree empty?).');
     return;
   }
@@ -49,17 +48,17 @@ function main(): void {
     stubsWritten++;
   }
 
-  // _redirects: simple 3-column format (`<from> <to> <status>`) understood
-  // by Netlify, Cloudflare Pages, Sevalla, and most static hosts. Each line
-  // is a permanent redirect (308 — same semantics as the meta-refresh stub
-  // but without the round-trip). Static rules from public/_redirects (e.g.
-  // the catch-all 404) are appended last so they stay after IA redirects.
-  const generatedRedirects = redirects.map(({ from, to }) => `${from} ${to} 308`);
-  const redirectsFile = [...generatedRedirects, ...staticRedirects].join('\n') + '\n';
+  const generatedRedirects = redirects.map(({ from, to }) => `${from} ${to} 308`).join('\n');
+  const redirectsFile =
+    generatedRedirects && publicRedirects
+      ? `${generatedRedirects}\n\n${publicRedirects}\n`
+      : generatedRedirects
+        ? `${generatedRedirects}\n`
+        : `${publicRedirects}\n`;
   writeFileSync(join(OUT_DIR, '_redirects'), redirectsFile);
 
   console.log(
-    `✅ Wrote ${stubsWritten} redirect stubs and out/_redirects (${redirects.length} generated + ${staticRedirects.length} static rules).`,
+    `✅ Wrote ${stubsWritten} redirect stubs and out/_redirects (${redirects.length} generated IA rules + public/_redirects).`,
   );
 }
 


### PR DESCRIPTION
## Summary

- Adds `public/_redirects` using the same strategy as qvac docs: markdown content negotiation (`Accept: text/markdown`) and a catch-all `404` rule that serves `/404.html` with a real HTTP 404 status on Sevalla.
- Updates postbuild to prepend generated IA `308` redirects ahead of `public/_redirects`, keeping the catch-all as the last rule in `out/_redirects`.
- Extends `check:redirects` to verify the catch-all 404 rule is present and last.

## Test plan

- [ ] Run `npm run build` and confirm `out/_redirects` has IA redirects first, then markdown rules, then `/*   /404.html   404` last
- [ ] Run `npm run check:redirects`
- [ ] After deploy, request a non-existent path and confirm HTTP 404 (not 200)
- [ ] Request a page with `Accept: text/markdown` and confirm redirect to the `.md` sibling


Made with [Cursor](https://cursor.com)