### PR TITLE
fix(getting-started): switch to published branch when cloning pear-docs

### DIFF
--- a/content/getting-started/build-a-peer-to-peer-chat/reshape-into-a-production-app.mdx
+++ b/content/getting-started/build-a-peer-to-peer-chat/reshape-into-a-production-app.mdx
@@ -76,7 +76,9 @@ Part 1 was type-along in five files. The production scaffold is ~14 files and a 
 
 ```bash skip="desktop-gui"
 git clone https://github.com/holepunchto/pear-docs
-cd pear-docs/examples/getting-started/pear-chat
+cd pear-docs
+git switch published
+cd examples/getting-started/pear-chat
 npm install
 npm run build
 ```


### PR DESCRIPTION
## Summary
- Add `git switch published` to the pear-docs clone instructions in the reshape getting-started guide so readers land on the branch that contains the published examples.

## Test plan
- [ ] Verify the clone block in [Reshape into a production app](https://docs.pears.com/getting-started/build-a-peer-to-peer-chat/reshape-into-a-production-app) reads correctly after merge


Made with [Cursor](https://cursor.com)