### PR TITLE
docs: rename "the Pears stack" to "the Pear stack"

### DIFF
--- a/content/explanation/bare-on-native.mdx
+++ b/content/explanation/bare-on-native.mdx
@@ -9,7 +9,7 @@ A peer-to-peer app has two very different halves.
 1. One is the **core**: swarm identity, storage, replication, and the protocol logic—code that should be identical on every device.
 2. The other is the **UI**: windows, views, and gestures—code that is necessarily different on a desktop, a phone, and a terminal.
 
-Bare's answer is to keep the core in one place and let only the UI change. This page explains that pattern and the machinery that connects the two halves. For the runtime itself, see [Inside Bare](/explanation/bare-runtime); for where this sits in the wider picture, see [The Pears stack](/explanation/the-pears-stack).
+Bare's answer is to keep the core in one place and let only the UI change. This page explains that pattern and the machinery that connects the two halves. For the runtime itself, see [Inside Bare](/explanation/bare-runtime); for where this sits in the wider picture, see [The Pear stack](/explanation/the-pear-stack).
 
 ## The shape: shell, seam, core
 

--- a/content/explanation/bare-runtime.mdx
+++ b/content/explanation/bare-runtime.mdx
@@ -9,7 +9,7 @@ schemaType: WebPage
 
 <Callout type="info">
 - For the exact API, see the [`Bare` runtime reference](/reference/bare/runtime).
-- For where Bare sits relative to Pear, see [The Pears stack](/explanation/the-pears-stack).
+- For where Bare sits relative to Pear, see [The Pear stack](/explanation/the-pear-stack).
 </Callout>
 
 ## What Bare adds, and what it leaves out
@@ -82,4 +82,4 @@ It depends on the build. Bare talks to the engine through the `libjs` ABI, so it
 - [One core, many platforms](/explanation/bare-on-native)—embedding the runtime in native and mobile apps.
 - [Handle app suspension](/how-to/run-on-native/handle-app-suspension)—stop all I/O on `suspend` or the OS will force-terminate the app.
 - [Runtime and languages](/explanation/runtime-and-languages)—why Pear is JavaScript and how other languages plug in.
-- [The Pears stack](/explanation/the-pears-stack)—where the runtime sits relative to Pear.
+- [The Pear stack](/explanation/the-pear-stack)—where the runtime sits relative to Pear.

--- a/content/explanation/index.mdx
+++ b/content/explanation/index.mdx
@@ -15,7 +15,7 @@ Pages are grouped by topic and ordered roughly from foundational concepts to app
 
 ### Platform foundations
 
-- [The Pears stack](/explanation/the-pears-stack)—how Pear and Bare layer together, from the native C foundations up to the apps you run.
+- [The Pear stack](/explanation/the-pear-stack)—how Pear and Bare layer together, from the native C foundations up to the apps you run.
 - [Peer-to-peer, demystified](/explanation/peer-to-peer-demystified)—hole punching, public-key identity, and the roles of HyperDHT and Hyperswarm.
 - [Runtime and languages](/explanation/runtime-and-languages)—JavaScript on Bare, native addons for other languages, and the Pear-end pattern for cross-platform apps.
 - [Using Bare on its own](/explanation/use-bare-standalone)—the entry point for adopting Bare as a standalone runtime, without Pear's peer-to-peer platform.

--- a/content/explanation/runtime-and-languages.mdx
+++ b/content/explanation/runtime-and-languages.mdx
@@ -8,7 +8,7 @@ schemaType: WebPage
 Pear applications are JavaScript programs. The runtime under them is **[Bare](/explanation/bare-runtime)**, a small embeddable JavaScript runtime that strips the assumptions Node.js carries about being a server. This page explains why the language story looks the way it does, how non-JavaScript code joins in, and what the recommended app shape is when you want one codebase to run on desktop, mobile, and terminal. 
 
 <Callout type="info">
-For where Bare sits relative to Pear, see [The Pears stack](/explanation/the-pears-stack).
+For where Bare sits relative to Pear, see [The Pear stack](/explanation/the-pear-stack).
 </Callout>
 
 ## Why JavaScript
@@ -50,7 +50,7 @@ See [Workers](/explanation/workers) for the pattern in full—what crosses the I
 
 ## See also
 
