### PR TITLE
docs: refer to the platform as "Pear", not "Pear by Holepunch"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pear Docs
 
-Official documentation for the [Pear](https://pears.com) platform by Holepunch.
+Official documentation for the [Pear](https://pears.com) platform.
 
 * Source code and content of the docs website.
 * Automation scripts for link checking and documentation quality.

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Pear by Holepunch
+title: Pear
 description: Pear loads applications remotely from peers and lets anyone create and share applications with peers.
 docType: page
 schemaType: WebPage

--- a/src/lib/custom-tree.ts
+++ b/src/lib/custom-tree.ts
@@ -17,7 +17,7 @@ import type { Node } from 'fumadocs-core/page-tree';
  *     the site's `trailingSlash` mode.
  */
 export const customTree: Node[] = [
-  { type: 'page', name: 'Pear by Holepunch', url: '/' },
+  { type: 'page', name: 'Pear', url: '/' },
   {
     type: 'folder',
     name: 'Getting Started',


### PR DESCRIPTION
## What

The docs referred to the platform as **Pear by Holepunch** in two user-visible places. Renames them to just **Pear**.

| File | Before | After |
|---|---|---|
| `content/index.mdx` | `title: Pear by Holepunch` | `title: Pear` |
| `src/lib/custom-tree.ts` | nav entry `'Pear by Holepunch'` | `'Pear'` |
| `README.md` | "the Pear platform by Holepunch" | "the Pear platform." |

The homepage frontmatter title also feeds the SEO title built in `src/app/(docs)/[[...slug]]/page.tsx`, so the `<title>` becomes `Pear — Peer-to-Peer Application Runtime` (previously `Pear by Holepunch — …`).

## Not touched

Every other `Holepunch` mention is legitimate and left as-is:

- `github.com/holepunchto/*` repository links
- the `_– Holepunch, the P2P Company_` signature line on the homepage
- "Holepunch's official Electron template" (`hello-pear-electron`)
- the troubleshooting line asking users to notify Holepunch, and the linked Holepunch video

## Verification

- `npm run types:check` — clean
- `npm run check:internal-links` — 137 files, all valid
- `npm run check:doctypes` — pass
- Dev preview: homepage `<h1>` and top sidebar entry both render "Pear"

🤖 Generated with [Claude Code](https://claude.com/claude-code)