### PR TITLE
multi-rooms: fix worker crash when a just-joined room's info hasn't synced yet

### DIFF
--- a/examples/how-to/connect-to-peers/multi-rooms/workers/worker-task.js
+++ b/examples/how-to/connect-to-peers/multi-rooms/workers/worker-task.js
@@ -65,7 +65,12 @@ class WorkerTask extends ReadyResource {
       invite: room.invite,
       info: room.info
     }))
-    rooms.sort((a, b) => a.info.at - b.info.at)
+    // A just-joined room has no `info` yet — it only arrives once its
+    // ChatAccount 'update' syncs the room metadata from the peer who created
+    // it (see joinRoom in chat-account.js). If _rooms() runs in that window,
+    // `.info` is undefined and a bare `.at` access throws, taking the whole
+    // worker down.
+    rooms.sort((a, b) => (a.info?.at ?? 0) - (b.info?.at ?? 0))
     this.pipe.write(JSON.stringify({ type: 'rooms', rooms }))
   }
 }


### PR DESCRIPTION
## Summary
- \`joinRoom()\` in \`chat-account.js\` adds a room to \`this.rooms\` immediately, with no \`info\` — the real metadata (including its creation time) only arrives later, asynchronously, once it syncs from the peer who created the room.
- If the account's \`update\` event fires \`_rooms()\` in that window, the sort comparator's bare \`a.info.at\` throws on the just-joined room's undefined \`info\`, crashing the worker with an uncaught promise rejection.
- Fix: default missing \`info.at\` to \`0\` in the sort comparator instead of assuming it's always present.

Found while running this example live (joining a room reliably crashed the worker).

## Test plan
- [ ] Run the multi-rooms example with two peers; create a room in peer A, join it from peer B, confirm no crash and the room list renders correctly on both sides.