### PR TITLE
docs: reference install.pears.com as the primary Pear install path

### DIFF
--- a/content/getting-started/index.mdx
+++ b/content/getting-started/index.mdx
@@ -16,7 +16,7 @@ There are two ways in. Start from the finished template and learn your way aroun
 
 Get the [`pear`](/reference/pear/cli) CLI from **[install.pears.com](https://install.pears.com)**:
 
-<Tabs items={['curl (macOS / Linux)', 'irm (Windows)', 'npx']}>
+<Tabs items={['curl (macOS / Linux)', 'irm (Windows)', 'npx', 'docker']}>
 <Tab value="curl (macOS / Linux)">
 ```sh
 curl https://install.pears.com/pear.sh | sh
@@ -32,9 +32,14 @@ irm https://install.pears.com/pear.ps1 | iex
 npx pear
 ```
 </Tab>
+<Tab value="docker">
+```sh
+docker run -it --rm tetherto/pear
+```
+</Tab>
 </Tabs>
 
-Follow the `PATH` instructions the installer prints, then run `pear` directly. See [Install & upgrade](/reference/pear/cli#install) for the npm-global alternative and upgrade details.
+Follow the `PATH` instructions the installer prints, then run `pear` directly. See [Install & upgrade](/reference/pear/cli#install) for the npm-global alternative and upgrade details. The [`tetherto/pear`](https://hub.docker.com/r/tetherto/pear) image runs Pear inside Ubuntu with `pear` and `pear-install` ready to go—handy for trying this walkthrough without installing anything locally.
 
 ## Start from a template
 

--- a/content/getting-started/index.mdx
+++ b/content/getting-started/index.mdx
@@ -6,10 +6,35 @@ schemaType: TechArticle
 ---
 
 import { Cards, Card } from 'fumadocs-ui/components/card'
+import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
 
 Build a peer-to-peer desktop chat app with [Pear](https://docs.pears.com), then evolve it into the same shape as the official [`hello-pear-electron`](https://github.com/holepunchto/hello-pear-electron) template, and finally release it over the air.
 
 There are two ways in. Start from the finished template and learn your way around it, or build the same app up from scratch across a four-part path.
+
+## Install Pear
+
+Get the [`pear`](/reference/pear/cli) CLI from **[install.pears.com](https://install.pears.com)**:
+
+<Tabs items={['curl (macOS / Linux)', 'irm (Windows)', 'npx']}>
+<Tab value="curl (macOS / Linux)">
+```sh
+curl https://install.pears.com/pear.sh | sh
+```
+</Tab>
+<Tab value="irm (Windows)">
+```powershell
+irm https://install.pears.com/pear.ps1 | iex
+```
+</Tab>
+<Tab value="npx">
+```sh
+npx pear
+```
+</Tab>
+</Tabs>
+
+Follow the `PATH` instructions the installer prints, then run `pear` directly. See [Install & upgrade](/reference/pear/cli#install) for the npm-global alternative and upgrade details.
 
 ## Start from a template
 
@@ -79,7 +104,7 @@ Each part adds one layer to that picture:
 - [Node.js](https://nodejs.org/) v22.17 or newer and npm v10.9 or newer
 - A POSIX-style terminal (macOS, Linux, or Windows with WSL)
 - An IDE or text editor
-- The [`pear`](/reference/pear/cli) CLI (`npx pear`)—only required for parts 3 and 4 (shipping and updating)
+- The [`pear`](/reference/pear/cli) CLI—[install it above](#install-pear); only required for parts 3 and 4 (shipping and updating)
 
 Each part lists any extra npm packages it adds.
 

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -4,11 +4,38 @@ description: Pear loads applications remotely from peers and lets anyone create 
 docType: page
 schemaType: WebPage
 ---
+
+import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
+
 Pear is an installable peer-to-peer runtime, development, and deployment platform. Build, share, and extend unstoppable, zero-infrastructure P2P apps for mobile, desktop, and terminal.
 
 Welcome to the Internet of Peers.
 
 &nbsp; _– Holepunch, the P2P Company_
+
+## Install Pear
+
+Get the [`pear`](/reference/pear/cli) CLI from **[install.pears.com](https://install.pears.com)**:
+
+<Tabs items={['curl (macOS / Linux)', 'irm (Windows)', 'npx']}>
+<Tab value="curl (macOS / Linux)">
+```sh
+curl https://install.pears.com/pear.sh | sh
+```
+</Tab>
+<Tab value="irm (Windows)">
+```powershell
+irm https://install.pears.com/pear.ps1 | iex
+```
+</Tab>
+<Tab value="npx">
+```sh
+npx pear
+```
+</Tab>
+</Tabs>
+
+Follow the `PATH` instructions the installer prints, then run `pear` directly. Full details, upgrade instructions, and the npm-global alternative are on [Install & upgrade](/reference/pear/cli#install).
 
 ## Showcase
 

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -17,7 +17,7 @@ Welcome to the Internet of Peers.
 
 Get the [`pear`](/reference/pear/cli) CLI from **[install.pears.com](https://install.pears.com)**:
 
-<Tabs items={['curl (macOS / Linux)', 'irm (Windows)', 'npx']}>
+<Tabs items={['curl (macOS / Linux)', 'irm (Windows)', 'npx', 'docker']}>
 <Tab value="curl (macOS / Linux)">
 ```sh
 curl https://install.pears.com/pear.sh | sh
@@ -33,9 +33,14 @@ irm https://install.pears.com/pear.ps1 | iex
 npx pear
 ```
 </Tab>
+<Tab value="docker">
+```sh
+docker run -it --rm tetherto/pear
+```
+</Tab>
 </Tabs>
 
-Follow the `PATH` instructions the installer prints, then run `pear` directly. Full details, upgrade instructions, and the npm-global alternative are on [Install & upgrade](/reference/pear/cli#install).
+Follow the `PATH` instructions the installer prints, then run `pear` directly. Full details, upgrade instructions, and the npm-global alternative are on [Install & upgrade](/reference/pear/cli#install). The [`tetherto/pear`](https://hub.docker.com/r/tetherto/pear) image runs Pear inside Ubuntu with `pear` and `pear-install` ready to go—a low-risk way to try out Pear apps without installing anything locally.
 
 ## Showcase
 

--- a/content/reference/pear/cli.mdx
+++ b/content/reference/pear/cli.mdx
@@ -22,7 +22,7 @@ This page tracks **Pear v3**. Several commands were removed in v3—most notably
 
 The fastest way to install Pear is the installer at **[install.pears.com](https://install.pears.com)**—it also works via `npx` if you'd rather go through npm:
 
-<Tabs items={['curl (macOS / Linux)', 'irm (Windows)', 'npx']}>
+<Tabs items={['curl (macOS / Linux)', 'irm (Windows)', 'npx', 'docker']}>
 <Tab value="curl (macOS / Linux)">
 ```sh
 curl https://install.pears.com/pear.sh | sh
@@ -38,9 +38,16 @@ irm https://install.pears.com/pear.ps1 | iex
 npx pear
 ```
 </Tab>
+<Tab value="docker">
+```sh
+docker run -it --rm tetherto/pear
+```
+</Tab>
 </Tabs>
 
 This bootstraps Pear onto the system. Complete the setup by following the `PATH` instructions the installer prints, then run `pear` directly. To install it globally through npm instead, use `npm i -g pear`—and every `pear <cmd>` also works as `npx pear <cmd>`, which is handy for running commands from a directory other than the one you installed into. npm and Node.js are only the delivery mechanism: after install, `pear` runs on [Bare](/reference/bare/runtime), not Node.
+
+The [`tetherto/pear`](https://hub.docker.com/r/tetherto/pear) Docker image runs Pear inside Ubuntu 24.04 with `pear` and `pear-install` ready to go—a low-risk way to try out Pear apps without installing anything on the host.
 
 ### Moving from Pear v2 to v3
 

--- a/content/reference/pear/cli.mdx
+++ b/content/reference/pear/cli.mdx
@@ -5,6 +5,8 @@ docType: reference
 schemaType: APIReference
 ---
 
+import { Tabs, Tab } from 'fumadocs-ui/components/tabs'
+
 {/* Maintainer note: "Command source on GitHub" links point at the `main` branch because Pear v3 is not yet tagged. Re-pin them to the v3 tag (for example /blob/v3.x.x/) once it ships. */}
 
 <Status level="stable" />
@@ -18,13 +20,27 @@ This page tracks **Pear v3**. Several commands were removed in v3—most notably
 ## Install & upgrade
 <a name="install"></a>
 
-Install the Pear platform with [`npx`](https://docs.npmjs.com/cli/commands/npx):
+The fastest way to install Pear is the installer at **[install.pears.com](https://install.pears.com)**—it also works via `npx` if you'd rather go through npm:
 
+<Tabs items={['curl (macOS / Linux)', 'irm (Windows)', 'npx']}>
+<Tab value="curl (macOS / Linux)">
+```sh
+curl https://install.pears.com/pear.sh | sh
+```
+</Tab>
+<Tab value="irm (Windows)">
+```powershell
+irm https://install.pears.com/pear.ps1 | iex
+```
+</Tab>
+<Tab value="npx">
 ```sh
 npx pear
 ```
+</Tab>
+</Tabs>
 
-This bootstraps Pear onto the system. Complete the setup by following the `PATH` instructions the `npx pear` command prints, then run `pear` directly. To install it globally instead, use `npm i -g pear`—and every `pear <cmd>` also works as `npx pear <cmd>`, which is handy for running commands from a directory other than the one you installed into. npm and Node.js are only the delivery mechanism: after install, `pear` runs on [Bare](/reference/bare/runtime), not Node.
+This bootstraps Pear onto the system. Complete the setup by following the `PATH` instructions the installer prints, then run `pear` directly. To install it globally through npm instead, use `npm i -g pear`—and every `pear <cmd>` also works as `npx pear <cmd>`, which is handy for running commands from a directory other than the one you installed into. npm and Node.js are only the delivery mechanism: after install, `pear` runs on [Bare](/reference/bare/runtime), not Node.
 
 ### Moving from Pear v2 to v3
 


### PR DESCRIPTION
## Summary
- Add an "Install Pear" section to the homepage (primary position, right after the intro) linking install.pears.com with curl/irm/npx setup commands
- Add the same section to the Getting Started page, and point the "Before you start" CLI bullet at it
- Lead the CLI reference's Install & upgrade section with install.pears.com, keeping `npm i -g pear` as the documented alternative

## Test plan
- [x] Ran the dev server and visually verified all three pages render correctly
- [x] Verified the curl/irm/npx tab switching works on each page
- [x] Verified internal links (`/reference/pear/cli#install`, `#install-pear` anchors) resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)