### PR TITLE
docs: correct stale pear v3 CLI output samples, flags, and commands

### DIFF
--- a/content/getting-started/build-a-peer-to-peer-chat/ship.mdx
+++ b/content/getting-started/build-a-peer-to-peer-chat/ship.mdx
@@ -61,7 +61,7 @@ pear touch
 ```
 
 <Callout type="warning">
-Stage and provision only work against links you **own**—ones you minted on this machine with `pear touch`. If you stage to someone else's link (for example the public placeholder from part 2), `pear stage --dry-run` prints `🍐 Staging null` with an empty diff and `pear provision` has nothing to sync. Always use the link `pear touch` just printed.
+Stage and provision only work against links you **own**—ones you minted on this machine with `pear touch`. If you stage to someone else's link (for example the public placeholder from part 2), `pear stage` prints the header and then fails with `✖ Destination must be writable`. Always use the link `pear touch` just printed.
 </Callout>
 
 Point `package.json#upgrade` at the stage link for now—you will switch it to the **provision link** after the first provision:
@@ -75,15 +75,18 @@ Your output will be different.
 
 ```bash
 pear seed pear://<stage-link>
---------------------------------------------------------  
-Pear Link:     pear://<stage-link>
-Drive Key:     73d02bee8bb356402592cafe0bd9c993202742223943a830332d237fae2173b7 
-Discovery Key: 127512b795163f8c13aa3e718ef9995d40d2ae7533e485c2c363a92adb8c8a9c 
-Content Key:    
-Firewalled:    true 
-NAT Type:      Consistent 
-Network:       [ Peers: 0 ] [ ⬆ 0B - 0B/s ] [ ⬇ 0B - 0B/s] 
---------------------------------------------------------  
+
+Seeding:        pear://<stage-link>
+Drive Key:      <stage-key>
+Drive Length:   0
+Discovery Key:  qx138e5wnc3bmnjcbks68xpp17m6bj6h5165hud9ps4tr8zad4fo
+Content Key:    pending
+Firewalled:     true
+NAT Type:       consistent
+Whoami:         t8kgj1p3a4e9x8p1etsgks1rc4j58yu9xjh11bbjkgys7zkfmabo
+Network:        [ Peers 0 ]  [ ⬆ 0B - 0B/s ]  [ ⬇ 0B - 0B/s ]
+────────────────────────────────────────────────────────
+^_^ announced
 ```
 
 Leave `pear seed` running in its own terminal for the rest of the tutorial—without an active seeder, peers cannot download your build. 
@@ -246,26 +249,38 @@ pear stage --dry-run pear://<stage-link> ./pear-chat-1.0.1
 Your keys and byte counts will differ; the shape looks like this:
 
 ```text
-🍐 Staging pear://<stage-link>
-+ package.json                         2.1 kB
-+ electron/main.js                    12.4 kB
-+ workers/chat-room.js                 8.7 kB
-+ renderer/index.html                  3.2 kB
-+ by-arch/darwin-arm64/app/PearChat   48.2 MB
-  ... more files ...
-pear://0.<length>.<stage-key>
+🍐 Staging pear-chat
+
+[  pear://<stage-link>  ]
+pear://0.0.<stage-key>
+
+Current: 1
+
+NOTE: This is a dry run, no changes will be persisted.
+
++ /package.json (+2.1kB)
++ /by-arch/darwin-arm64/app/PearChat.app/Contents/Info.plist (+1.4kB)
++ /by-arch/darwin-arm64/app/PearChat.app/Contents/MacOS/PearChat (+55kB)
++ /by-arch/darwin-arm64/app/PearChat.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework (+165MB)
++ /by-arch/darwin-arm64/app/PearChat.app/Contents/Resources/app/electron/main.js (+12.4kB)
++ /by-arch/darwin-arm64/app/PearChat.app/Contents/Resources/app/workers/chat-room.js (+8.7kB)
++ /by-arch/darwin-arm64/app/PearChat.app/Contents/Resources/app/renderer/index.html (+3.2kB)
+  ... more files under /by-arch/ ...
+✔ Skipping (dry-run)
+
+Staging dry run complete!
 ```
 
 How to read it:
 