-- [The Pears stack](/explanation/the-pears-stack)—the full layering, from native C foundations up to apps.
+- [The Pear stack](/explanation/the-pear-stack)—the full layering, from native C foundations up to apps.
 - [Inside Bare](/explanation/bare-runtime)—what the runtime adds, its lifecycle, and why it's minimal.
 - [One core, many platforms](/explanation/bare-on-native)—running the Pear-end in a worklet behind a typed RPC seam.
 - [Workers](/explanation/workers)—the host-and-worker split this page calls the "Pear-end."

--- a/content/explanation/the-pear-stack.mdx
+++ b/content/explanation/the-pear-stack.mdx
@@ -1,11 +1,11 @@
 ---
-title: "The Pears stack"
+title: "The Pear stack"
 description: "How Pear and Bare fit together—from the native C foundations up through the Bare runtime, the peer-to-peer building blocks, and the Pear platform to the apps people run."
 docType: explanation
 schemaType: WebPage
 ---
 
-Pear is the platform people see: a runtime, a CLI, and over-the-air updates for peer-to-peer apps. [Bare](/explanation/bare-runtime) is the engine underneath it. They're often named together—"the Pears stack"—but they sit at different layers, and knowing which layer you're working at makes the rest of these docs easier to navigate.
+Pear is the platform people see: a runtime, a CLI, and over-the-air updates for peer-to-peer apps. [Bare](/explanation/bare-runtime) is the engine underneath it. They're often named together—"the Pear stack"—but they sit at different layers, and knowing which layer you're working at makes the rest of these docs easier to navigate.
 
 This page lays out the whole stack, bottom to top, and shows where each library you'll meet elsewhere belongs.
 

--- a/content/explanation/use-bare-standalone.mdx
+++ b/content/explanation/use-bare-standalone.mdx
@@ -15,7 +15,7 @@ Use standalone Bare when you want:
 - **A modular Node.js alternative.** Bare is mobile-first and ships almost no standard library; you opt into only the [`bare-*` modules](/reference/modules/bare-modules) you actually use, keeping bundles small.
 - **A single standalone executable.** Compile a CLI, service, or daemon into one binary with no Node.js, Bare, or Pear install required on the user's machine.
 
-If instead you're building a peer-to-peer app—storage, replication, swarms, over-the-air updates—start with Pear rather than Bare directly: [Getting started](/getting-started) and [The Pears stack](/explanation/the-pears-stack) show how Bare fits underneath it.
+If instead you're building a peer-to-peer app—storage, replication, swarms, over-the-air updates—start with Pear rather than Bare directly: [Getting started](/getting-started) and [The Pear stack](/explanation/the-pear-stack) show how Bare fits underneath it.
 
 ## The runtime-only path
 
@@ -39,4 +39,4 @@ If instead you're building a peer-to-peer app—storage, replication, swarms, ov
 
 ## Where Bare and Pear meet
 
-Even used on its own, Bare shares an ecosystem with Pear. The peer-to-peer [building blocks](/reference/building-blocks/hypercore) are ordinary JavaScript modules that run on Bare, and tools like [`compact-encoding`](/reference/helpers/compact-encoding) and `hyperschema` are used on both sides. So if a standalone Bare app later grows peer-to-peer features, the same core moves onto Pear unchanged—see [The Pears stack](/explanation/the-pears-stack).
+Even used on its own, Bare shares an ecosystem with Pear. The peer-to-peer [building blocks](/reference/building-blocks/hypercore) are ordinary JavaScript modules that run on Bare, and tools like [`compact-encoding`](/reference/helpers/compact-encoding) and `hyperschema` are used on both sides. So if a standalone Bare app later grows peer-to-peer features, the same core moves onto Pear unchanged—see [The Pear stack](/explanation/the-pear-stack).

--- a/content/getting-started/from-a-template/start-from-hello-pear-bare.mdx
+++ b/content/getting-started/from-a-template/start-from-hello-pear-bare.mdx
@@ -178,7 +178,7 @@ Before you ship, set your identity in `package.json`:
 - [Start from a template](/getting-started/from-a-template)—both boilerplates, side by side.
 - [Start from the hello-pear-electron template](/getting-started/from-a-template/start-from-hello-pear-electron)—the desktop counterpart, with a renderer, preload bridge, and Bare worker.
 - [Inside Bare](/explanation/bare-runtime)—what the runtime this template builds on actually is, and its lifecycle.
