### PR TITLE
docs(bare): add Node.js builtin-to-bare module mapping

### DIFF
--- a/content/explanation/bare-runtime.mdx
+++ b/content/explanation/bare-runtime.mdx
@@ -59,7 +59,11 @@ No. Bare is a separate runtime built on `libjs` and `libuv`. The surface looks f
 
 ### Can I use npm modules with Bare?
 
-Pure-JavaScript packages from npm generally work, and Bare uses the npm dependency model. Packages that depend on Node's built-in modules need the corresponding [`bare-*` module](/reference/modules/bare-modules) (or the `bare-node` shim), and packages with native addons need to be built against Bare's addon API rather than Node's N-API (the [`bare-compat-napi`](https://github.com/holepunchto/bare-compat-napi) headers ease that transition). For the full builtin-to-`bare-*` mapping, see [Node.js compatibility](/reference/modules/bare-modules#nodejs-compatibility).
+Pure-JavaScript packages from npm generally work, and Bare uses the npm dependency model. Packages that depend on Node's built-in modules need the corresponding [`bare-*` module](/reference/modules/bare-modules) (or the `bare-node` shim), and packages with native addons need to be built against Bare's addon API rather than Node's N-API (the [`bare-compat-napi`](https://github.com/holepunchto/bare-compat-napi) headers ease that transition).
+
+<Callout type="info">
+For the full builtin-to-`bare-*` mapping, see [Node.js compatibility](/reference/modules/bare-modules#nodejs-compatibility).
+</Callout>
 
 ### Do users need Node.js installed to run a Bare app?
 

--- a/content/explanation/bare-runtime.mdx
+++ b/content/explanation/bare-runtime.mdx
@@ -54,7 +54,7 @@ No. Bare is a separate runtime built on `libjs` and `libuv`. The surface looks f
 
 ### Can I use npm modules with Bare?
 
-Pure-JavaScript packages from npm generally work, and Bare uses the npm dependency model. Packages that depend on Node's built-in modules need the corresponding [`bare-*` module](/reference/modules/bare-modules) (or the `bare-node` shim), and packages with native addons need to be built against Bare's addon API rather than Node's N-API.
+Pure-JavaScript packages from npm generally work, and Bare uses the npm dependency model. Packages that depend on Node's built-in modules need the corresponding [`bare-*` module](/reference/modules/bare-modules) (or the `bare-node` shim), and packages with native addons need to be built against Bare's addon API rather than Node's N-API (the [`bare-compat-napi`](https://github.com/holepunchto/bare-compat-napi) headers ease that transition). For the full builtin-to-`bare-*` mapping, see [Node.js compatibility](/reference/modules/bare-modules#nodejs-compatibility).
 
 ### Do users need Node.js installed to run a Bare app?
 

--- a/content/explanation/bare-runtime.mdx
+++ b/content/explanation/bare-runtime.mdx
@@ -5,7 +5,12 @@ docType: explanation
 schemaType: WebPage
 ---
 
-[Bare](https://github.com/holepunchto/bare) is the JavaScript runtime every Pear app runs on. Like Node.js, it gives you an asynchronous, event-driven environment for writing applications in JavaScript. Unlike Node.js, it treats **embedding** and **cross-device support** as core use cases—it aims to run just as well inside a phone app as on a laptop or a server. This page explains what that buys you and why the runtime is shaped the way it is. For the exact API, see the [`Bare` runtime reference](/reference/bare/runtime); for where Bare sits relative to Pear, see [The Pears stack](/explanation/the-pears-stack).
+[Bare](https://github.com/holepunchto/bare) is the JavaScript runtime every Pear app runs on. Like Node.js, it gives you an asynchronous, event-driven environment for writing applications in JavaScript. Unlike Node.js, it treats **embedding** and **cross-device support** as core use cases—it aims to run just as well inside a phone app as on a laptop or a server. This page explains what that buys you and why the runtime is shaped the way it is. 
+
+<Callout type="info">
+- For the exact API, see the [`Bare` runtime reference](/reference/bare/runtime).
+- For where Bare sits relative to Pear, see [The Pears stack](/explanation/the-pears-stack).
+</Callout>
 
 ## What Bare adds, and what it leaves out
 

--- a/content/explanation/runtime-and-languages.mdx
+++ b/content/explanation/runtime-and-languages.mdx
@@ -19,7 +19,7 @@ Two pragmatic reasons:
 
 2. **Bare keeps it small.** Bare ships without Node's standard library opinions—no `fs.read` on a URL, no built-in `http` module, no Worker baggage. That makes it cheap to embed in mobile apps, desktop shells, and constrained terminal environments alike. The Pear runtime adds the bits applications actually need on top.
 
-If you're coming from Node.js, the surface looks similar but isn't identical—see [Bare modules](/reference/modules/bare-modules) for the exact set of standard libraries available. The [`bare-node`](https://github.com/holepunchto/bare-node) shim maps many Node.js builtins onto their Bare equivalents, easing the port.
+If you're coming from Node.js, the surface looks similar but isn't identical—see [Bare modules](/reference/modules/bare-modules) for the exact set of standard libraries available, and the [Node.js compatibility](/reference/modules/bare-modules#nodejs-compatibility) section for a builtin-by-builtin mapping to the corresponding `bare-*` modules. The [`bare-node`](https://github.com/holepunchto/bare-node) shim maps many Node.js builtins onto their Bare equivalents, easing the port.
 
 ## Other languages: native addons
 

--- a/content/reference/modules/bare-modules.mdx
+++ b/content/reference/modules/bare-modules.mdx
@@ -165,13 +165,21 @@ The sections below catalog the rest of the published `bare-*` modules. They're l
 
 Coming from Node.js, the surface looks familiar, but Bare's standard library is opt-in rather than built in (see [Inside Bare](/explanation/bare-runtime)). Porting is mostly a matter of installing the right modules:
 
-- **Builtin replacements** — for each Node.js builtin your code uses, install the matching `bare-*` module. The mapping table below covers the common ones; each is documented in its functional section above.
-- **Shims, globals & polyfills** — [`bare-node`](https://github.com/holepunchto/bare-node) is the umbrella entry point that maps Node.js builtins and globals onto their Bare equivalents. The remaining modules below fill specific gaps.
-- **Native addons** — addons written against Node-API don't load directly; rebuild them against Bare's addon API, or use [`bare-compat-napi`](https://github.com/holepunchto/bare-compat-napi) for Node-API compatibility headers.
+### Builtin replacements
+
+For each Node.js builtin your code uses, install the matching `bare-*` module. The mapping table below covers the common ones; each is documented in its functional section above.
+
+### Shims, globals & polyfills
+
+[`bare-node`](https://github.com/holepunchto/bare-node) is the umbrella entry point that maps Node.js builtins and globals onto their Bare equivalents. The remaining modules below fill specific gaps.
+
+### Native addons
+
+Addons written against Node-API don't load directly; rebuild them against Bare's addon API, or use [`bare-compat-napi`](https://github.com/holepunchto/bare-compat-napi) for Node-API compatibility headers.
+
+### Web-standard APIs
 
 Several web-standard APIs a Node.js developer expects — [`bare-url`](https://github.com/holepunchto/bare-url) (WHATWG URL), [`bare-fetch`](https://github.com/holepunchto/bare-fetch) (WHATWG Fetch), [`bare-encoding`](https://github.com/holepunchto/bare-encoding) (text encoding), and [`bare-console`](https://github.com/holepunchto/bare-console) — are WHATWG implementations and live in the functional sections above rather than here.
-
-### Node.js builtin → Bare module
 
 | Node.js builtin | Bare module |
 | --- | --- |

--- a/content/reference/modules/bare-modules.mdx
+++ b/content/reference/modules/bare-modules.mdx
@@ -163,6 +163,48 @@ The sections below catalog the rest of the published `bare-*` modules. They're l
 
 ## Node.js compatibility
 
+Coming from Node.js, the surface looks familiar, but Bare's standard library is opt-in rather than built in (see [Inside Bare](/explanation/bare-runtime)). Porting is mostly a matter of installing the right modules:
+
+- **Builtin replacements** — for each Node.js builtin your code uses, install the matching `bare-*` module. The mapping table below covers the common ones; each is documented in its functional section above.
+- **Shims, globals & polyfills** — [`bare-node`](https://github.com/holepunchto/bare-node) is the umbrella entry point that maps Node.js builtins and globals onto their Bare equivalents. The remaining modules below fill specific gaps.
+- **Native addons** — addons written against Node-API don't load directly; rebuild them against Bare's addon API, or use [`bare-compat-napi`](https://github.com/holepunchto/bare-compat-napi) for Node-API compatibility headers.
+
+Several web-standard APIs a Node.js developer expects — [`bare-url`](https://github.com/holepunchto/bare-url) (WHATWG URL), [`bare-fetch`](https://github.com/holepunchto/bare-fetch) (WHATWG Fetch), [`bare-encoding`](https://github.com/holepunchto/bare-encoding) (text encoding), and [`bare-console`](https://github.com/holepunchto/bare-console) — are WHATWG implementations and live in the functional sections above rather than here.
+
+### Node.js builtin → Bare module
+
+| Node.js builtin | Bare module |
+| --- | --- |
+| `assert` | [bare-assert](https://github.com/holepunchto/bare-assert) |
+| `async_hooks` | [bare-async-hooks](https://github.com/holepunchto/bare-async-hooks) |
+| `buffer` | [bare-buffer](https://github.com/holepunchto/bare-buffer) |
+| `child_process` | [bare-subprocess](https://github.com/holepunchto/bare-subprocess) |
+| `console` | [bare-console](https://github.com/holepunchto/bare-console) |
+| `crypto` | [bare-crypto](https://github.com/holepunchto/bare-crypto) |
+| `dgram` | [bare-dgram](https://github.com/holepunchto/bare-dgram) |
+| `dns` | [bare-dns](https://github.com/holepunchto/bare-dns) |
+| `events` | [bare-events](https://github.com/holepunchto/bare-events) |
+| `fs` | [bare-fs](https://github.com/holepunchto/bare-fs) |
+| `http` | [bare-http1](https://github.com/holepunchto/bare-http1) |
+| `https` | [bare-https](https://github.com/holepunchto/bare-https) |
+| `net` | [bare-net](https://github.com/holepunchto/bare-net) / [bare-tcp](https://github.com/holepunchto/bare-tcp) |
+| `os` | [bare-os](https://github.com/holepunchto/bare-os) |
+| `path` | [bare-path](https://github.com/holepunchto/bare-path) |
+| `process` | [bare-process](https://github.com/holepunchto/bare-process) |
+| `querystring` | [bare-querystring](https://github.com/holepunchto/bare-querystring) |
+| `readline` | [bare-readline](https://github.com/holepunchto/bare-readline) |
+| `stream` | [bare-stream](https://github.com/holepunchto/bare-stream) |
+| `string_decoder` | [bare-string-decoder](https://github.com/holepunchto/bare-string-decoder) |
+| `timers` | [bare-timers](https://github.com/holepunchto/bare-timers) |
+| `tls` | [bare-tls](https://github.com/holepunchto/bare-tls) |
+| `tty` | [bare-tty](https://github.com/holepunchto/bare-tty) |
+| `url` | [bare-url](https://github.com/holepunchto/bare-url) |
+| `vm` | [bare-vm](https://github.com/holepunchto/bare-vm) |
+| `worker_threads` | [bare-worker](https://github.com/holepunchto/bare-worker) |
+| `zlib` | [bare-zlib](https://github.com/holepunchto/bare-zlib) |
+
+### Shims & compatibility layers
+
 Shims and compatibility layers that map Node.js APIs and globals onto Bare. See also [`bare-node`](https://github.com/holepunchto/bare-node) as the umbrella entry point.
 
 | Module | Description |


### PR DESCRIPTION
## Summary

Improves the Bare ↔ Node.js compatibility story, which was previously accurate but scattered across three pages with no single "what replaces Node's `X`?" reference.

- **`bare-modules.mdx`** — adds a **`Node.js builtin → Bare module` mapping table** (26 rows: `fs`→`bare-fs`, `crypto`→`bare-crypto`, `child_process`→`bare-subprocess`, `worker_threads`→`bare-worker`, …), splits the existing shims under a "Shims & compatibility layers" subsection, and notes the WHATWG modules (`bare-url`/`bare-fetch`/`bare-encoding`/`bare-console`) that live in the functional sections rather than here.
- **`bare-runtime.mdx`** — the npm-modules FAQ now points to [`bare-compat-napi`](https://github.com/holepunchto/bare-compat-napi) for Node-API addons (previously implied N-API was a dead end) and links to the new mapping section.
- **`runtime-and-languages.mdx`** — the "coming from Node.js" note now links to the mapping table, giving the three pages a consistent entry point.

## Why

A reader porting from Node.js couldn't answer "what replaces `fs`/`crypto`/`child_process`?" from any single page — the builtin replacements were filed by function (Networking, Data, …) while the "Node.js compatibility" section listed only shims/polyfills. The new table consolidates that.

## Verification

- `fumadocs-mdx` compiles all three files with no errors.
- Both changed pages render locally (HTTP 200); the new `#nodejs-compatibility` heading id and the cross-page anchor link resolve correctly (slug confirmed via `github-slugger`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)