-- **`+` lines**—files that would be written or updated. Scan for surprises before you run without `--dry-run`.
-- **Last line**—a **versioned link** (`pear://0.<length>.<stage-key>`). The `<length>` is the Hypercore length after this stage; you need the full string for `pear provision` in the next step. On a first stage, `<length>` is usually a few hundred to a few thousand—not `0`.
+- **`+` lines**—files that would be written or updated, as `/`-prefixed drive paths with byte counts in parentheses. Scan for surprises before you run without `--dry-run`.
+- **Versioned link in the header**—the line under the bracketed stage link shows the drive at its **current** length. On a first stage nothing is staged yet, so it reads `pear://0.0.<stage-key>`. The versioned link you need for `pear provision` is printed by the real stage in the next step, after the sync actually happens.
 
 Look for:
 
-- Files you expect to ship—`electron/`, `workers/`, `renderer/`, `package.json`, `node_modules/...`.
+- Only two entries at the drive root—`/package.json` and `/by-arch/...`. That is everything `pear build` writes into the deployment directory. Your app source (`electron/`, `workers/`, `renderer/`, `node_modules/`) ships **inside** the packaged app—for example under `/by-arch/darwin-arm64/app/PearChat.app/Contents/Resources/app/`—never as loose files at the root.
 - No surprise additions—stray `.DS_Store`, editor swap files, secrets, the deployment directory itself.
-- Sensible byte counts—if a file is suddenly 100 MB, something is wrong.
+- Sensible byte counts—the Electron framework binary dominates (a hundred-plus MB per platform-arch); if an unrelated file is suddenly 100 MB, something is wrong.
 
 #### 2. Stage for real
 
@@ -275,28 +290,30 @@ If the diff looks right, drop the `--dry-run` flag and run it for real:
 pear stage pear://<stage-link> ./pear-chat-1.0.1
 ```
 
-The live output should match the dry-run diff. Copy the **versioned link**: `pear://0.<length>.<stage-key>`. It appears twice in the output; either copy works:
+The live output repeats the dry-run diff, then ends with the post-stage **versioned link** after the `^Latest:` line:
 
 ```text
 🍐 Staging pear-chat
 
 [  pear://<stage-link>  ]
-pear://0.<length>.<stage-key>
+pear://0.0.<stage-key>
 
-Current: <length>
-Release: 0 [UNRELEASED]
+Current: 1
 
-✔ Skipping warmup (no changes)
++ /package.json (+2.1kB)
+  ... same diff as the dry run ...
 
 Staging complete!
 
-^Latest: <length>
-Release: 0 [UNRELEASED]
+^Latest: 1426
 
 pear://0.1426.9mdt6h676phg7nuwp1urs7457nsz3juyeuqcbw4h7r1tqz8e84ay
+[  pear://<stage-link>  ]
 ```
 
-Use that full versioned string as the first argument to `pear provision` below (not the unversioned `<stage-link>` you passed to `pear stage`).
+Copy the versioned link printed under `^Latest:`—`pear://0.<length>.<stage-key>`, where `<length>` is the Hypercore length **after** this stage (a few hundred to a few thousand on a first stage). Don't copy the versioned link at the top of the output—that one shows the drive **before** staging (`pear://0.0.<stage-key>` on a first stage).
+
+Use the full versioned string as the first argument to `pear provision` below (not the unversioned `<stage-link>` you passed to `pear stage`).
 
 #### 3. Mint the provision link
 
