### PR TITLE
docs(cli): drop dead keet alias and sync v3 flags

### DIFF
--- a/content/explanation/storage-and-distribution.mdx
+++ b/content/explanation/storage-and-distribution.mdx
@@ -80,8 +80,8 @@ That runtime capability has been unbundled from the CLI: `pear run` was **remove
 Installing replaces "run from a link" with a first-class on-disk install. [`pear install pear://<key>`](/reference/pear/cli#pear-install) pulls an application built with [`pear build`](https://github.com/holepunchto/hello-pear-electron#deploying) from the swarm and sets it up locally, the same way the platform binary arrives—there is still no download server, only peers. The command works for both applications and standalone binaries.
 
 ```bash
-# install Keet peer-to-peer
-pear install pear://keet
+# install an application peer-to-peer
+pear install pear://<key>
 ```
 
 <Callout type="info">

--- a/content/reference/pear/api.mdx
+++ b/content/reference/pear/api.mdx
@@ -59,7 +59,7 @@ The application version consists of `Pear.app.key`, `Pear.app.length` and `Pear.
 **REMOVED**
 
 Given an application that is run from a pear:// link with an alias it, contains that alias.
-For example the `Pear.app.alias` for `pear run pear://keet` would be `keet`.
+For example the `Pear.app.alias` for `pear run pear://myapp` would be `myapp`.
 
 #### `Pear.app.dev <Boolean>`
 <a name="pear-app-dev"></a>

--- a/content/reference/pear/cli.mdx
+++ b/content/reference/pear/cli.mdx
@@ -142,6 +142,8 @@ Production signing coordination. Gate production releases behind a quorum of sig
 ```
   --config [./pear.json]        Config file path
   --peer-update-timeout <ms>    Peer update timeout in ms (request, verify, commit)
+  --vanity <vanity>             Vanity link prefix (link)
+  --force                       Skip sanity checks (request)
   --json                        Newline delimited JSON output
   --help|-h                     Show help
 ```
@@ -227,10 +229,10 @@ Synchronize files from link to dir.
 To dump to stdout, use `-` in place of `<dir>`.
 </Callout>
 
-`<link>` can contain a path portion to dump a subset of the files for the Pear application. For example, to dump only the `CHANGELOG.md` from Keet into a `dump-dir` directory run:
+`<link>` can contain a path portion to dump a subset of the files for the Pear application. For example, to dump only the `CHANGELOG.md` from an application into a `dump-dir` directory run:
 
 ```
-pear dump pear://keet/CHANGELOG.md dump-dir/
+pear dump pear://<key>/CHANGELOG.md dump-dir/
 ```
 
 ```
@@ -254,8 +256,9 @@ pear dump pear://keet/CHANGELOG.md dump-dir/
 Creates a Pear link. Pear links hold a key, this is the basis for application discovery.
 
 ```
-  --json      Newline delimited JSON output
-  --help|-h   Show help
+  --vanity <vanity>   Generate a vanity link with this prefix
+  --json              Newline delimited JSON output
+  --help|-h           Show help
 ```
 
 ## `pear sidecar [command]`
@@ -400,10 +403,10 @@ Install a Pear application—or the Pear platform itself—from a `pear://` link
 ```
 
 <Callout type="info">
-As of Pear v3, `pear install` is part of the Pear CLI, provided by the standalone [`pear-install`](https://www.npmjs.com/package/pear-install) module. For example, install Keet peer-to-peer with:
+As of Pear v3, `pear install` is part of the Pear CLI, provided by the standalone [`pear-install`](https://www.npmjs.com/package/pear-install) module. For example, install an application peer-to-peer with:
 
 ```
-pear install pear://keet
+pear install pear://<key>
 ```
 
 See [Storage and distribution](/explanation/storage-and-distribution#installing-applications) for the install model and the direction described in [Pear Evolution](https://pears.com/news/pear-evolution/).


### PR DESCRIPTION
## What

Fixes broken `keet`-alias examples in the docs and brings the CLI reference fully in sync with the Pear v3 source.

### Dead `keet` alias
The `keet` alias no longer resolves, so these examples were broken. Replaced with the `pear://<key>` placeholder form used elsewhere in the docs:
- `pear dump pear://keet/CHANGELOG.md dump-dir/` → `pear dump pear://<key>/CHANGELOG.md dump-dir/`
- `pear install pear://keet` → `pear install pear://<key>` (in both the CLI reference and the storage-and-distribution explanation)
- `reference/pear/api.mdx` `Pear.app.alias` example → illustrative `myapp` alias (this is a removed-API historical note, so an example alias is appropriate)

This clears the last `keet` alias reference in the docs.

### v3 flag sync
Audited the full CLI reference against the v3 source (`holepunchto/pear` `cmd/index.js`, plus the `pear-install`/`pear-build` command definitions). Added three flags that were missing:
- `pear touch --vanity <vanity>`
- `pear multisig link --vanity <vanity>`
- `pear multisig request --force` (Skip sanity checks)

## Audit result
The rest of the reference is accurate for v3:
- All 15 active commands documented; all 6 removed commands correctly badged with migration guidance.
- `build` and `install` flag lists match their source modules exactly.
- No stale entries (nothing documented that v3 has dropped); hidden flags correctly omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)