### PR TITLE
Rename release-pipeline page, add hello-pear-bare home card

### DIFF
--- a/content/explanation/deployment-releasing-apps-p2p.mdx
+++ b/content/explanation/deployment-releasing-apps-p2p.mdx
@@ -1,5 +1,5 @@
 ---
-title: Release pipeline
+title: "Deployment - Releasing Apps P2P"
 description: >-
   Why Pear desktop releases use stage, provision, and multisig pear links—the
   trust ladder, release lines, deployment directory, and recurring cycle.

--- a/content/explanation/index.mdx
+++ b/content/explanation/index.mdx
@@ -34,7 +34,7 @@ Pages are grouped by topic and ordered roughly from foundational concepts to app
 
 - [Pear desktop application architecture](/explanation/pear-desktop-architecture)—how a typical Pear Electron app splits updates, storage, and Bare workers (with a link to a full sample repo).
 - [Workers](/explanation/workers)—why peer-to-peer logic lives in a Bare worker behind one IPC stream, and where the host/worker boundary should sit.
-- [Release pipeline](/explanation/release-pipeline)—stage, provision, multisig, release lines, and deployment-directory diagrams (agnostic; sample implementation on GitHub).
+- [Release pipeline](/explanation/deployment-releasing-apps-p2p)—stage, provision, multisig, release lines, and deployment-directory diagrams (agnostic; sample implementation on GitHub).
 
 {/* Planned explanation pages. Uncomment each bullet as the page lands.
 

--- a/content/explanation/pear-desktop-architecture.mdx
+++ b/content/explanation/pear-desktop-architecture.mdx
@@ -74,8 +74,8 @@ The [getting started chat](/getting-started/build-a-peer-to-peer-chat/build-a-pe
 ## Where to go next
 
 - [Start from the hello-pear-electron template](/getting-started/from-a-template/start-from-hello-pear-electron)—a hands-on tour of this architecture in the official boilerplate.
-- [Release pipeline](/explanation/release-pipeline)—stage, provision, multisig, and diagrams for moving builds between links.
-- [Release pipeline glossary](/explanation/release-pipeline#glossary)—terminology in one table.
+- [Release pipeline](/explanation/deployment-releasing-apps-p2p)—stage, provision, multisig, and diagrams for moving builds between links.
+- [Release pipeline glossary](/explanation/deployment-releasing-apps-p2p#glossary)—terminology in one table.
 - [Storage and distribution](/explanation/storage-and-distribution)—Pear-wide layout versus per-app `dir`.
 - [Deploy your application](/how-to/operate-an-app/manual-deployment/deployment)—when you are ready to run commands.
 

--- a/content/explanation/storage-and-distribution.mdx
+++ b/content/explanation/storage-and-distribution.mdx
@@ -109,7 +109,7 @@ Self-seeding with `pear seed` only covers cores you hold locally and requires an
 ## See also
 
 - [Pear desktop application architecture](/explanation/pear-desktop-architecture)—how a typical Electron app maps `dir`, workers, and OTA into that layout.
-- [Release pipeline](/explanation/release-pipeline)—stage, provision, multisig, and release lines for shipping desktop builds.
+- [Release pipeline](/explanation/deployment-releasing-apps-p2p)—stage, provision, multisig, and release lines for shipping desktop builds.
 - [Manage installed applications](/how-to/manage-installed-applications)—listing and dropping local application storage.
 - [Deploy your application](/how-to/operate-an-app/manual-deployment/deployment)—staging and seeding new releases.
 - [Hypercore](/reference/building-blocks/hypercore)—the append-only log every other primitive composes.

--- a/content/getting-started/build-a-peer-to-peer-chat/reshape-into-a-production-app.mdx
+++ b/content/getting-started/build-a-peer-to-peer-chat/reshape-into-a-production-app.mdx
@@ -14,7 +14,7 @@ By the end you have the shared **`pear-chat` scaffold** every chat-family and me
 - A separate [Bare worker](/explanation/runtime-and-languages) that owns all the P2P code.
 - An [Autobase](/reference/building-blocks/autobase)-backed shared room with [blind-pairing](https://www.npmjs.com/package/blind-pairing) invite codes, so two peers join from a short string without exposing keys.
 - On-disk persistence via [Corestore](/reference/helpers/corestore) + a [HyperDB](https://www.npmjs.com/package/hyperdb) view—the conversation survives restarts.
-- A separate [OTA updater worker](/explanation/release-pipeline#ota-update-event-lifecycle), wired but inert, ready for [part 3](/getting-started/build-a-peer-to-peer-chat/ship) and [part 4](/getting-started/build-a-peer-to-peer-chat/update) to flip on.
+- A separate [OTA updater worker](/explanation/deployment-releasing-apps-p2p#ota-update-event-lifecycle), wired but inert, ready for [part 3](/getting-started/build-a-peer-to-peer-chat/ship) and [part 4](/getting-started/build-a-peer-to-peer-chat/update) to flip on.
 - A polished [Tailwind CSS](https://tailwindcss.com/) UI (compiled by the CLI, not the CDN) with a peer counter and a **copy-invite** button.
 
 <include>../../_snippets/_hello-pear-electron-callout.mdx</include>
@@ -403,5 +403,5 @@ Or zoom out to the conceptual picture:
 
 - [Pear desktop application architecture](/explanation/pear-desktop-architecture)—why a production app splits OTA updates, storage, and workers.
 - [Workers](/explanation/workers)—what a Bare worker is and why P2P state lives there.
-- [Release pipeline](/explanation/release-pipeline)—staging links, multisig, and the OTA loop.
+- [Release pipeline](/explanation/deployment-releasing-apps-p2p)—staging links, multisig, and the OTA loop.
   

--- a/content/getting-started/build-a-peer-to-peer-chat/ship.mdx
+++ b/content/getting-started/build-a-peer-to-peer-chat/ship.mdx
@@ -34,7 +34,7 @@ This part stops after step 6—the first `pear stage` plus `pear provision`. You
 
 - [Deploy a Pear desktop app](/how-to/operate-an-app/manual-deployment/deployment)—every command, every release line.
 - [Build desktop distributables](/how-to/operate-an-app/build-and-package/build-desktop-distributables)—code-signing, notarization, MSIX publisher details.
-- [Release pipeline](/explanation/release-pipeline)—the conceptual picture.
+- [Release pipeline](/explanation/deployment-releasing-apps-p2p)—the conceptual picture.
 
 <include>../../_snippets/_hello-pear-electron-callout.mdx</include>
 
@@ -437,6 +437,6 @@ Every release iteration after this is the same pattern: `npm version patch`, `np
 - [Build desktop distributables](/how-to/operate-an-app/build-and-package/build-desktop-distributables)—code-signing, notarization, MSIX publisher details.
 - [Publish a changelog for your app](/how-to/operate-an-app/publish-a-changelog)—ship a `CHANGELOG.md` so users read your release notes with `pear changelog`.
 - [Troubleshoot desktop releases](/how-to/operate-an-app/manual-deployment/troubleshoot-desktop-releases)—"the app did not update," lost write-access, stage size blowups.
-- [Release pipeline](/explanation/release-pipeline)—the conceptual picture, deployment layers, and release lines.
-- [Release pipeline glossary](/explanation/release-pipeline#glossary)—terminology.
+- [Release pipeline](/explanation/deployment-releasing-apps-p2p)—the conceptual picture, deployment layers, and release lines.
+- [Release pipeline glossary](/explanation/deployment-releasing-apps-p2p#glossary)—terminology.
 - [`hello-pear-electron`](https://github.com/holepunchto/hello-pear-electron)—the upstream template every snippet in this getting started path is based on.

--- a/content/getting-started/build-a-peer-to-peer-chat/update.mdx
+++ b/content/getting-started/build-a-peer-to-peer-chat/update.mdx
@@ -19,7 +19,7 @@ From here you put the live OTA cycle to work:
 2. [Change something visible in the renderer](#make-a-visible-change)
 3. [Stage v1.0.2 onto your **stage link**](#stage-and-provision-the-deployment-directory)
 4. [Provision it onto the provision link](#stage-and-provision-the-deployment-directory)
-5. [Watch the OTA cycle fire](#watch-the-ota-cycle-fire)—see the [OTA update event lifecycle](/explanation/release-pipeline#ota-update-event-lifecycle)
+5. [Watch the OTA cycle fire](#watch-the-ota-cycle-fire)—see the [OTA update event lifecycle](/explanation/deployment-releasing-apps-p2p#ota-update-event-lifecycle)
 6. [Preview multisig](#multisig-production-releases), the production gate on top of provision.
 
 <include>../../_snippets/_hello-pear-electron-callout.mdx</include>
@@ -36,7 +36,7 @@ You do not need cosigners, a Windows machine, or Apple signing credentials to fo
 
 - [Deploy a Pear desktop app](/how-to/operate-an-app/manual-deployment/deployment)—every command, every release line.
 - [Build desktop distributables](/how-to/operate-an-app/build-and-package/build-desktop-distributables)—code-signing, notarization, MSIX publisher details.
-- [Release pipeline](/explanation/release-pipeline)—the conceptual picture.
+- [Release pipeline](/explanation/deployment-releasing-apps-p2p)—the conceptual picture.
 
 ## Before you start
 
@@ -200,7 +200,7 @@ pear multisig verify <source-link> <signing request> [...responses]
 pear multisig commit <source-link> <signing request> [...responses]   # commits when quorum is reached
 ```
 
-[Release pipeline](/explanation/release-pipeline) and [Deploy a Pear desktop app](/how-to/operate-an-app/manual-deployment/deployment) cover the full quorum lifecycle, key rotation, recovering from lost write-access, and the [release lines](/explanation/release-pipeline#release-lines) pattern (development → staging → rc → prerelease → production) that real teams use.
+[Release pipeline](/explanation/deployment-releasing-apps-p2p) and [Deploy a Pear desktop app](/how-to/operate-an-app/manual-deployment/deployment) cover the full quorum lifecycle, key rotation, recovering from lost write-access, and the [release lines](/explanation/deployment-releasing-apps-p2p#release-lines) pattern (development → staging → rc → prerelease → production) that real teams use.
 
 </Step>
 
@@ -224,6 +224,6 @@ Every release iteration after part 3 is the same pattern: `npm version patch`, `
 - [Deploy a Pear desktop app](/how-to/operate-an-app/manual-deployment/deployment)—the canonical how-to with every command, every flag, and every recovery procedure.
 - [Build desktop distributables](/how-to/operate-an-app/build-and-package/build-desktop-distributables)—code-signing, notarization, MSIX publisher details.
 - [Troubleshoot desktop releases](/how-to/operate-an-app/manual-deployment/troubleshoot-desktop-releases)—"the app did not update," lost write-access, stage size blowups, OTA polling cadence.
-- [Release pipeline](/explanation/release-pipeline)—the conceptual picture, deployment layers, and release lines.
-- [Release pipeline glossary](/explanation/release-pipeline#glossary)—terminology.
+- [Release pipeline](/explanation/deployment-releasing-apps-p2p)—the conceptual picture, deployment layers, and release lines.
+- [Release pipeline glossary](/explanation/deployment-releasing-apps-p2p#glossary)—terminology.
 - [`hello-pear-electron`](https://github.com/holepunchto/hello-pear-electron)—the upstream template every snippet in this getting started path is based on.

--- a/content/getting-started/from-a-template/index.mdx
+++ b/content/getting-started/from-a-template/index.mdx
@@ -33,7 +33,7 @@ The fastest way to a production-shaped app is to clone an official boilerplate a
 Both share the same peer-to-peer core: the [Bare](/reference/modules/bare-modules) runtime, [`pear-runtime`](/reference/pear/runtime) for updates, and the [Hyperswarm](/reference/building-blocks/hyperswarm) + [Corestore](/reference/helpers/corestore) stack. Your peer-to-peer logic is portable between them—only the shell (GUI versus terminal) changes. See [Runtime and languages](/explanation/runtime-and-languages).
 
 <Callout type="info">
-Once you've cloned a template and made it yours, ship it over the air: [Deploy your application](/how-to/operate-an-app/manual-deployment/deployment) is the step-by-step release flow, and [Release pipeline](/explanation/release-pipeline) explains the stage → provision → multisig model behind it.
+Once you've cloned a template and made it yours, ship it over the air: [Deploy your application](/how-to/operate-an-app/manual-deployment/deployment) is the step-by-step release flow, and [Release pipeline](/explanation/deployment-releasing-apps-p2p) explains the stage → provision → multisig model behind it.
 </Callout>
 
 ## Where to go next

--- a/content/getting-started/index.mdx
+++ b/content/getting-started/index.mdx
@@ -104,7 +104,7 @@ Each part adds one layer to that picture:
 - Part 1 wires the renderer ↔ main ↔ worker ↔ peers path with the smallest amount of code.
 - Part 2 reshapes that into the full [`hello-pear-electron`](https://github.com/holepunchto/hello-pear-electron) production scaffold: a dedicated Bare chat worker, an [Autobase](/reference/building-blocks/autobase)-backed room with [blind-pairing](https://www.npmjs.com/package/blind-pairing) invites, a HyperDB schema, on-disk persistence, a separate OTA updater worker, and a polished Tailwind UI—the vanilla renderer that every peer-to-peer how-to extends.
 - Part 3 turns the project into a release pipeline: signed distributables, a `pear://` upgrade link, and the first published version on a [Hypercore](/reference/building-blocks/hypercore).
-- Part 4 puts that release pipeline in motion: run the installed app, ship a second version, watch OTA fire end-to-end, and preview the production `stage → provision → multisig` flow from the [release pipeline](/explanation/release-pipeline).
+- Part 4 puts that release pipeline in motion: run the installed app, ship a second version, watch OTA fire end-to-end, and preview the production `stage → provision → multisig` flow from the [release pipeline](/explanation/deployment-releasing-apps-p2p).
 
 ## Before you start
 
@@ -119,6 +119,6 @@ Each part lists any extra npm packages it adds.
 
 - [Pear desktop application architecture](/explanation/pear-desktop-architecture)—why Bare workers, the preload bridge, and the OTA updater look the way they do.
 - [Storage and distribution](/explanation/storage-and-distribution)—where `pear.storage` lives in development versus production.
-- [Release pipeline](/explanation/release-pipeline)—the `stage → provision → multisig` flow parts 3 and 4 walk through.
-- [Release pipeline glossary](/explanation/release-pipeline#glossary)—terms used across the desktop release docs.
+- [Release pipeline](/explanation/deployment-releasing-apps-p2p)—the `stage → provision → multisig` flow parts 3 and 4 walk through.
+- [Release pipeline glossary](/explanation/deployment-releasing-apps-p2p#glossary)—terms used across the desktop release docs.
 - The upstream template: [`holepunchto/hello-pear-electron`](https://github.com/holepunchto/hello-pear-electron).

--- a/content/how-to/operate-an-app/build-and-package/build-desktop-distributables.mdx
+++ b/content/how-to/operate-an-app/build-and-package/build-desktop-distributables.mdx
@@ -7,7 +7,7 @@ docType: how-to
 schemaType: TechArticle
 ---
 
-This guide shows you how to **produce per-OS distributables** and assemble a **deployment directory** that `pear stage` can consume. It assumes you already ship with Electron tooling (for example Electron Forge) and a Pear release line; for the overall pipeline, read [Release pipeline](/explanation/release-pipeline) and [Deploy your application](/how-to/operate-an-app/manual-deployment/deployment).
+This guide shows you how to **produce per-OS distributables** and assemble a **deployment directory** that `pear stage` can consume. It assumes you already ship with Electron tooling (for example Electron Forge) and a Pear release line; for the overall pipeline, read [Release pipeline](/explanation/deployment-releasing-apps-p2p) and [Deploy your application](/how-to/operate-an-app/manual-deployment/deployment).
 
 <Callout type="info">
 To run all of this on hosted runners instead of by hand on each OS, see [Build and sign desktop apps in CI](/how-to/operate-an-app/github-actions/build-and-sign-in-ci)—the [`make-pear-app`](/reference/ci-and-release/github-actions#make-pear-app) action automates the signing and notarization steps below.
@@ -24,7 +24,7 @@ To run all of this on hosted runners instead of by hand on each OS, see [Build a
 Complete these before you cut binaries you will ship to others:
 
 - Application metadata and icons are **final for the brand** you are releasing under.
-- You know which **release line** link (development, staging, rc, etc.) this build will track—see [Release pipeline](/explanation/release-pipeline).
+- You know which **release line** link (development, staging, rc, etc.) this build will track—see [Release pipeline](/explanation/deployment-releasing-apps-p2p).
 - For **macOS** and **Windows** production paths, plan **vendor signing** up front (same certificate across builds for MSIX updates).
 
 ## macOS
@@ -102,7 +102,7 @@ Then continue with **dry-run** and real **`pear stage`** as described in [Deploy
 - [Build and sign desktop apps in CI](/how-to/operate-an-app/github-actions/build-and-sign-in-ci)—automate this whole flow with the `make-pear-app` GitHub Action.
 - [Desktop release npm scripts](/reference/ci-and-release/desktop-release-npm-scripts)—common `npm` entry points in sample repos.
 - [Troubleshoot desktop releases](/how-to/operate-an-app/manual-deployment/troubleshoot-desktop-releases)—OTA did not land, `pear stage` sizes exploded, or keys were lost.
-- [Release pipeline glossary](/explanation/release-pipeline#glossary)—terminology for links, lines, and multisig.
+- [Release pipeline glossary](/explanation/deployment-releasing-apps-p2p#glossary)—terminology for links, lines, and multisig.
 
 <Callout type="info">
 

--- a/content/how-to/operate-an-app/github-actions/publish-with-github-actions.mdx
+++ b/content/how-to/operate-an-app/github-actions/publish-with-github-actions.mdx
@@ -139,5 +139,5 @@ Read the diff in the Actions log. Look for the files you expect, no surprise add
 - [Deploy your application](/how-to/operate-an-app/manual-deployment/deployment)—the full manual flow with release lines, provision, and multisig.
 - [Ship your app](/getting-started/build-a-peer-to-peer-chat/ship)—the type-along walkthrough of staging by hand.
 - [Configuration](/reference/pear/configuration)—the `upgrade` field and other `package.json` settings.
-- [Release pipeline](/explanation/release-pipeline)—the conceptual picture of staging and OTA updates.
+- [Release pipeline](/explanation/deployment-releasing-apps-p2p)—the conceptual picture of staging and OTA updates.
 - [Troubleshoot desktop releases](/how-to/operate-an-app/manual-deployment/troubleshoot-desktop-releases)—when an update does not reach peers.

--- a/content/how-to/operate-an-app/index.mdx
+++ b/content/how-to/operate-an-app/index.mdx
@@ -8,7 +8,7 @@ schemaType: WebPage
 
 import { Cards, Card } from 'fumadocs-ui/components/card'
 
-Everything for shipping a Pear app to users and keeping it updated over the air. For the conceptual picture behind the flow, see [Release pipeline](/explanation/release-pipeline).
+Everything for shipping a Pear app to users and keeping it updated over the air. For the conceptual picture behind the flow, see [Release pipeline](/explanation/deployment-releasing-apps-p2p).
 
 <Cards>
   <Card href="/how-to/operate-an-app/github-actions" title="CI/CD with GitHub Actions" description="Build, sign, and publish a Pear app from CI so shipping is a git push." />

--- a/content/how-to/operate-an-app/manual-deployment/deployment.mdx
+++ b/content/how-to/operate-an-app/manual-deployment/deployment.mdx
@@ -5,7 +5,7 @@ docType: how-to
 schemaType: TechArticle
 ---
 
-This is the operator reference for the desktop release flow. The conceptual picture lives in [Release pipeline](/explanation/release-pipeline); the type-along path is in [Ship your app](/getting-started/build-a-peer-to-peer-chat/ship) and [Deploy over-the-air updates](/getting-started/build-a-peer-to-peer-chat/update). Use this page when you need exact commands for the eight **Foundational Steps** documented in [`hello-pear-electron`'s Foundational Steps](https://github.com/holepunchto/hello-pear-electron#foundational-steps).
+This is the operator reference for the desktop release flow. The conceptual picture lives in [Release pipeline](/explanation/deployment-releasing-apps-p2p); the type-along path is in [Ship your app](/getting-started/build-a-peer-to-peer-chat/ship) and [Deploy over-the-air updates](/getting-started/build-a-peer-to-peer-chat/update). Use this page when you need exact commands for the eight **Foundational Steps** documented in [`hello-pear-electron`'s Foundational Steps](https://github.com/holepunchto/hello-pear-electron#foundational-steps).
 
 <include>../../../_snippets/_ci-publish-shortcut-callout.mdx</include>
 
@@ -30,7 +30,7 @@ Run `pear seed` on at least one always-online machine so peers can fetch updates
 
 ## 1. Set the upgrade link
 
-Every shipped build polls a `pear://` link from its `package.json` `upgrade` field. Set it once per [release line](/explanation/release-pipeline#release-lines):
+Every shipped build polls a `pear://` link from its `package.json` `upgrade` field. Set it once per [release line](/explanation/deployment-releasing-apps-p2p#release-lines):
 
 ```sh skip="release-flow"
 npm pkg set upgrade=pear://qxenz5wmspmryjc13m9yzsqj1conqotn8fb4ocbufwtz9mtbqq5o
@@ -242,7 +242,7 @@ This is useful for kiosk binaries or air-gapped distributions where OTA must be 
 
 A typical project keeps several stage drives in parallel—`development`, `staging`, `rc`, plus any number of custom lines for experiments or hotfixes. Each line has its own `pear://` link from step 0 and its own seeded reseeders.
 
-Production has exactly one chain: `rc` → provision (`prerelease`) → multisig (`production`). The `rc` build's `upgrade` field points at the multisig link, so `rc` builds do not receive OTA updates—every `rc` iteration requires a new installer. The [Release pipeline](/explanation/release-pipeline#release-lines) explanation has the conceptual picture.
+Production has exactly one chain: `rc` → provision (`prerelease`) → multisig (`production`). The `rc` build's `upgrade` field points at the multisig link, so `rc` builds do not receive OTA updates—every `rc` iteration requires a new installer. The [Release pipeline](/explanation/deployment-releasing-apps-p2p#release-lines) explanation has the conceptual picture.
 
 To bootstrap a new release line:
 
@@ -258,13 +258,13 @@ To bootstrap a new release line:
 - [Sign with multisig](/how-to/operate-an-app/multisig/sign-with-multisig)—the per-release prepare → sign → verify → commit flow.
 - [Troubleshoot multisig](/how-to/operate-an-app/multisig/troubleshoot-multisig)—refused requests, interrupted commits, and recovering lost write access.
 - [Publish with GitHub Actions](/how-to/operate-an-app/github-actions/publish-with-github-actions)—the simplest publish/update workflow, staging from CI on every push.
-- [Release pipeline](/explanation/release-pipeline)—conceptual diagrams for stage, provision, multisig, and release lines.
+- [Release pipeline](/explanation/deployment-releasing-apps-p2p)—conceptual diagrams for stage, provision, multisig, and release lines.
 - [Build desktop distributables](/how-to/operate-an-app/build-and-package/build-desktop-distributables)—per-OS makes, signing, notarization, and MSIX publisher details.
 - [Submit to app stores](/how-to/operate-an-app/build-and-package/submit-to-app-stores)—Flathub and Snap Store packaging on top of the Linux distributables.
 - [Desktop release npm scripts](/reference/ci-and-release/desktop-release-npm-scripts)—the `package.json` scripts that drive this flow.
 - [Publish a changelog for your app](/how-to/operate-an-app/publish-a-changelog)—ship a `CHANGELOG.md` so users read release notes with `pear changelog`.
 - [Troubleshoot desktop releases](/how-to/operate-an-app/manual-deployment/troubleshoot-desktop-releases)—OTA, seeding, deployment-folder, and lost write-access pitfalls.
-- [Release pipeline glossary](/explanation/release-pipeline#glossary)—terminology.
+- [Release pipeline glossary](/explanation/deployment-releasing-apps-p2p#glossary)—terminology.
 - [`pear-ci` GitHub Action reference](/reference/ci-and-release/pear-ci-action)—inputs, outputs, and the CLI behind CI publishing.
 - [`pear-runtime` reference](/reference/pear/runtime)—the runtime that drives OTA on the client.
 - [Storage and distribution](/explanation/storage-and-distribution)—how releases reach users.

--- a/content/how-to/operate-an-app/manual-deployment/index.mdx
+++ b/content/how-to/operate-an-app/manual-deployment/index.mdx
@@ -8,7 +8,7 @@ schemaType: WebPage
 
 import { Cards, Card } from 'fumadocs-ui/components/card'
 
-The hands-on release flow when you need release lines, provision, and full control. For the concepts, see [Release pipeline](/explanation/release-pipeline).
+The hands-on release flow when you need release lines, provision, and full control. For the concepts, see [Release pipeline](/explanation/deployment-releasing-apps-p2p).
 
 <Cards>
   <Card href="/how-to/operate-an-app/manual-deployment/deployment" title="Deploy your application" description="The eight Foundational Steps: touch, upgrade link, version, make, pear build, stage, provision, and multisig." />

--- a/content/how-to/operate-an-app/manual-deployment/troubleshoot-desktop-releases.mdx
+++ b/content/how-to/operate-an-app/manual-deployment/troubleshoot-desktop-releases.mdx
@@ -7,7 +7,7 @@ docType: how-to
 schemaType: TechArticle
 ---
 
-Use this guide when **desktop OTA** or **`pear stage`** behaves unexpectedly after you have a [deployment directory](/explanation/release-pipeline#deployment-directory-and-release-lines) and a release line. For general Pear and Bare development issues, see [Troubleshoot common issues](/how-to/troubleshooting).
+Use this guide when **desktop OTA** or **`pear stage`** behaves unexpectedly after you have a [deployment directory](/explanation/deployment-releasing-apps-p2p#deployment-directory-and-release-lines) and a release line. For general Pear and Bare development issues, see [Troubleshoot common issues](/how-to/troubleshooting).
 
 <include>../../../_snippets/_install-pear-cli-callout.mdx</include>
 
@@ -187,7 +187,7 @@ Keeping one folder per version also makes **rollback** easier: you can re-stage 
 
 - [Deploy your application](/how-to/operate-an-app/manual-deployment/deployment)—dry-run staging and provision commands.
 - [Build desktop distributables](/how-to/operate-an-app/build-and-package/build-desktop-distributables)—correct `pear build` invocation before staging.
-- [Release pipeline](/explanation/release-pipeline)—which link each build should follow.
+- [Release pipeline](/explanation/deployment-releasing-apps-p2p)—which link each build should follow.
 
 <Callout type="info">
 

--- a/content/how-to/operate-an-app/multisig/set-up-multisig.mdx
+++ b/content/how-to/operate-an-app/multisig/set-up-multisig.mdx
@@ -68,4 +68,4 @@ The provision drive's `upgrade` field now points at the multisig drive. Setup is
 - [Sign with multisig](/how-to/operate-an-app/multisig/sign-with-multisig)—the repeatable prepare → sign → verify → commit flow for every release.
 - [Troubleshoot multisig](/how-to/operate-an-app/multisig/troubleshoot-multisig)—interrupted commits, `INCOMPATIBLE_SOURCE_AND_TARGET`, and recovering lost write access.
 - [Deploy your application](/how-to/operate-an-app/manual-deployment/deployment)—the full eight-step release flow this gates.
-- [Release pipeline](/explanation/release-pipeline)—conceptual diagrams for stage, provision, and multisig.
+- [Release pipeline](/explanation/deployment-releasing-apps-p2p)—conceptual diagrams for stage, provision, and multisig.

--- a/content/how-to/operate-an-app/multisig/sign-with-multisig.mdx
+++ b/content/how-to/operate-an-app/multisig/sign-with-multisig.mdx
@@ -87,4 +87,4 @@ pear info --multisig <multisig-link>
 - [Set up multisig](/how-to/operate-an-app/multisig/set-up-multisig)—the one-time setup this flow depends on.
 - [Troubleshoot multisig](/how-to/operate-an-app/multisig/troubleshoot-multisig)—request refused, interrupted commits, and `INCOMPATIBLE_SOURCE_AND_TARGET`.
 - [Deploy your application](/how-to/operate-an-app/manual-deployment/deployment)—the full eight-step release flow.
-- [Release pipeline](/explanation/release-pipeline)—conceptual diagrams for stage, provision, and multisig.
+- [Release pipeline](/explanation/deployment-releasing-apps-p2p)—conceptual diagrams for stage, provision, and multisig.

--- a/content/how-to/operate-an-app/multisig/troubleshoot-multisig.mdx
+++ b/content/how-to/operate-an-app/multisig/troubleshoot-multisig.mdx
@@ -77,4 +77,4 @@ To automate this in CI, the [`pear-provision-recover`](/reference/ci-and-release
 - [Set up multisig](/how-to/operate-an-app/multisig/set-up-multisig)—generate keys, configure `pear.json`, and point `upgrade` at the multisig link.
 - [Sign with multisig](/how-to/operate-an-app/multisig/sign-with-multisig)—the prepare → sign → verify → commit flow.
 - [Troubleshoot desktop releases](/how-to/operate-an-app/manual-deployment/troubleshoot-desktop-releases)—OTA, seeding, and staging problems.
-- [Release pipeline](/explanation/release-pipeline)—conceptual diagrams for stage, provision, and multisig.
+- [Release pipeline](/explanation/deployment-releasing-apps-p2p)—conceptual diagrams for stage, provision, and multisig.

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -50,8 +50,9 @@ Starter paths and the most relevant docs for building and shipping a Pear deskto
 <Cards>
   <Card href="/getting-started" title="Getting started" description="Type-along chat, persistence, then ship and update." />
   <Card href="/getting-started/from-a-template/start-from-hello-pear-electron" title="hello-pear-electron template" description="Clone the boilerplate and learn your way around it, then add a feature end to end." />
+  <Card href="/getting-started/from-a-template/start-from-hello-pear-bare" title="hello-pear-bare template" description="Clone the terminal boilerplate and learn your way around it, then ship it as a standalone binary." />
   <Card href="/explanation/pear-desktop-architecture" title="Pear desktop architecture" description="How Electron, Bare workers, storage, and OTA fit together." />
-  <Card href="/explanation/release-pipeline" title="Release pipeline" description="Stage → provision → multisig and release lines." />
+  <Card href="/explanation/deployment-releasing-apps-p2p" title="Deployment - Releasing Apps P2P" description="Stage → provision → multisig and release lines." />
   <Card href="/explanation/use-bare-standalone" title="Using Bare on its own" description="Use Bare—the runtime under Pear—on its own as an embeddable, cross-platform JavaScript runtime, without the peer-to-peer platform." />
 </Cards>
 
@@ -59,7 +60,7 @@ The upstream Electron template used by the team is `holepunchto/hello-pear-elect
 
 ## How-to guides by task
 
-Goal-oriented recipes, grouped by task. **Releasing and distributing your app** lives here too—shipping and updating is a how-to, spanning [manual deployment](/how-to/operate-an-app/manual-deployment), [multisig](/how-to/operate-an-app/multisig), [build & package](/how-to/operate-an-app/build-and-package), and [CI](/how-to/operate-an-app/github-actions); the why is in [Release pipeline](/explanation/release-pipeline).
+Goal-oriented recipes, grouped by task. **Releasing and distributing your app** lives here too—shipping and updating is a how-to, spanning [manual deployment](/how-to/operate-an-app/manual-deployment), [multisig](/how-to/operate-an-app/multisig), [build & package](/how-to/operate-an-app/build-and-package), and [CI](/how-to/operate-an-app/github-actions); the why is in [Release pipeline](/explanation/deployment-releasing-apps-p2p).
 
 <Cards>
   <Card href="/how-to/connect-to-peers" title="Connect to peers" description="Dial a peer by key with HyperDHT, join topics with Hyperswarm, and host multiple rooms in one app." />

--- a/content/reference/ci-and-release/desktop-release-npm-scripts.mdx
+++ b/content/reference/ci-and-release/desktop-release-npm-scripts.mdx
@@ -69,4 +69,4 @@ Unsigned local builds are fine on the machine that made them; production paths n
 - [Build desktop distributables](/how-to/operate-an-app/build-and-package/build-desktop-distributables)—signing, notarization, MSIX publisher, and the `pear build` deployment directory layout.
 - [Deploy your application](/how-to/operate-an-app/manual-deployment/deployment)—stage, provision, and multisig once the deployment directory exists.
 - [Getting started—part 3 (ship)](/getting-started/build-a-peer-to-peer-chat/ship) and [part 4 (update)](/getting-started/build-a-peer-to-peer-chat/update)—type-along walkthrough of the whole flow.
-- [Release pipeline](/explanation/release-pipeline)—how the scripts above feed into trust boundaries and release lines.
+- [Release pipeline](/explanation/deployment-releasing-apps-p2p)—how the scripts above feed into trust boundaries and release lines.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -69,7 +69,9 @@ const config = {
       { source: '/reference/faq', destination: '/explanation', permanent: true },
       // Release pipeline glossary was folded into the release-pipeline
       // explanation as a "Glossary" section (subtask: glossary merge).
-      { source: '/reference/release-pipeline-glossary', destination: '/explanation/release-pipeline#glossary', permanent: true },
+      { source: '/reference/release-pipeline-glossary', destination: '/explanation/deployment-releasing-apps-p2p#glossary', permanent: true },
+      // "Release pipeline" was renamed "Deployment - Releasing Apps P2P"; the slug moved too.
+      { source: '/explanation/release-pipeline', destination: '/explanation/deployment-releasing-apps-p2p', permanent: true },
       // Building-block reference docs live at /reference/building-blocks/*.
       // Keep /building-blocks/* as a legacy shortcut that redirects there.
       { source: '/building-blocks/:slug', destination: '/reference/building-blocks/:slug', permanent: true },

--- a/scripts/redirects.ts
+++ b/scripts/redirects.ts
@@ -133,7 +133,13 @@ export function buildRedirects(contentRoot = 'content'): Redirect[] {
   // as a "Glossary" section, so the standalone reference page is gone.
   out.push({
     from: '/reference/release-pipeline-glossary/',
-    to: '/explanation/release-pipeline/#glossary',
+    to: '/explanation/deployment-releasing-apps-p2p/#glossary',
+  });
+
+  // "Release pipeline" was renamed "Deployment - Releasing Apps P2P"; the slug moved with it.
+  out.push({
+    from: '/explanation/release-pipeline/',
+    to: '/explanation/deployment-releasing-apps-p2p/',
   });
 
   // Troubleshooting and manage-installed-applications were promoted to

--- a/src/lib/custom-tree.ts
+++ b/src/lib/custom-tree.ts
@@ -143,8 +143,8 @@ export const customTree: Node[] = [
           },
           {
             type: 'page',
-            name: 'Release pipeline',
-            url: '/explanation/release-pipeline',
+            name: 'Deployment - Releasing Apps P2P',
+            url: '/explanation/deployment-releasing-apps-p2p',
           },
         ],
       },


### PR DESCRIPTION
## Summary
- Renamed `/explanation/release-pipeline` to `/explanation/deployment-releasing-apps-p2p` ("Deployment - Releasing Apps P2P") — H1, doc file, sidebar label, and homepage card all updated, with a 301 redirect from the old URL and every internal link repointed to the new path.
- Added a `hello-pear-bare` template card to the homepage, next to the existing `hello-pear-electron` card.

## Test plan
- [x] `npm run check:internal-links` — passes
- [x] `npm run check:doctypes` — passes
- [x] `npm run check:cross-links` — passes
- [x] Verified in dev server: new page shows the new title in H1/tab/breadcrumb, old URL redirects, homepage shows both template cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)