@@ -333,16 +350,39 @@ Example with concrete keys (yours will differ):
 pear provision --dry-run pear://0.1426.9mdt6h676phg7nuwp1urs7457nsz3juyeuqcbw4h7r1tqz8e84ay pear://o11z79iogfzx1ckthrhwoeyk7pyxxhy7par4edq5sy1dmwieutso pear://0.0.o11z79iogfzx1ckthrhwoeyk7pyxxhy7par4edq5sy1dmwieutso
 ```
 
-Provision output is another file diff, then confirmation on the target link:
+Provision syncs the target, prints the same file diff you just staged plus a summary, and—on the real run—ends with the provisioned links. The dry run stops after `Dry Run Complete`; the real run pauses for a 10-second cooldown before writing:
 
 ```text
-🍐 Provisioning pear://0.1079.qxenz5... → pear://q9sopzoq...
-+ package.json                         2.1 kB
-  ... same files as stage ...
-pear://q9sopzoqgas9usoiq7uzkkwngm5pzj4zo3n4esjwwbmw6offis8o
+Syncing existing metadata, please wait...
+
+Completed metadata sync
+Checking diff
+
++ /package.json (+2.1kB)
+  ... same diff as the stage ...
+Diffing complete
+Total changes: 1425
+Package version: 1.0.1
+
+Core:
+  Key: o11z79iogfzx1ckthrhwoeyk7pyxxhy7par4edq5sy1dmwieutso
+  ...
+
+NOT A DRY RUN! Waiting 10s for certainty. Use ctrl+c to bail
+Staging to target...
+  ... same diff again ...
+
+Provisioned:
+  Verlink: pear://0.1426.o11z79iogfzx1ckthrhwoeyk7pyxxhy7par4edq5sy1dmwieutso
+
+  Hashlink: pear://0.1426.o11z79iogfzx1ckthrhwoeyk7pyxxhy7par4edq5sy1dmwieutso.<hash>
+
+Seed with:
+
+   pear seed pear://o11z79iogfzx1ckthrhwoeyk7pyxxhy7par4edq5sy1dmwieutso
 ```
 
-The diff should mirror what you just staged. The last line is the provision link peers will poll—set `upgrade` to that unversioned link, not the versioned stage link.
+The diff should mirror what you just staged. The `Seed with` line at the end names the unversioned provision link peers will poll—set `upgrade` to that link in the next step, not the versioned stage link.
 
 #### 5. Switch `upgrade` to the provision link
 

--- a/content/getting-started/build-a-peer-to-peer-chat/ship.mdx
+++ b/content/getting-started/build-a-peer-to-peer-chat/ship.mdx
@@ -307,7 +307,7 @@ Staging complete!
 
 ^Latest: 1426
 
-pear://0.1426.9mdt6h676phg7nuwp1urs7457nsz3juyeuqcbw4h7r1tqz8e84ay
+pear://0.1426.<stage-key>
 [  pear://<stage-link>  ]
 ```
 

--- a/content/getting-started/from-a-template/start-from-hello-pear-bare.mdx
+++ b/content/getting-started/from-a-template/start-from-hello-pear-bare.mdx
@@ -126,10 +126,10 @@ Build each platform's binary on a matching host.
 ## Install over the air
 
 Distribute the executable through the usual channels—a download on your website, `apt`, or Homebrew.
