### PR TITLE
chore: add Google Search Console site-verification file

### DIFF
--- a/public/googleb79b36e088621ed1.html
+++ b/public/googleb79b36e088621ed1.html
@@ -1,0 +1,1 @@
+google-site-verification: googleb79b36e088621ed1.html


### PR DESCRIPTION
## Summary

Adds the Google Search Console HTML verification file so the production docs site can be verified for ownership.

- `public/googleb79b36e088621ed1.html` (one line: `google-site-verification: googleb79b36e088621ed1.html`)

## Why `public/` and why target `published`

- `next.config` uses `output: 'export'`, which copies `public/` verbatim into the `out/` static bundle, so the file is served at the site root: `/googleb79b36e088621ed1.html`.
- Static-file resolution runs ahead of the `_redirects` catch-all (`/* /404.html 404`, not forced), so the file returns `200` rather than the 404 page. The forced markdown-negotiation rules only match trailing-slash paths with `Accept: text/markdown`, which a `.html` filename can't hit.
- Targeting `published` because Search Console verifies the **live** site — the file has to be on the deployed branch, not a feature branch.

## Verified locally

```
GET http://localhost:3000/googleb79b36e088621ed1.html
HTTP/1.1 200 OK
Content-Type: text/html; charset=UTF-8

google-site-verification: googleb79b36e088621ed1.html
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)