-- [The Pears stack](/explanation/the-pears-stack)—where Bare and Pear sit relative to each other.
+- [The Pear stack](/explanation/the-pear-stack)—where Bare and Pear sit relative to each other.
 - [Runtime and languages](/explanation/runtime-and-languages)—where Bare fits among Pear's runtimes.
 - [Bundle a Bare app](/how-to/run-on-native/bundle-a-bare-app)—the `bare-pack` and `bare-build` paths behind `npm run make`.
 - [Bare modules](/reference/modules/bare-modules)—the Bare standard library this template builds on.

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -44,7 +44,7 @@ Prefer to start from a finished project? [**Start from the `hello-pear-electron`
 
 ### About Pear—_understand this_
 
-Conceptual background on Pear's design—[the Pears stack](/explanation/the-pears-stack), [runtime and languages](/explanation/runtime-and-languages), [storage and distribution](/explanation/storage-and-distribution), and [dependencies on the network](/explanation/dependencies-and-network). Use this when you want to know _why_, not _how_.
+Conceptual background on Pear's design—[the Pear stack](/explanation/the-pear-stack), [runtime and languages](/explanation/runtime-and-languages), [storage and distribution](/explanation/storage-and-distribution), and [dependencies on the network](/explanation/dependencies-and-network). Use this when you want to know _why_, not _how_.
 
 [**About Pear →**](/explanation)
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -75,6 +75,8 @@ const config = {
       { source: '/building-blocks/:slug', destination: '/reference/building-blocks/:slug', permanent: true },
       { source: '/helpers/:slug', destination: '/reference/helpers/:slug', permanent: true },
       { source: '/tools/:slug', destination: '/reference/tools/:slug', permanent: true },
+      // "The Pears stack" was renamed "The Pear stack"; the slug moved too.
+      { source: '/explanation/the-pears-stack', destination: '/explanation/the-pear-stack', permanent: true },
     ];
   },
 };

--- a/scripts/redirects.ts
+++ b/scripts/redirects.ts
@@ -247,6 +247,10 @@ export function buildRedirects(contentRoot = 'content'): Redirect[] {
   out.push({ from: '/guide/debugging-a-pear-terminal-app/', to: '/how-to/troubleshooting/' });
   out.push({ from: '/guide/creating-a-pear-init-template/', to: '/reference/pear/cli/' });
 
+  // "The Pears stack" was renamed "The Pear stack" to drop the pluralised
+  // brand term; the slug moved with it.
+  out.push({ from: '/explanation/the-pears-stack/', to: '/explanation/the-pear-stack/' });
+
   out.sort((a, b) => a.from.localeCompare(b.from));
   return out;
 }

--- a/src/lib/custom-tree.ts
+++ b/src/lib/custom-tree.ts
@@ -71,8 +71,8 @@ export const customTree: Node[] = [
         children: [
           {
             type: 'page',
-            name: 'The Pears stack',
-            url: '/explanation/the-pears-stack',
+            name: 'The Pear stack',
+            url: '/explanation/the-pear-stack',
           },
           {
             type: 'page',


### PR DESCRIPTION
## What & why

Move away from the pluralised **Pears** brand term in the docs — the platform is called **Pear**. Requested off the back of the [the-pears-stack explanation page](https://docs.pears.com/explanation/the-pears-stack/).

## Changes

- **Renamed the page** `content/explanation/the-pears-stack.mdx` → `the-pear-stack.mdx` (via `git mv`, history preserved), updating its `title` and prose.
- **Updated the term + link URL** in every reference — display text `The Pears stack` → `The Pear stack` and the slug `/explanation/the-pears-stack` → `/explanation/the-pear-stack`: `content/index.mdx`, `explanation/{index,runtime-and-languages,bare-on-native,bare-runtime,use-bare-standalone}.mdx`, `getting-started/from-a-template/start-from-hello-pear-bare.mdx`, and the sidebar nav in `src/lib/custom-tree.ts`.
- **Added a 308 redirect** for the old URL in both the production source of truth (`scripts/redirects.ts`) and the `next dev` mirror (`next.config.mjs`).

## Deliberately left untouched

- **Domains** — `pears.com`, `pass.pears.com`, `docs.pears.com` are real URLs.
- **Flatpak IDs** — `com.pears.HelloPear` are real package identifiers.
- **`dict.json`** — Webster's dictionary data (the fruit "Pears"), not the brand.

## Verification

- `npm run check:internal-links` → ✅ all links resolve (confirms the slug rename left nothing broken).
- `check:redirects` passes after a fresh `next build` regenerates the redirect stubs in `out/` (the checker runs against build artifacts, so it must run post-build — as CI does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)