-You can also install it peer-to-peer: once your `upgrade` link is [seeding](/explanation/availability-and-blind-peering#seeding-with-pear-seed) a release, pull it directly with the preview [`pear install`](/reference/pear/cli#pear-install) command:
+You can also install it peer-to-peer: once your `upgrade` link is [seeding](/explanation/availability-and-blind-peering#seeding-with-pear-seed) a release, pull it directly with the [`pear install`](/reference/pear/cli#pear-install) command:
 
 ```bash
-npx pear-install pear://<key>
+pear install pear://<key>
 ```
 
 After the first install, new releases reach users through the swarm—no reinstall needed. For how staging and seeding work, see [Deploy your application](/how-to/operate-an-app/manual-deployment/deployment) and [Installing applications](/explanation/storage-and-distribution#installing-applications).

--- a/content/how-to/operate-an-app/manual-deployment/deployment.mdx
+++ b/content/how-to/operate-an-app/manual-deployment/deployment.mdx
@@ -159,7 +159,7 @@ The signature is:
 pear provision <versioned-source-link> <target-link> <versioned-production-link>
 ```
 
-A **versioned link** has the form `pear://<fork>.<length>.<key>`. Read the `<length>` from the most recent `pear stage` output line.
+A **versioned link** has the form `pear://<fork>.<length>.<key>`. Copy it from the most recent `pear stage` output—the link printed under the `^Latest:` line at the end (the versioned link at the top of the output shows the drive *before* that stage).
 
 The target link is a fresh `pear://` from step 0. While bootstrapping, set the third argument (the versioned production link) to `pear://0.0.<target-key>`; after a multisig drive exists, use `pear://<fork>.<length>.<multisig-key>` instead.
 

--- a/content/how-to/operate-an-app/manual-deployment/troubleshoot-desktop-releases.mdx
+++ b/content/how-to/operate-an-app/manual-deployment/troubleshoot-desktop-releases.mdx
@@ -17,14 +17,18 @@ An update will not apply unless `package.json` **`version`** changes. Use `npm v
 
 ### Advance the release pointer after `pear stage`
 
-`pear stage` writes new content into the Hypercore but does **not** move the `release` pointer that peers poll. The staging output reports both lengths:
+`pear stage` writes new content into the Hypercore but does **not** move the `release` pointer that peers poll. Staging ends by printing the new **`Latest`** length and the post-stage versioned link:
 
 ```text skip="sample-output"
-Latest: 1191
-Release: 1177
+Staging complete!
+
+^Latest: 1191
+
+pear://0.1191.<stage-key>
+[  pear://<stage-link>  ]
 ```
 
-If `Latest` is higher than `Release`, peers continue to fetch the older content. The single-key `pear release` command was **removed in Pear v3**—advance the pointer for a production release with [`pear provision`](/how-to/operate-an-app/manual-deployment/deployment#6-provision) followed by [`pear multisig`](/reference/pear/cli#pear-multisig) quorum cosigning, which manage the release pointer.
+The stage output does not show a release pointer, so a clean stage on its own never changes what peers already tracking the link fetch—they keep the previous release until the pointer advances. The single-key `pear release` command was **removed in Pear v3**—advance the pointer for a production release with [`pear provision`](/how-to/operate-an-app/manual-deployment/deployment#6-provision) followed by [`pear multisig`](/reference/pear/cli#pear-multisig) quorum cosigning, which manage the release pointer.
 
 ### Tune `PearRuntime` `delay` for live OTA visibility
 
@@ -161,7 +165,7 @@ If you have multiple Node versions installed, pin one for the project—for exam
 
 If the **deployment directory** (output of `pear build`) lives **inside** the application tree that gets staged, each stage can **re-include the previous deployment blob**, so diffs grow without bound.
 
-**Fix:** always emit `pear build` output **beside** the repo root (sibling `target` directory) or omit `--target` so the tool writes a versioned folder **outside** the app tree. Never run:
+**Fix:** always pass `--target` pointing to a sibling directory **beside** the app root. Note that omitting `--target` does **not** protect you: `pear build` then writes a `<name>-<version>` folder into the directory you run it *from*, so run it from a parent directory outside the app tree if you leave `--target` off. Never run:
 
 ```bash skip="signed-build"
 # Bad: target inside the app you are about to stage

--- a/content/how-to/operate-an-app/multisig/sign-with-multisig.mdx
+++ b/content/how-to/operate-an-app/multisig/sign-with-multisig.mdx
@@ -68,7 +68,7 @@ The commit is not safely finished until the new multisig drive's key is seeded b
 pear seed <multisig-link>
 ```
 
-Once the program detects that at least two seeders have fully downloaded the multisig drive, it is safe to stop it with `Ctrl+C`.
+`pear seed` shows replication activity rather than a completion signal: peer events (`o-o peer join`) and the upload totals in the `Network` row confirm other peers are pulling the drive. The commit itself prints `Waiting for remote seeders to pick up the changes...` and continues on its own once the drive is seeded. Keep seeding until peers have replicated, then stop it with `Ctrl+C`.
 
 <Callout type="warning">
 **Do not abort a running commit.** An interrupted commit leaves the production build in an intermediate state. See [Recover from an interrupted commit](/how-to/operate-an-app/multisig/troubleshoot-multisig#interrupted-or-aborted-commit) before retrying.

--- a/content/reference/pear/cli.mdx
+++ b/content/reference/pear/cli.mdx
@@ -142,7 +142,6 @@ Production signing coordination. Gate production releases behind a quorum of sig
 ```
   --config [./pear.json]        Config file path
   --peer-update-timeout <ms>    Peer update timeout in ms (request, verify, commit)
-  --vanity <vanity>             Vanity link prefix (link)
   --force                       Skip sanity checks (request)
   --json                        Newline delimited JSON output
   --help|-h                     Show help
@@ -256,7 +255,6 @@ pear dump pear://<key>/CHANGELOG.md dump-dir/
 Creates a Pear link. Pear links hold a key, this is the basis for application discovery.
 
 ```
-  --vanity <vanity>   Generate a vanity link with this prefix
   --json              Newline delimited JSON output
   --help|-h           Show help
 ```

--- a/content/reference/pear/cli.mdx
+++ b/content/reference/pear/cli.mdx
@@ -261,6 +261,10 @@ Creates a Pear link. Pear links hold a key, this is the basis for application di
   --help|-h           Show help
 ```
 
+<Callout type="info">
+`--vanity` is present on the `main` branch this page tracks but is not yet in the released `3.0.x` binary—`pear touch --help` on the installed CLI lists only `--json` and `--help`. It becomes available once the next runtime version ships.
+</Callout>
+
 ## `pear sidecar [command]`
 
 [Command source on GitHub](https://github.com/holepunchto/pear/blob/main/cmd/sidecar.js)
@@ -378,7 +382,7 @@ The database contains metadata stored on this device used by the Pear runtime.
 
 <Status level="removed" />
 
-`pear init` has been removed from the Pear CLI—it exits with `ERR_LEGACY: pear init has been removed`.
+`pear init` has been removed from the Pear CLI. Unlike `pear run` (which prints a dedicated removal message), `init` is no longer a recognized command, so it is rejected as an unknown argument—`✖ Unrecognized Argument at index 0 with value init`, followed by the top-level usage.
 
 <Callout type="info">
 To scaffold a project, clone the official template instead—[`holepunchto/hello-pear-electron`](https://github.com/holepunchto/hello-pear-electron)—and follow [Start from the hello-pear-electron template](/getting-started/from-a-template/start-from-hello-pear-electron).

--- a/content/reference/pear/cli.mdx
+++ b/content/reference/pear/cli.mdx
@@ -261,10 +261,6 @@ Creates a Pear link. Pear links hold a key, this is the basis for application di
   --help|-h           Show help
 ```
 
-<Callout type="info">
-`--vanity` is present on the `main` branch this page tracks but is not yet in the released `3.0.x` binary—`pear touch --help` on the installed CLI lists only `--json` and `--help`. It becomes available once the next runtime version ships.
-</Callout>
-
 ## `pear sidecar [command]`
 
 [Command source on GitHub](https://github.com/holepunchto/pear/blob/main/cmd/sidecar.js)

--- a/examples/getting-started/pear-chat/forge.config.js
+++ b/examples/getting-started/pear-chat/forge.config.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const path = require('path')
+const plink = require('pear-link')
 const pkg = require('./package.json')
 const appName = pkg.productName ?? pkg.name
 
@@ -115,6 +116,12 @@ module.exports = {
     readPackageJson: async (forgeConfig, packageJson) => {
       if (process.env.UPGRADE_KEY) {
         packageJson.upgrade = process.env.UPGRADE_KEY
+      }
+
+      try {
+        plink.parse(packageJson.upgrade)
+      } catch {
+        throw new Error('Use `pear touch` to get a valid upgrade key for package.json#upgrade')
       }
 
       return packageJson


### PR DESCRIPTION
Corrects documentation that showed **impossible or v2-era `pear` CLI output**. Every claim here was verified against a real `pear@3.0.0` run (throwaway `pear touch` links, a mock deployment directory) and the `pear`/`pear-build` source, then adversarially re-checked before landing.

## Why

`pear build` writes **only** `package.json` + `by-arch/<arch>/app/<AppName>.app/…` into the deployment directory. The getting-started tutorial's stage diff showed `electron/main.js`, `workers/chat-room.js`, `renderer/index.html` as loose files at the drive root — a layout `pear build` can never produce. Auditing that surfaced a cluster of related v2-era drift across the CLI reference and how-tos.

## Changes

**Getting started — ship.mdx** (`32bce2a`)
- Dry-run stage sample: real header + `NOTE:` line, `/`-prefixed drive paths with byte counts in parens, and **no** trailing versioned link (a dry run doesn't print one).
- Real stage sample: post-stage verlink under `^Latest:`; dropped the v2-only `Release: 0 [UNRELEASED]` and `✔ Skipping warmup` lines.
- Provision sample: real `Syncing… / Checking diff / Total changes / Core+Blobs / NOT A DRY RUN! Waiting 10s / Provisioned: Verlink+Hashlink / Seed with:` shape.
- `pear seed` sample: v3 table fields (`Seeding:`, `Drive Length:`, `Whoami:`, z-base-32 keys, `Content Key: pending`).
- Non-writable-link callout: v3 fails with `✖ Destination must be writable`, not "`Staging null` with an empty diff".

**CLI reference + how-tos + example** (`5ce2f9e`)
- **cli.mdx**: `pear init` has no handler, so it fails as `✖ Unrecognized Argument` — it does **not** emit `ERR_LEGACY: pear init has been removed` (only `pear run` gets a dedicated removal message). Corrected.
- **cli.mdx**: `--vanity` ships in no released 3.0.x binary, so it's **removed** from both the `pear touch` and `pear multisig` flag listings rather than shown as available. Verified against a clean `pear@3.0.0`: `pear touch --help` lists only `--json`/`--help` (and `pear touch --vanity` errors `✖ Unrecognized Flag`), and `pear multisig request --help` has `--force`/`--config`/`--peer-update-timeout` but no `--vanity`. The flag exists only on `main`. (`1d82987`, `c572c1b`)
- **deployment.mdx**: point at the `^Latest:` verlink explicitly (the top-of-output verlink is pre-stage).
- **start-from-hello-pear-bare.mdx**: `npx pear-install` → `pear install` (first-class v3 command; dropped "preview").
- **troubleshoot-desktop-releases.mdx**: stage output has no `Release:` line — replaced with the real `^Latest:` + verlink shape; and omitting `--target` does **not** write outside the app tree (`pear-build` resolves `<name>-<version>` against cwd), so corrected the size-growth guidance.
- **sign-with-multisig.mdx**: no "two seeders fully downloaded" detection exists — described the real signals (peer events + Network upload totals; commit prints `Waiting for remote seeders…`).
- **examples/getting-started/pear-chat/forge.config.js**: sync the `readPackageJson` hook with upstream `hello-pear-electron` — validate `package.json#upgrade` via `plink.parse` (`pear-link` resolves transitively per the lockfile).

## Notes
- Independent of #322, though the two PRs share three files—`cli.mdx`, `ship.mdx`, and `deployment.mdx`—each edited in non-overlapping sections (#322: the `pear changelog` block, a `ship.mdx` "See also" bullet, and a `deployment.mdx` related-links bullet; this PR: `pear init`/`pear touch`/`--vanity`, the stage/seed/provision samples, and the versioned-link guidance), so they merge in either order without conflict. `cli.mdx` is additionally touched by #325 (the Install & upgrade section), also non-overlapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

