### PR TITLE
Document hello-pear-bare single-thread and daemon variants

### DIFF
--- a/content/getting-started/from-a-template/start-from-hello-pear-bare.mdx
+++ b/content/getting-started/from-a-template/start-from-hello-pear-bare.mdx
@@ -137,28 +137,7 @@ git clone -b variant/single-thread https://github.com/holepunchto/hello-pear-bar
 
 Same `App` [`ready-resource`](https://github.com/holepunchto/ready-resource) shape and event surface (`updating`, `updating-delta`, `updated`, `update-applied`, `error`) as `main`, but `_open()` constructs `PearRuntime` directly instead of spawning a worker and wrapping its IPC in a `FramedStream`:
 
-```js
-_open() {
-  const store = new Corestore(path.join(this.dir, 'pear-runtime', 'corestore'))
-  const swarm = new Hyperswarm()
-
-  this.store = store
-  this.swarm = swarm
-
-  const pear = new PearRuntime({
-    dir: this.dir,
-    app: this.app,
-    updates: this.updates,
-    version: this.version,
-    upgrade: this.upgrade,
-    name: this.name,
-    store,
-    swarm
-  })
-
-  this.pear = pear
-  // ...
-}
+```js file=<rootDir>/examples/getting-started/hello-pear-bare-single-thread/app.js#L23-L41 title="app.js"
 ```
 
 See [`app.js`](https://github.com/holepunchto/hello-pear-bare/blob/variant/single-thread/app.js) on the `variant/single-thread` branch for the full file.
@@ -167,21 +146,12 @@ See [`app.js`](https://github.com/holepunchto/hello-pear-bare/blob/variant/singl
 
 `bin.mjs` spawns a **detached** updater and returns immediately—the foreground command never blocks on the network:
 
-```js
-if (updates !== false) {
-  App.spawnUpdater(dir, os.execPath(), isDev ? Bare.argv[1] : null, wait)
-}
+```js file=<rootDir>/examples/getting-started/hello-pear-bare-daemon/bin.mjs#L50-L57 title="bin.mjs"
 ```
 
 `App.spawnUpdater` re-invokes the same executable with a hidden `--updater` flag through [`bare-daemon`](https://github.com/holepunchto/bare-daemon):
 
-```js
-static spawnUpdater(dir, app, entrypoint, updateWindow) {
-  const args = entrypoint === null ? [] : [entrypoint]
-  args.push('--updater', '--storage', dir)
-  if (updateWindow !== undefined) args.push('--update-window', String(updateWindow))
-  return daemon.spawn(app, args)
-}
+```js file=<rootDir>/examples/getting-started/hello-pear-bare-daemon/app.js#L11-L18 title="app.js"
 ```
 
 The daemon acquires an `updater.lock` file in the storage directory—via [`fs-native-extensions`](https://github.com/holepunchto/fs-native-extensions)—so only one updater runs per storage directory at a time, waits up to `--update-window` (default 30 seconds) for an update to arrive, and logs to `<storage>/updates.log` instead of stdout since nothing is attached to read it. See [`app.js`](https://github.com/holepunchto/hello-pear-bare/blob/variant/daemon/app.js) and [`bin.mjs`](https://github.com/holepunchto/hello-pear-bare/blob/variant/daemon/bin.mjs) on the `variant/daemon` branch for the full files.

--- a/content/getting-started/from-a-template/start-from-hello-pear-bare.mdx
+++ b/content/getting-started/from-a-template/start-from-hello-pear-bare.mdx
@@ -117,6 +117,81 @@ flowchart LR
   swarm <-->|"replicate update drive"| peers((seeding peers))
 ```
 
+## Variants
+
+The `main` branch above (a Bare worker thread) is one of three process shapes `holepunchto/hello-pear-bare` ships. All three keep the same `upgrade` link, build targets, and `pear install`/[`pear seed`](/explanation/availability-and-blind-peering#seeding-with-pear-seed) flow from [Clone and run](#clone-and-run) onward—only `app.js` and `bin.mjs` differ. Pick the branch that matches how your CLI runs:
+
+| Branch | Shape | Use it for |
+| --- | --- | --- |
+| [`main`](https://github.com/holepunchto/hello-pear-bare) (this page) | `pear-runtime` inside a Bare [worker](/explanation/workers) thread | Long-lived programs (services, REPLs, TUIs) that keep peer-to-peer logic off the main thread. |
+| [`variant/single-thread`](https://github.com/holepunchto/hello-pear-bare/tree/variant/single-thread) | `pear-runtime` constructed directly in the main Bare process—no worker, no IPC framing | Long-lived programs whose peer-to-peer logic doesn't need a separate thread. |
+| [`variant/daemon`](https://github.com/holepunchto/hello-pear-bare/tree/variant/daemon) | `pear-runtime` runs inside a detached [`bare-daemon`](https://github.com/holepunchto/bare-daemon) process that the foreground command spawns and returns from immediately | Short-lived CLI invocations (like `git`) that shouldn't block on an update check—the command exits while the daemon updates in the background. |
+
+Clone whichever branch fits, swapping it into step 1 of [Clone and run](#clone-and-run):
+
+```bash
+git clone -b variant/single-thread https://github.com/holepunchto/hello-pear-bare
+```
+
+### `single-thread`
+
+Same `App` [`ready-resource`](https://github.com/holepunchto/ready-resource) shape and event surface (`updating`, `updating-delta`, `updated`, `update-applied`, `error`) as `main`, but `_open()` constructs `PearRuntime` directly instead of spawning a worker and wrapping its IPC in a `FramedStream`:
+
+```js
+_open() {
+  const store = new Corestore(path.join(this.dir, 'pear-runtime', 'corestore'))
+  const swarm = new Hyperswarm()
+
+  this.store = store
+  this.swarm = swarm
+
+  const pear = new PearRuntime({
+    dir: this.dir,
+    app: this.app,
+    updates: this.updates,
+    version: this.version,
+    upgrade: this.upgrade,
+    name: this.name,
+    store,
+    swarm
+  })
+
+  this.pear = pear
+  // ...
+}
+```
+
+See [`app.js`](https://github.com/holepunchto/hello-pear-bare/blob/variant/single-thread/app.js) on the `variant/single-thread` branch for the full file.
+
+### `daemon`
+
+`bin.mjs` spawns a **detached** updater and returns immediately—the foreground command never blocks on the network:
+
+```js
+if (updates !== false) {
+  App.spawnUpdater(dir, os.execPath(), isDev ? Bare.argv[1] : null, wait)
+}
+```
+
+`App.spawnUpdater` re-invokes the same executable with a hidden `--updater` flag through [`bare-daemon`](https://github.com/holepunchto/bare-daemon):
+
+```js
+static spawnUpdater(dir, app, entrypoint, updateWindow) {
+  const args = entrypoint === null ? [] : [entrypoint]
+  args.push('--updater', '--storage', dir)
+  if (updateWindow !== undefined) args.push('--update-window', String(updateWindow))
+  return daemon.spawn(app, args)
+}
+```
+
+The daemon acquires an `updater.lock` file in the storage directory—via [`fs-native-extensions`](https://github.com/holepunchto/fs-native-extensions)—so only one updater runs per storage directory at a time, waits up to `--update-window` (default 30 seconds) for an update to arrive, and logs to `<storage>/updates.log` instead of stdout since nothing is attached to read it. See [`app.js`](https://github.com/holepunchto/hello-pear-bare/blob/variant/daemon/app.js) and [`bin.mjs`](https://github.com/holepunchto/hello-pear-bare/blob/variant/daemon/bin.mjs) on the `variant/daemon` branch for the full files.
+
+Tune how long a run waits for an update before giving up:
+
+```bash
+npm start -- --updates --update-window 60000
+```
+
 ## Build a standalone binary
 
 [`bare-build`](https://github.com/holepunchto/bare-build) compiles `bin.mjs` and its dependencies into a single standalone executable with no peer dependencies—users don't need Node.js, Bare, or the [Pear CLI](/reference/pear/cli) installed. Build for your current host with:

--- a/examples/getting-started/hello-pear-bare-daemon/README.md
+++ b/examples/getting-started/hello-pear-bare-daemon/README.md
@@ -1,0 +1,157 @@
+# hello-pear-bare
+
+> Pear Hello World for Standalone Bare Processes with `pear-runtime`
+
+End-to-end boilerplate for embedding [pear-runtime] into a Standalone [Bare] Process with peer-to-peer OTA update support.
+
+This variant is for providing P2P OTA updates to short-lived CLI programs. It uses a detached [`bare-daemon`][bare-daemon] updater, allowing the foreground command to exit while the update check continues in the background. Long-lived programs (services, REPLs TUIs) with are better suited to `main` or `single-thread` variants.
+
+- Peer-to-Peer deployment with [pear][pear-docs] CLI
+- Peer-to-Peer Over-the-Air updates with [`pear-runtime`][pear-runtime] module
+- Detached updater process via [`bare-daemon`][bare-daemon]
+- Cross-platform standalone distributables via [`bare-build`][bare-build]
+
+## Variants
+
+- [`main`](https://github.com/holepunchto/hello-pear-bare/tree/main): runs `pear-runtime` inside a Bare worker thread.
+- [`single-thread`](https://github.com/holepunchto/hello-pear-bare/tree/variant/single-thread): workerless with `pear-runtime` updates.
+- (current) [`daemon`](https://github.com/holepunchto/hello-pear-bare/tree/variant/daemon): runs `pear-runtime` in a detached updater daemon.
+
+## Table of Contents
+
+- [OS Support](#os-support)
+- [Requirements](#requirements)
+- [Development](#development)
+  - [Install Dependencies](#install-dependencies)
+  - [Create an upgrade link](#create-an-upgrade-link)
+  - [Start](#start)
+- [Architecture](#architecture)
+  - [Updates](#updates)
+- [Peer-to-Peer Deployments](#peer-to-peer-deployments)
+- [Installing Distributables](#installing-distributables)
+- [Scripts](#scripts)
+- [Project Structure](#project-structure)
+- [Troubleshooting](#troubleshooting)
+
+## OS Support
+
+- **macOS** — arm64, x64
+- **Linux** — arm64, x64
+- **Windows** — arm64, x64
+
+## Requirements
+
+- `npm` via [Node.js][nodejs]
+- [pear][pear-docs] - `npx pear`
+
+## Development
+
+### Install Dependencies
+
+```sh
+npm install
+```
+
+### Create an upgrade link
+
+This template expects `package.json` to contain a valid `pear://` link in the `upgrade` field. If it still contains the placeholder `pear://<YOUR_KEY_HERE>`, startup will fail with `INVALID_URL`.
+
+Create a link with [`pear touch`](https://docs.pears.com/reference/cli.html#pear-touch-flags-channel):
+
+```sh
+pear touch
+```
+
+Copy the generated `pear://...` link into the `upgrade` field in `package.json`.
+
+### Start
+
+Start app in development mode:
+
+```sh
+npm start
+```
+
+By default this repo starts with `--no-updates` in development to avoid local dev binaries being swapped while you iterate.
+
+Enable updates for local flow testing:
+
+```sh
+npm start -- --updates
+```
+
+Set how long the daemon waits for an update:
+
+```sh
+npm start -- --updates --update-window 60000
+```
+
+Development runs are unbundled, so they exercise the daemon lifecycle without replacing the local Bare executable. Updates are applied by standalone builds.
+
+## Architecture
+
+### Updates
+
+Updates are managed by the `App` class in `app.js`. The foreground CLI starts itself in a detached updater mode with `bare-daemon`. The updater owns `Corestore`, `Hyperswarm` and `PearRuntime`, while `updater.lock` ensures only one updater runs per storage directory.
+
+It uses the configured `upgrade` link in `package.json`, waits 30 seconds by default and writes output to `<storage>/updates.log`. Once a download starts, the daemon remains alive until the update is applied or an error occurs.
+
+Per-run disable updates:
+
+```sh
+npm start -- --no-updates
+```
+
+## Peer-to-Peer Deployments
+
+Use the [`pear`][pear-docs] CLI to deploy applications.
+
+Set the `upgrade` field in `package.json` to your distribution drive link, then follow the default flow from section 4 onward:
+
+[hello-pear-electron: 4. Build Deployment Directory and onward](https://github.com/holepunchto/hello-pear-electron#4-build-deployment-directory-)
+
+## Installing Distributables
+
+Once the `pear://<key>` upgrade link is seeding the build deployment folder the standalone binary can be installed peer-to-peer directly onto the system with Pear:
+
+```sh
+npx pear-install pear://<key>
+```
+
+## Scripts
+
+- `npm start` - run the Bare Process in dev mode (`bare bin.mjs --no-updates`)
+- `npm test` - run `brittle-bare` tests
+- `npm run lint` - run prettier check and lunte
+- `npm run format` - format repository with prettier
+- `npm run make` - auto-detect host OS/arch and run matching build target
+- `npm run make:darwin-arm64` - build standalone to `out/darwin-arm64`
+- `npm run make:darwin-x64` - build standalone to `out/darwin-x64`
+- `npm run make:linux-arm64` - build standalone to `out/linux-arm64`
+- `npm run make:linux-x64` - build standalone to `out/linux-x64`
+- `npm run make:win32-arm64` - build standalone to `out/win32-arm64`
+- `npm run make:win32-x64` - build standalone to `out/win32-x64`
+
+## Project Structure
+
+- `bin.mjs` - entrypoint and runtime wiring
+- `app.js` - daemon launcher and updater resource
+- `scripts/make.js` - platform/arch build target selector
+- `test/index.js` - brittle-bare tests
+
+## Troubleshooting
+
+- `INVALID_URL: Invalid URL 'pear://<YOUR_KEY_HERE>'` means the placeholder `upgrade` link in `package.json` has not been replaced. Run `pear touch`, then put the generated `pear://...` link in `package.json`.
+- If updates do not trigger, verify `package.json` contains a valid `upgrade` Pear link and that peers are seeding the target drive.
+- Check `<storage>/updates.log` for daemon startup and updater errors.
+- If `npm run make` fails on unsupported hosts, run a specific `make:<platform>-<arch>` script or build on a supported host.
+- This template does not implement app-level data persistence; it is a minimal CLI + updater example.
+
+<!-- Reference Links -->
+
+[pear-docs]: https://docs.pears.com
+[bare-daemon]: https://github.com/holepunchto/bare-daemon
+[pear-runtime]: https://github.com/holepunchto/pear-runtime
+[Bare]: https://github.com/holepunchto/bare
+[nodejs]: https://nodejs.org
+[bare-build]: https://github.com/holepunchto/bare-build

--- a/examples/getting-started/hello-pear-bare-daemon/app.js
+++ b/examples/getting-started/hello-pear-bare-daemon/app.js
@@ -1,0 +1,181 @@
+const fs = require('bare-fs')
+const fsx = require('fs-native-extensions')
+const daemon = require('bare-daemon')
+const path = require('bare-path')
+const Corestore = require('corestore')
+const Hyperswarm = require('hyperswarm')
+const PearRuntime = require('pear-runtime')
+const ReadyResource = require('ready-resource')
+
+module.exports = class App extends ReadyResource {
+  static spawnUpdater(dir, app, entrypoint, updateWindow) {
+    const args = entrypoint === null ? [] : [entrypoint]
+    args.push('--updater', '--storage', dir)
+    if (updateWindow !== undefined) {
+      args.push('--update-window', String(updateWindow))
+    }
+    return daemon.spawn(app, args)
+  }
+
+  constructor({ dir, app, updates, version, upgrade, name }) {
+    super()
+
+    fs.mkdirSync(dir, { recursive: true })
+
+    this.dir = dir
+    this.app = app
+    this.updates = updates
+    this.version = version
+    this.upgrade = upgrade
+    this.name = name
+
+    this.store = null
+    this.swarm = null
+    this.pear = null
+    this.timeout = null
+    this.lock = null
+    this.downloading = false
+  }
+
+  async _open() {
+    const store = new Corestore(path.join(this.dir, 'pear-runtime', 'corestore'))
+    const swarm = new Hyperswarm()
+
+    this.store = store
+    this.swarm = swarm
+
+    try {
+      const pear = new PearRuntime({
+        dir: this.dir,
+        app: this.app,
+        updates: this.updates,
+        version: this.version,
+        upgrade: this.upgrade,
+        name: this.name,
+        store,
+        swarm
+      })
+
+      this.pear = pear
+
+      pear.on('error', (err) => this.emit('error', err))
+      pear.updater.on('error', (err) => this.emit('error', err))
+
+      if (this.updates !== false) {
+        pear.updater.on('updating', () => {
+          this.downloading = true
+          clearTimeout(this.timeout)
+          this.timeout = null
+          this.emit('updating')
+        })
+        pear.updater.on('updating-delta', (delta) => this.emit('updating-delta', delta))
+        pear.updater.on('updated', () => {
+          this.downloading = false
+          this._applyUpdate()
+        })
+      }
+
+      await pear.ready()
+
+      if (this.updates === false) return
+      swarm.on('connection', (connection) => store.replicate(connection))
+      swarm.join(pear.updater.drive.core.discoveryKey, {
+        client: true,
+        server: false
+      })
+    } catch (err) {
+      await this._teardown().catch(noop)
+      throw err
+    }
+  }
+
+  async _close() {
+    await this._teardown()
+  }
+
+  async _teardown() {
+    clearTimeout(this.timeout)
+    this.timeout = null
+    this.downloading = false
+
+    const store = this.store
+    const swarm = this.swarm
+    const pear = this.pear
+    const lock = this.lock
+
+    this.store = null
+    this.swarm = null
+    this.pear = null
+    this.lock = null
+
+    try {
+      await swarm?.destroy()
+      await pear?.close()
+      await store?.close()
+    } finally {
+      if (lock !== null) {
+        fsx.unlock(lock)
+        fs.closeSync(lock)
+      }
+    }
+  }
+
+  async _applyUpdate() {
+    this.emit('updated')
+    const pear = this.pear
+    if (pear === null) return
+
+    try {
+      await pear.updater.applyUpdate()
+      this.emit('update-applied')
+    } catch (err) {
+      this.emit('error', err)
+    }
+  }
+
+  async updater(wait = 30_000) {
+    if (this.updates === false) return
+
+    const lock = fs.openSync(path.join(this.dir, 'updater.lock'), 'a+')
+    if (fsx.tryLock(lock) === false) {
+      fs.closeSync(lock)
+      return
+    }
+    this.lock = lock
+
+    let completed = false
+    let resolveCompletion
+    const completion = new Promise((resolve) => {
+      resolveCompletion = resolve
+    })
+    const complete = () => {
+      completed = true
+      clearTimeout(this.timeout)
+      this.timeout = null
+      resolveCompletion()
+    }
+
+    this.once('update-applied', complete)
+    this.once('error', complete)
+    this.once('close', complete)
+
+    try {
+      await this.ready()
+      if (completed === false && this.downloading === false) {
+        this.timeout = setTimeout(complete, wait)
+      }
+      await completion
+    } finally {
+      this.removeListener('update-applied', complete)
+      this.removeListener('error', complete)
+      this.removeListener('close', complete)
+    }
+  }
+
+  async exit(code = 0) {
+    Bare.exitCode = code
+    await this.close()
+  }
+}
+
+function noop() {}

--- a/examples/getting-started/hello-pear-bare-daemon/bin.mjs
+++ b/examples/getting-started/hello-pear-bare-daemon/bin.mjs
@@ -1,0 +1,107 @@
+import { command, flag, summary } from 'paparam'
+import { persistent } from 'bare-storage'
+import process from 'bare-process'
+import os from 'bare-os'
+import { isWindows } from 'which-runtime'
+import path from 'bare-path'
+import FileLog from 'bare-file-logger'
+import Console from 'bare-console'
+import pkg from './package.json'
+import App from './app.js'
+
+const appName = pkg.productName || pkg.name
+const isDev = path.basename(Bare.argv[0], path.extname(Bare.argv[0])) === 'bare'
+
+const cmd = command(
+  appName,
+  summary(pkg.description),
+  flag('--version|-v', 'Print the current version'),
+  flag('--storage <dir>', 'custom storage directory'),
+  flag('--no-updates', 'disable OTA updates for this run'),
+  flag('--update-window <ms>', 'updater wait in milliseconds'),
+  flag('--updater', 'run updater daemon').hide()
+)
+
+cmd.parse(Bare.argv.slice(isDev ? 2 : 1))
+if (cmd.flags.help) Bare.exit()
+if (cmd.flags.version) {
+  console.log(`${appName} v${pkg.version}`)
+  Bare.exit()
+}
+
+const updates = cmd.flags.updates
+const storage = cmd.flags.storage || (isDev ? null : path.join(persistent(), appName))
+const dir = storage || path.join(os.tmpdir(), 'pear', appName)
+let wait
+try {
+  wait = updateWindow(cmd.flags.updateWindow)
+} catch (err) {
+  console.error('[app:error]', err.message)
+  Bare.exit(1)
+}
+
+if (cmd.flags.updater) {
+  await runUpdater(dir, wait)
+  Bare.exit()
+}
+
+console.log(`Updates: ${updates === false ? 'disabled' : 'enabled'}`)
+
+if (updates !== false) {
+  try {
+    App.spawnUpdater(dir, os.execPath(), isDev ? Bare.argv[1] : null, wait)
+  } catch (err) {
+    console.error('[app:error]', err)
+    Bare.exit(1)
+  }
+}
+
+console.log('\nCLI ready.\n')
+
+async function runUpdater(dir, wait) {
+  const app = new App({
+    dir,
+    app: isDev ? null : os.execPath(),
+    updates: true,
+    version: pkg.version,
+    upgrade: pkg.upgrade,
+    name: isWindows ? appName + '.exe' : appName
+  })
+  const output = new FileLog(path.join(dir, 'updates.log'), { maxSize: 1024 * 1024 })
+  const log = new Console(output)
+
+  app.on('updating', () => log.log('[updater] getting new update'))
+  app.on('updating-delta', (delta) => log.log('[updater]', delta))
+  app.on('updated', () => log.log('[updater] update complete... applying'))
+  app.on('update-applied', () => log.log('[updater] applied update, restart to run latest version'))
+  app.on('error', (err) => log.error('[app:error]', err))
+
+  process.on('SIGHUP', () => app.exit(129))
+  process.on('SIGINT', () => app.exit(130))
+  process.on('SIGQUIT', () => app.exit(131))
+  process.on('SIGTERM', () => app.exit(143))
+
+  let code = 0
+  try {
+    await app.updater(wait)
+  } catch (err) {
+    log.error('[app:error]', err)
+    code = 1
+  }
+  code = Bare.exitCode || code
+  try {
+    await app.exit(code)
+  } finally {
+    output.close()
+  }
+}
+
+function updateWindow(value) {
+  if (value === undefined) return undefined
+
+  const wait = Number(value)
+  if (Number.isSafeInteger(wait) === false || wait < 0) {
+    throw new Error('--update-window must be a non-negative integer')
+  }
+  return wait
+}

--- a/examples/getting-started/hello-pear-bare-daemon/package-lock.json
+++ b/examples/getting-started/hello-pear-bare-daemon/package-lock.json
@@ -1,0 +1,2735 @@
+{
+  "name": "hello-pear-bare",
+  "version": "0.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hello-pear-bare",
+      "version": "0.0.0-rc.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-console": "^6.2.0",
+        "bare-daemon": "^1.2.4",
+        "bare-file-logger": "^1.2.1",
+        "bare-fs": "^4.7.2",
+        "bare-os": "^3.9.0",
+        "bare-path": "^3.0.0",
+        "bare-process": "^4.5.0",
+        "bare-storage": "^1.1.0",
+        "corestore": "^7.9.2",
+        "fs-native-extensions": "^1.5.0",
+        "hyperswarm": "^4.17.0",
+        "paparam": "^1.10.1",
+        "pear-runtime": "^1.1.4",
+        "ready-resource": "^1.2.0",
+        "which-runtime": "^1.4.0"
+      },
+      "bin": {
+        "hello-pear-bare": "bin.mjs"
+      },
+      "devDependencies": {
+        "bare-build": "^1.0.1",
+        "bare-runtime": "^1.29.5",
+        "brittle": "^3.19.0",
+        "lunte": "^1.2.0",
+        "prettier": "^3.6.2",
+        "prettier-config-holepunch": "^2.0.0"
+      }
+    },
+    "node_modules/@hyperswarm/secret-stream": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@hyperswarm/secret-stream/-/secret-stream-6.9.1.tgz",
+      "integrity": "sha512-xb0S5y3YJwBakD77JOGBHlBxdp63mHClZoXBYoLv+9wH8e054ESKlmQptWqjJK5dv5VMUIVYOJB4MaOpB0JdGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.1.0",
+        "hypercore-crypto": "^3.3.1",
+        "noise-curve-ed": "^2.0.1",
+        "noise-handshake": "^4.0.0",
+        "sodium-secretstream": "^1.1.0",
+        "sodium-universal": "^5.0.0",
+        "streamx": "^2.14.0",
+        "timeout-refresh": "^2.0.0",
+        "unslab": "^1.3.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/adaptive-timeout": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/adaptive-timeout/-/adaptive-timeout-1.0.1.tgz",
+      "integrity": "sha512-+seGiBtHqbnyZ0Quq/ZGxxwP66153WBABawa07/QeyuPFzbduPBjiGQAyCiriiLDzt3dkbMBskSlfqtRwblK8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xache": "^1.2.1"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-abort": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/bare-abort/-/bare-abort-2.0.13.tgz",
+      "integrity": "sha512-zdc8l88eB11Jsz5rDd6sCAgv2kUFXgdrZWoMlgU6JMkfAi1/uuGFC3IEHswKbIRQTk5H3T5CMuechsXYxiaHlQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-addon-resolve": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.10.0.tgz",
+      "integrity": "sha512-sSd0jieRJlDaODOzj0oe0RjFVC1QI0ZIjGIdPkbrTXsdVVtENg14c+lHHAhHwmWCZ2nQlMhy8jA3Y5LYPc/isA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-module-resolve": "^1.10.0",
+        "bare-semver": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-ansi-escapes": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/bare-ansi-escapes/-/bare-ansi-escapes-2.2.3.tgz",
+      "integrity": "sha512-02ES4/E2RbrtZSnHJ9LntBhYkLA6lPpSEeP8iqS3MccBIVhVBlEmruF1I7HZqx5Q8aiTeYfQVeqmrU9YO2yYoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-stream": "^2.6.5"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-apk": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/bare-apk/-/bare-apk-0.1.3.tgz",
+      "integrity": "sha512-LakK8fcKDQaMDZvfaMAH7vB1tkDrKGi8rffSG4QkagM+Db8kn6pOEr02Iacix0cG3G83HlKqJ7xmIl4uZHkIhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-env": "^3.0.0",
+        "bare-fs": "^4.5.2",
+        "bare-os": "^3.6.2",
+        "bare-path": "^3.0.0",
+        "bare-subprocess": "^5.2.1",
+        "require-asset": "^1.2.1"
+      }
+    },
+    "node_modules/bare-app-image": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/bare-app-image/-/bare-app-image-0.1.1.tgz",
+      "integrity": "sha512-FOmSjy+0bx6Qkztl+n7PHhrqxSnu4ccsokjHPwQUFnDNcAetYlxsLQHquq7B/vJeZiowBVJV+ulrTdwuVBfXpA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "dependencies": {
+        "bare-fs": "^4.5.1",
+        "bare-path": "^3.0.0",
+        "bare-subprocess": "^5.1.5",
+        "require-asset": "^1.1.0"
+      }
+    },
+    "node_modules/bare-assert": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bare-assert/-/bare-assert-1.2.0.tgz",
+      "integrity": "sha512-c6uvgvTJBspTDxtVnPgrBKmLgcpW3Fp72NVKDLg6oT4QjQbhGtvrkHMhGYMK1sh4vjBHOBmuUalyt9hSzV37fQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-inspect": "^3.1.2"
+      }
+    },
+    "node_modules/bare-buffer": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/bare-buffer/-/bare-buffer-3.6.1.tgz",
+      "integrity": "sha512-8mzp60t6jdSD3cEGmyxAV1YrAN2+mnxiUvBPQHJJ4WNk0hSVLJGSIEolRj09ZP8yt/+oSj2N2f5kDVW8297n4A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "bare": ">=1.20.0"
+      }
+    },
+    "node_modules/bare-build": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build/-/bare-build-1.0.1.tgz",
+      "integrity": "sha512-UUaJT/Wpz6wiStnQcKFiB+BliI4dw3l+9IrKSt1EHB/xsYiPi32mOmlJX/oHhX6dpAW/kyIYGM7OcjWBerQ+Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "workspaces": [
+        "npm/*",
+        "test/fixtures/*"
+      ],
+      "dependencies": {
+        "bare-build-android-arm": "1.0.1",
+        "bare-build-android-arm64": "1.0.1",
+        "bare-build-android-ia32": "1.0.1",
+        "bare-build-android-x64": "1.0.1",
+        "bare-build-darwin-arm64": "1.0.1",
+        "bare-build-darwin-x64": "1.0.1",
+        "bare-build-ios-arm64": "1.0.1",
+        "bare-build-ios-arm64-simulator": "1.0.1",
+        "bare-build-ios-x64-simulator": "1.0.1",
+        "bare-build-linux-arm64": "1.0.1",
+        "bare-build-linux-x64": "1.0.1",
+        "bare-build-win32-arm64": "1.0.1",
+        "bare-build-win32-x64": "1.0.1",
+        "bare-bundle-id": "^1.0.2",
+        "bare-fs": "^4.5.1",
+        "bare-lief": "^0.1.3",
+        "bare-link": "^3.1.0",
+        "bare-module-resolve": "^1.12.0",
+        "bare-module-traverse": "^2.0.0",
+        "bare-os": "^3.6.2",
+        "bare-pack": "^2.0.0",
+        "bare-path": "^3.0.0",
+        "bare-semver": "^1.0.3",
+        "bare-subprocess": "^5.1.5",
+        "bare-tpl": "^1.0.0",
+        "bare-unpack": "^1.1.3",
+        "bare-url": "^2.3.2",
+        "paparam": "^1.8.0"
+      },
+      "bin": {
+        "bare-build": "bin.js"
+      },
+      "optionalDependencies": {
+        "bare-apk": "^0.1.2",
+        "bare-app-image": "^0.1.0"
+      }
+    },
+    "node_modules/bare-build-android-arm": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build-android-arm/-/bare-build-android-arm-1.0.1.tgz",
+      "integrity": "sha512-3XEH1SWFHJnkeOYh59dch1Te6U8Qh+imqtbdyvc31cQdBP19FHnUksMlC8+iXDiH4i4XA8tm/o+RIEYRsWVJkQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      }
+    },
+    "node_modules/bare-build-android-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build-android-arm64/-/bare-build-android-arm64-1.0.1.tgz",
+      "integrity": "sha512-yKBeQ3/mXP09osdS49I3I7yw3ZnDllZeJDLXgIE1UvMRBPMMQ+ha8xc3//zAlaTLqEzcDvyDEbg4whqLdqpe2A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      }
+    },
+    "node_modules/bare-build-android-ia32": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build-android-ia32/-/bare-build-android-ia32-1.0.1.tgz",
+      "integrity": "sha512-xSGPnvGePkdnpEIWdK8uERzsLOaiPvYNeCat5mYZNaV+7muo6BGUghyHlZYhErru6gvG8I2xT9kXa+Zrfci79g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      }
+    },
+    "node_modules/bare-build-android-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build-android-x64/-/bare-build-android-x64-1.0.1.tgz",
+      "integrity": "sha512-B/N4c5LPtI+VnE7IPSfJwf4hUTsXN9l5CIZMGD8GBSJDB4gnmroOoYljVI4FURtXvhT6eibH8zGzSyzWWNC85Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      }
+    },
+    "node_modules/bare-build-darwin-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build-darwin-arm64/-/bare-build-darwin-arm64-1.0.1.tgz",
+      "integrity": "sha512-WQPJrU/rdqUuHE5dhkmG1m86yxZFdW8YxoQPPWKps3UMVnUi2nurUiVrbXjABytKRnTXOU5Zcn/gFuTHmj2Czg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      }
+    },
+    "node_modules/bare-build-darwin-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build-darwin-x64/-/bare-build-darwin-x64-1.0.1.tgz",
+      "integrity": "sha512-eqWc3QevrHveHebIrsDKPrKMIaiw0bfQDTnEeQkxovUVv6mxLa7iLl/e/MVZDJS/iwaKbTNdfgBOwxr9QGGYSA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      }
+    },
+    "node_modules/bare-build-ios-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build-ios-arm64/-/bare-build-ios-arm64-1.0.1.tgz",
+      "integrity": "sha512-oidAnaBbRhZMHxRMkMbsQUSnxMgIZYlbnBAS89M+Lz14gU7H15CPcNPEtVMIkT3FmMF4yJqh9LVrRPMerV3PIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      }
+    },
+    "node_modules/bare-build-ios-arm64-simulator": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build-ios-arm64-simulator/-/bare-build-ios-arm64-simulator-1.0.1.tgz",
+      "integrity": "sha512-IuEj0rob1Q/d/8k9CfhQto30T6/7egMzBTvkpSgrkCJg7HjUomWDmhL5pmF9QAECRHkcQfeYMcsIV1/gm3Nd9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      }
+    },
+    "node_modules/bare-build-ios-x64-simulator": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build-ios-x64-simulator/-/bare-build-ios-x64-simulator-1.0.1.tgz",
+      "integrity": "sha512-0b1K2upUhdMu/03+XSVFhzaw+0JFPjLxBXKitfbEVhXsJ1lkpDvk+gmxqgZ5ayM0cYwV+kATvSc1UWPQ/Jdm9w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      }
+    },
+    "node_modules/bare-build-linux-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build-linux-arm64/-/bare-build-linux-arm64-1.0.1.tgz",
+      "integrity": "sha512-DBfWBeNHVxVAr+mOVQJsAqu7q6xaW6Cl1KDCAsgZyu+GtnfzKORRVM6m36AVINpqkPJLFS322oPhOEndltriUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      }
+    },
+    "node_modules/bare-build-linux-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build-linux-x64/-/bare-build-linux-x64-1.0.1.tgz",
+      "integrity": "sha512-IzIAVGvcdSeM/Vc1LP/f2Q0VXnEJBkiI1bgRY4AXBX9mH1GZLC4KiH513IFtlWZREvhijBrRWMK+vs/BLakrqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      }
+    },
+    "node_modules/bare-build-win32-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build-win32-arm64/-/bare-build-win32-arm64-1.0.1.tgz",
+      "integrity": "sha512-u1IzNH28KyvywAwJpx8MaFlyZxI8epW+Nlc5LOn9REVNscZIQ3OFiIbIwedU5zA6H4dVCnV8B7iQBYS57Cz/8Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      }
+    },
+    "node_modules/bare-build-win32-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build-win32-x64/-/bare-build-win32-x64-1.0.1.tgz",
+      "integrity": "sha512-j59qDgopfW2x5AnnDo5TFggf0o6Pestd1XDad1b6MvL1J0n1ixNRdqsT9HRRqEm95nZvQeO4F2EhdD6HPOz36A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      }
+    },
+    "node_modules/bare-bundle": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/bare-bundle/-/bare-bundle-1.10.0.tgz",
+      "integrity": "sha512-4LVlnJAHr00Hh6Vu6ZUJS38rcEtJT3b3vChXSsBsJ2mk1TN0lQ+gzd+Dw5L0aV7uqDZv84smuwW+O02X7PfDlw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-bundle-id": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bare-bundle-id/-/bare-bundle-id-1.0.2.tgz",
+      "integrity": "sha512-RG/y1J/s6zWmsqUIDtclXh+xxMRTh1jo/10vFL58FKhe9UESchMNkwn0Cz10o5AdA/35WR/KUGoHhIGdyCjQrg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "sodium-native": "^5.0.9"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-bundle": "*"
+      }
+    },
+    "node_modules/bare-compat-napi": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/bare-compat-napi/-/bare-compat-napi-1.3.9.tgz",
+      "integrity": "sha512-1xmFuB8x2BIyBSPoZYsS2v2vRMSKUGgmcvjKPfHNqmeqtnjVDcANjVv7mucK0Yb01rlBlYB1ftT1n/zXaNmtmA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-console": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/bare-console/-/bare-console-6.2.0.tgz",
+      "integrity": "sha512-qQ+Vasa3NwNdVDcUWKIIEG5p7MKO7uABcV/xBR9MDwQg3QklC5ayemaHzBa/ER4h6TKN2PRQN5IppNwUAMtb8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-format": "^1.0.2",
+        "bare-hrtime": "^2.0.0",
+        "bare-logger": "^2.0.0",
+        "bare-system-logger": "^1.0.2",
+        "bare-type": "^1.1.0"
+      }
+    },
+    "node_modules/bare-cov": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/bare-cov/-/bare-cov-1.2.2.tgz",
+      "integrity": "sha512-d/b4HdL5ohZDwBvDegJeSkmo1X2MGlm22jXzuY2D7wl2W1+7nk/b7+HMogwgUa+zi8rVVRJQKHCHPHYBJpvlvw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.1.2",
+        "bare-inspector": "^6.0.1",
+        "bare-path": "^3.0.0",
+        "bare-process": "^4.2.1",
+        "bare-url": "^2.1.5",
+        "bare-v8-to-istanbul": "^1.0.2",
+        "picomatch": "^4.0.2",
+        "which-runtime": "^1.2.1"
+      }
+    },
+    "node_modules/bare-crypto": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/bare-crypto/-/bare-crypto-1.15.3.tgz",
+      "integrity": "sha512-macV9lbyJTsLPRXJkBtz8ivTGEo3LCyJInLT9IB/PWJ7pRXwvHs/FP4bx/fWw+HZkiepIYCAV2cuU5CR92XWCw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-assert": "^1.2.0",
+        "bare-stream": "^2.6.3"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-daemon": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/bare-daemon/-/bare-daemon-1.2.4.tgz",
+      "integrity": "sha512-pyWmqqsN9x2RNzXFpHObyU8+9vgFL7q63Nhtk+xRTXcWL/LkZrYpLmIpYlyPzwZrT2vL+lrjBwVMyCljThfC+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-env": "^3.0.0",
+        "bare-os": "^3.6.2",
+        "require-addon": "^1.1.0"
+      }
+    },
+    "node_modules/bare-debug-log": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bare-debug-log/-/bare-debug-log-2.0.0.tgz",
+      "integrity": "sha512-Vi42PkMQsNV9PUpx2Gl1hikshx5O9FzMJ6o9Nnopseg7qLBBK7Nl31d0RHcfwLEAfmcPApytpc0ZFfq68u22FQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-dns": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/bare-dns/-/bare-dns-2.1.4.tgz",
+      "integrity": "sha512-abwjHmpWqSRNB7V5615QxPH92L71AVzFm/kKTs8VYiNTAi2xVdonpv0BjJ0hwXLwomoW+xsSOPjW6PZPO14asg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.7.0"
+      }
+    },
+    "node_modules/bare-encoding": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bare-encoding/-/bare-encoding-1.0.3.tgz",
+      "integrity": "sha512-Kqf+t/azs13lUeyK4Tb7ha4wdLRXKWCXQ8w1rVmt7KtoPCPdHD/Xwt7LBIsCSwwGglrcmblo5VOLa5avkJqULA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-env": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-env/-/bare-env-3.0.0.tgz",
+      "integrity": "sha512-0u964P5ZLAxTi+lW4Kjp7YRJQ5gZr9ycYOtjLxsSrupgMz3sn5Z9n4SH/JIifHwvadsf1brA2JAjP+9IOWwTiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-file-logger": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bare-file-logger/-/bare-file-logger-1.2.3.tgz",
+      "integrity": "sha512-Jba+Gsc+WPP1HGbJ7G8h66Si58vDGDFsHttk3Ew0x0EHezc940ta7vw2xd77LZhdTT10zmPhsKfj+Qk6HZPU0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.7.0",
+        "bare-logger": "^2.0.0"
+      }
+    },
+    "node_modules/bare-format": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bare-format/-/bare-format-1.0.2.tgz",
+      "integrity": "sha512-GswdhnOnP9QtwRbrf4wLApw5widkaLMsLe2XOs35fQD2YfEN1ApoGka+cZ7PfvzxMgfYXmMhj/2OGlVn5/Dxgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-inspect": "^3.0.0"
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-hrtime": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bare-hrtime/-/bare-hrtime-2.1.1.tgz",
+      "integrity": "sha512-VMb3tHo05gsnbu3OXTmkDiwTjMlOsbQmKoysKqKEyR09m77TuDrYFbj3Q5GGk10dAKsUHrnXmwCaeJqzVpB5ZA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-http-parser": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bare-http-parser/-/bare-http-parser-1.1.5.tgz",
+      "integrity": "sha512-sPaDetLbWRmth04JmuTCvw/hoNdWJvYUJN8n1tYdGW3HM0mMnCvK2f0oIxE6HK7iOq+WlsRzEMg1LT/b0wGbLQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-http1": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/bare-http1/-/bare-http1-4.5.7.tgz",
+      "integrity": "sha512-PRuzs9ywt4vUvrC3mnHhQyaQfLYzdFy8XKOH0oKeKmYfyYYUqXBkdbJE2csESLBxJEbKDBjxPGLU+Qa0l1ds4A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.6.0",
+        "bare-http-parser": "^1.1.1",
+        "bare-stream": "^2.10.0",
+        "bare-tcp": "^2.2.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-https": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-https/-/bare-https-3.0.0.tgz",
+      "integrity": "sha512-W1GRSCzn+xXKf5bMcPs/hg6Ga1bxPqb7owGfS+tvlBQfPe5Q2STcanRuKZrgU60v5uKrhXH5cgWwM+DLqvXZgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-http1": "^4.4.0",
+        "bare-tcp": "^2.2.0",
+        "bare-tls": "^3.0.0"
+      }
+    },
+    "node_modules/bare-inspect": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/bare-inspect/-/bare-inspect-3.1.4.tgz",
+      "integrity": "sha512-jfW5KRA84o3REpI6Vr4nbvMn+hqVAw8GU1mMdRwUsY5yJovQamxYeKGVKGqdzs+8ZbG4jRzGUXP/3Ji/DnqfPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-ansi-escapes": "^2.1.0",
+        "bare-type": "^1.0.0"
+      },
+      "engines": {
+        "bare": ">=1.18.0"
+      }
+    },
+    "node_modules/bare-inspector": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/bare-inspector/-/bare-inspector-6.0.1.tgz",
+      "integrity": "sha512-rL+aKJ74FhF+6iJS2cV3C8js8nGF37H05ldiyMojgFP/N5eYShZ/mhSbTcDh1yriW5jndYd6xWQU0E/CE14Tiw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.1.0",
+        "bare-http1": "^4.0.0",
+        "bare-stream": "^2.0.0",
+        "bare-url": "^2.0.0",
+        "bare-ws": "^3.0.0"
+      },
+      "engines": {
+        "bare": ">=1.25.0"
+      },
+      "peerDependencies": {
+        "bare-tcp": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-tcp": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-lief": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bare-lief/-/bare-lief-0.1.6.tgz",
+      "integrity": "sha512-eNqgZGoHVPGtbkLoDPVyKKEe9uTkXFqOvTevb1iDv3SXv/eU7kMgJoAukSdvFUg7QWNiqd2o/pZwaMy5n3cjNw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-addon": "^1.2.0"
+      }
+    },
+    "node_modules/bare-link": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/bare-link/-/bare-link-3.2.2.tgz",
+      "integrity": "sha512-8URo/GQp1tQloDmCbM2fw3vUaSWs6aNbq3yyy6ioVy4z2zatWHzfeSncI6FXRn7MBcuXgMyBCCdg/NM3sAPUiw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.0.0",
+        "bare-lief": "^0.2.0",
+        "bare-module-resolve": "^1.12.0",
+        "bare-os": "^3.2.0",
+        "bare-path": "^3.0.0",
+        "bare-subprocess": "^6.0.0",
+        "bare-url": "^2.0.9",
+        "paparam": "^1.5.0"
+      },
+      "bin": {
+        "bare-link": "bin.js"
+      }
+    },
+    "node_modules/bare-link/node_modules/bare-lief": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/bare-lief/-/bare-lief-0.2.4.tgz",
+      "integrity": "sha512-h9urnxzacY8z2BKc4ABdbyGXBivfern5IPXzbtU94KyXD8r0nGBKtjQTU0BNHq0POxE6qe8zLGfuQSd9IoqpQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-assert": "^1.2.0",
+        "require-addon": "^1.2.0"
+      }
+    },
+    "node_modules/bare-link/node_modules/bare-subprocess": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/bare-subprocess/-/bare-subprocess-6.1.0.tgz",
+      "integrity": "sha512-8L6KtbmreDy4Fc1BdDqaDo9fg0nbedUmTSFQxYPV0uHIM2BBAX8+E0LyMDKgkk0I+mlKto80WYzOnIhT8VDdOg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-env": "^3.0.0",
+        "bare-events": "^2.5.4",
+        "bare-os": "^3.0.1",
+        "bare-pipe": "^4.2.0",
+        "bare-structured-clone": "^1.5.2",
+        "bare-tcp": "^2.4.1",
+        "bare-url": "^2.2.2"
+      },
+      "engines": {
+        "bare": ">=1.7.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-logger": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/bare-logger/-/bare-logger-2.0.3.tgz",
+      "integrity": "sha512-U6K7NxHdeAHxEgHFDV8zXvgjgDZKQO6LlCrxQvUvlrZEVTnoezSImMWizi85rbZpVsbeI1ZWcLCRGnoIf5EV8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-format": "^1.0.0"
+      }
+    },
+    "node_modules/bare-module": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/bare-module/-/bare-module-6.2.0.tgz",
+      "integrity": "sha512-CoCTG8y8HKPnNW317OW1hynl28DasVPtbX033ZEAXk0Q3SYCUXi3OOnNAr6wTrDgMgpOsW0kl7Nifcom5GGH8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-bundle": "^1.3.0",
+        "bare-module-lexer": "^1.0.0",
+        "bare-module-resolve": "^1.8.0",
+        "bare-path": "^3.0.0",
+        "bare-url": "^2.0.1"
+      },
+      "engines": {
+        "bare": ">=1.23.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-module-lexer": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bare-module-lexer/-/bare-module-lexer-1.5.0.tgz",
+      "integrity": "sha512-FXjqDdVrR9zizyHcZvJtkUNe9CanFo9eOmo33O8CGEL45xYMiZDUvAqoQhsHb/RK2QKsryAyKiNv0W5kiALzmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-addon": "^1.0.2"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-module-resolve": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.2.tgz",
+      "integrity": "sha512-j+hiD5k99qec4KjJvYsI67q5AOBifmy9JG3oeMVxTmvrhn2sIdp8StrUvZu4YNgwTpO+NhniQG16N1ETDe1k5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-semver": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-module-traverse": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bare-module-traverse/-/bare-module-traverse-2.1.1.tgz",
+      "integrity": "sha512-+gNplZqErqrFwgAEqkGBz25sOaqkUMJV+2ZCM8qtAyg/WU+6jX2n6k5eJEe6QIqpWqTHpuSkXYQSVC0S+GtOAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-addon-resolve": "^1.5.0",
+        "bare-module-lexer": "^1.4.0",
+        "bare-module-resolve": "^1.7.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-net": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/bare-net/-/bare-net-2.3.2.tgz",
+      "integrity": "sha512-I+yz+pqbYsBkxDsnu5vkKvy7RSNY9CcAvu2jZT6PsmdXJQG1i3dmD5V7xc3334OVp2absgtUEYLmmuNFlphBzg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.2.2",
+        "bare-pipe": "^4.0.0",
+        "bare-stream": "^2.0.0",
+        "bare-tcp": "^2.0.0"
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-pack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bare-pack/-/bare-pack-2.1.0.tgz",
+      "integrity": "sha512-0iJ/2NRWYbB8iL8bWfQrKbtQzJHUyt3pdgyjDCNKhM3SeRNVi7rzrW6e6a/albzmwDm+x0frxiV2mNgAO0VdKg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-bundle": "^1.8.3",
+        "bare-bundle-id": "^1.0.0",
+        "bare-fs": "^4.2.1",
+        "bare-module-traverse": "~2.1.1",
+        "bare-path": "^3.0.0",
+        "paparam": "^1.5.0",
+        "promaphore": "^1.0.0"
+      },
+      "bin": {
+        "bare-pack": "bin.js"
+      },
+      "peerDependencies": {
+        "bare-buffer": "^3.6.0",
+        "bare-url": "^2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-pipe": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/bare-pipe/-/bare-pipe-4.2.1.tgz",
+      "integrity": "sha512-il5ssf8MGPHtuaHnqjAiJHUzNQ3dahjkIMAo1k+7+zxdqscZZf8gLyptjFGQHVNHb24z8zwmAXpMBeNcFjwMBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.0.0",
+        "bare-stream": "^2.0.0"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      }
+    },
+    "node_modules/bare-posix": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-posix/-/bare-posix-1.0.1.tgz",
+      "integrity": "sha512-b4quA8dyRVvX0aFIAIiev5zFATHwIUGr42Gmt+CqiBNg/bdsNkrj4bbkeotMOMiljJS4DCME5kywJO/TFwKo1A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-process": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/bare-process/-/bare-process-4.5.0.tgz",
+      "integrity": "sha512-NTtYDiwleJjWWNg4+yzS6B/RovL/LLPHVvoOM+18W+dYAXCmky0zFfN66hqqBbrlGAlb52/QgKrdzPR3x1QyHA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-abort": "^2.0.13",
+        "bare-env": "^3.0.0",
+        "bare-events": "^2.3.1",
+        "bare-hrtime": "^2.0.0",
+        "bare-os": "^3.7.1",
+        "bare-posix": "^1.0.1",
+        "bare-signals": "^4.0.0",
+        "bare-stdio": "^1.0.1"
+      }
+    },
+    "node_modules/bare-runtime": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime/-/bare-runtime-1.29.5.tgz",
+      "integrity": "sha512-PlKgMADJHL4SkzoQCE7uXzOJ0ZZKfDsdwcxFlTZ+ZKX8FJcuNqr8WHkG27ohirFEvNelYki8eBBk16bJGSfkVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "workspaces": [
+        "npm/*"
+      ],
+      "dependencies": {
+        "bare-fs": "^4.4.4",
+        "bare-os": "^3.0.1",
+        "bare-path": "^3.0.0",
+        "bare-process": "^4.2.1",
+        "bare-subprocess": "^6.1.0"
+      },
+      "bin": {
+        "bare": "bin/bare"
+      },
+      "optionalDependencies": {
+        "bare-runtime-android-arm": "1.29.5",
+        "bare-runtime-android-arm64": "1.29.5",
+        "bare-runtime-android-ia32": "1.29.5",
+        "bare-runtime-android-x64": "1.29.5",
+        "bare-runtime-darwin-arm64": "1.29.5",
+        "bare-runtime-darwin-x64": "1.29.5",
+        "bare-runtime-ios-arm64": "1.29.5",
+        "bare-runtime-ios-arm64-simulator": "1.29.5",
+        "bare-runtime-ios-x64-simulator": "1.29.5",
+        "bare-runtime-linux-arm64": "1.29.5",
+        "bare-runtime-linux-x64": "1.29.5",
+        "bare-runtime-win32-arm64": "1.29.5",
+        "bare-runtime-win32-x64": "1.29.5"
+      }
+    },
+    "node_modules/bare-runtime-android-arm": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime-android-arm/-/bare-runtime-android-arm-1.29.5.tgz",
+      "integrity": "sha512-b8syj2a++blVZCxu/3dBpnP93g8+st4Jl9N/TUL01iIFw5azLiImraJFylT9kJBCM1JN6qMQqPP2ImwspZIdMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      },
+      "bin": {
+        "bare": "bin/bare"
+      }
+    },
+    "node_modules/bare-runtime-android-arm64": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime-android-arm64/-/bare-runtime-android-arm64-1.29.5.tgz",
+      "integrity": "sha512-/0ltvJfco7D19m42/ZbOPugRexaZDXYIbBeuyh5eMUwA4YVtvXfBbQOPz/Tfm3V740PhdL/Oeuya54ABAZ8akw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      },
+      "bin": {
+        "bare": "bin/bare"
+      }
+    },
+    "node_modules/bare-runtime-android-ia32": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime-android-ia32/-/bare-runtime-android-ia32-1.29.5.tgz",
+      "integrity": "sha512-HV7xsZjpg57a4f5MkTR/JpxM+VhzgD4kpWyXP09MleqHUQEYYyuI9jSo9ZN6yT9pkRgrSaFDBTXIKtiqY8QZGA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      },
+      "bin": {
+        "bare": "bin/bare"
+      }
+    },
+    "node_modules/bare-runtime-android-x64": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime-android-x64/-/bare-runtime-android-x64-1.29.5.tgz",
+      "integrity": "sha512-/7mnA0aArtXgfntX6ie48R7Mcbt2sTDXoSgF1XaheTzFpYhSJa7EX6zELcZfIHXZ/H9vj7DP6FJWykJlpMCmQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      },
+      "bin": {
+        "bare": "bin/bare"
+      }
+    },
+    "node_modules/bare-runtime-darwin-arm64": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime-darwin-arm64/-/bare-runtime-darwin-arm64-1.29.5.tgz",
+      "integrity": "sha512-0lnroA/FmXKsWjIg9yQEJjOaW1G6W8CAs2Uq/w+3eIoF6sUNYrxTnbt+C1aT5apae3QFGgPeuDoOXezCEKtB5g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      },
+      "bin": {
+        "bare": "bin/bare"
+      }
+    },
+    "node_modules/bare-runtime-darwin-x64": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime-darwin-x64/-/bare-runtime-darwin-x64-1.29.5.tgz",
+      "integrity": "sha512-xyJn0JUy7r2ymukoSBR5FyHf1JTLVM9F/OXKpHzKL8/3/wY4hXDEDzAH4nTJB2U6p5+Tfrk59x4lLQM2LyMpKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      },
+      "bin": {
+        "bare": "bin/bare"
+      }
+    },
+    "node_modules/bare-runtime-ios-arm64": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime-ios-arm64/-/bare-runtime-ios-arm64-1.29.5.tgz",
+      "integrity": "sha512-pJEYLL8U1S8JGavDiAWJQdBwSFrkNgU8ISoX1BGstXN+R1kEzXXdtRULpJV9W3+ekMrG8DPjpWwnucFqfMcPzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "ios"
+      ],
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      },
+      "bin": {
+        "bare": "bin/bare"
+      }
+    },
+    "node_modules/bare-runtime-ios-arm64-simulator": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime-ios-arm64-simulator/-/bare-runtime-ios-arm64-simulator-1.29.5.tgz",
+      "integrity": "sha512-cqCTS2ITf1OOfvCYo78LbROvaZdpXzeYuEF+4eVauNecd/gmENLDN2eViBA1cMs2oEjfQOrmErolkmouaKHKLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "ios"
+      ],
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      },
+      "bin": {
+        "bare": "bin/bare"
+      }
+    },
+    "node_modules/bare-runtime-ios-x64-simulator": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime-ios-x64-simulator/-/bare-runtime-ios-x64-simulator-1.29.5.tgz",
+      "integrity": "sha512-5e+Wbw6zm5scjqyOvYgifR2A9aPWTMq/Lrat7llaXRd3g+T2gdYyJAP3n6RVYzvreDthvZVl7RfiXVKo3A1wBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "ios"
+      ],
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      },
+      "bin": {
+        "bare": "bin/bare"
+      }
+    },
+    "node_modules/bare-runtime-linux-arm64": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime-linux-arm64/-/bare-runtime-linux-arm64-1.29.5.tgz",
+      "integrity": "sha512-v6/FSrJ5oHeisOY0GHqTX4u/JwwIw1mRUIS85dXGwd8dnHyqFOECCguu4hNazqxuTiwsvZZ32ECnotwpPKinow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      },
+      "bin": {
+        "bare": "bin/bare"
+      }
+    },
+    "node_modules/bare-runtime-linux-x64": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime-linux-x64/-/bare-runtime-linux-x64-1.29.5.tgz",
+      "integrity": "sha512-OJgxNF85+mEB56zA1KVF4MSEKI6iNuZdaC5STE3UwySYrUkCTEDDmDh5ISSt81mTFz34qqQqQSEqTX02gXV1sw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      },
+      "bin": {
+        "bare": "bin/bare"
+      }
+    },
+    "node_modules/bare-runtime-win32-arm64": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime-win32-arm64/-/bare-runtime-win32-arm64-1.29.5.tgz",
+      "integrity": "sha512-rg5Zzd0Jp7LLu0fmj4MNQSRjqnFPRybO8tpfY4h/mnOBmsDhHjlJ+d+sltXCfioQvUCdkapNTEWPkMkU4Az9YA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      },
+      "bin": {
+        "bare": "bin/bare.exe"
+      }
+    },
+    "node_modules/bare-runtime-win32-x64": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime-win32-x64/-/bare-runtime-win32-x64-1.29.5.tgz",
+      "integrity": "sha512-vWYLRXo2R7v//jFz/dRD306NgZsgZMADaiEVlUcHjYWb16AtPaR/cIr7OJBWnEFMvqixTiUfEA0Hd9n91P3KMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      },
+      "bin": {
+        "bare": "bin/bare.exe"
+      }
+    },
+    "node_modules/bare-runtime/node_modules/bare-subprocess": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/bare-subprocess/-/bare-subprocess-6.1.0.tgz",
+      "integrity": "sha512-8L6KtbmreDy4Fc1BdDqaDo9fg0nbedUmTSFQxYPV0uHIM2BBAX8+E0LyMDKgkk0I+mlKto80WYzOnIhT8VDdOg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-env": "^3.0.0",
+        "bare-events": "^2.5.4",
+        "bare-os": "^3.0.1",
+        "bare-pipe": "^4.2.0",
+        "bare-structured-clone": "^1.5.2",
+        "bare-tcp": "^2.4.1",
+        "bare-url": "^2.2.2"
+      },
+      "engines": {
+        "bare": ">=1.7.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-semver": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.0.3.tgz",
+      "integrity": "sha512-HS/A30bi2+PiRJfU6R4+Kp+6KeLSCSByjYM2iiobOKzLAvtu1CT+S8xWfiU7wz0erknjkUoC+yXy108tzIuP5Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-sidecar": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/bare-sidecar/-/bare-sidecar-0.4.6.tgz",
+      "integrity": "sha512-imHop80OGC9HE5gVNQtAGJg5duUH2DL/7v7is0JrcdzE7WtleemWZ7BnlESB24l4xgAMEQnADkAgcMNiweMcNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.5.1",
+        "bare-module": "^6.1.3",
+        "bare-os": "^3.6.2",
+        "bare-path": "^3.0.0",
+        "bare-pipe": "^4.1.3",
+        "bare-stream": "^2.7.0",
+        "bare-subprocess": "^6.0.0",
+        "bare-url": "^2.3.2",
+        "require-asset": "^1.1.0"
+      }
+    },
+    "node_modules/bare-sidecar/node_modules/bare-subprocess": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/bare-subprocess/-/bare-subprocess-6.1.0.tgz",
+      "integrity": "sha512-8L6KtbmreDy4Fc1BdDqaDo9fg0nbedUmTSFQxYPV0uHIM2BBAX8+E0LyMDKgkk0I+mlKto80WYzOnIhT8VDdOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-env": "^3.0.0",
+        "bare-events": "^2.5.4",
+        "bare-os": "^3.0.1",
+        "bare-pipe": "^4.2.0",
+        "bare-structured-clone": "^1.5.2",
+        "bare-tcp": "^2.4.1",
+        "bare-url": "^2.2.2"
+      },
+      "engines": {
+        "bare": ">=1.7.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-signals": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/bare-signals/-/bare-signals-4.2.0.tgz",
+      "integrity": "sha512-fNHMOdQIlYuTvMB3Oh9Apk99hLKn351+Ir8vz+khiPTcOqIyGG4uWWjdLTzxWdYGsA0eT+We3y0K74hjj2nq7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.3",
+        "bare-os": "^3.3.1"
+      },
+      "engines": {
+        "bare": ">=1.7.0"
+      }
+    },
+    "node_modules/bare-stdio": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bare-stdio/-/bare-stdio-1.0.2.tgz",
+      "integrity": "sha512-3WJDqtvVGP4f+j68kyEC05umOYNwKJ1xG+YAXL8yZ605WgNqiRhVaFq+mVIhBt2eKNp7pa5vCQdhOt1pNh79SA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.5.2",
+        "bare-pipe": "^4.1.5",
+        "bare-tty": "^5.0.3"
+      }
+    },
+    "node_modules/bare-storage": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bare-storage/-/bare-storage-1.1.0.tgz",
+      "integrity": "sha512-zaQ4dtK4WeYPA1Hz8c9xCimkQLdZbeZnFp/6TmHh6/X5W6o/qXclxNno8DOeZRvdVjziMcADAId2TZJobWydkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-compat-napi": "^1.3.9",
+        "bare-env": "^3.0.0",
+        "bare-fs": "^4.5.3",
+        "bare-os": "^3.0.0",
+        "bare-path": "^3.0.0",
+        "require-addon": "^1.2.0"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-structured-clone": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/bare-structured-clone/-/bare-structured-clone-1.5.5.tgz",
+      "integrity": "sha512-b1x++7qt6x7T0Rm8NAg/EnU13+rn3Gfglv8N5PGtFcfdi4yAfLJs/mLbrVfc+C66DFrO+CxdIsl1NcnE6Ra+xQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-buffer": "^3.6.0",
+        "bare-type": "^1.1.0",
+        "bare-url": "^2.4.0",
+        "compact-encoding": "^3.0.1"
+      },
+      "engines": {
+        "bare": ">=1.2.0"
+      }
+    },
+    "node_modules/bare-stylize": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/bare-stylize/-/bare-stylize-0.0.1.tgz",
+      "integrity": "sha512-l3MjmIl476bWijYWf3RbE+osl4iuXSOMudzp0vAqzIK7gPgn/+G3oAxp8Oin9CFF911KBP0LO9kts8Ci8mGZaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-ansi-escapes": "^2.2.3",
+        "bare-process": "^4.2.1"
+      }
+    },
+    "node_modules/bare-subprocess": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bare-subprocess/-/bare-subprocess-5.2.3.tgz",
+      "integrity": "sha512-07wwswlV7M3sC9IykbZRZ/jHAkrXFWVLqdBWGv1y0ojCimtRD9hGwxdHmR5FUFmDUZLNsBmTYJNQqgio5+A85Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-env": "^3.0.0",
+        "bare-events": "^2.5.4",
+        "bare-os": "^3.0.1",
+        "bare-pipe": "^4.0.0",
+        "bare-url": "^2.2.2"
+      },
+      "engines": {
+        "bare": ">=1.7.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-system-logger": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bare-system-logger/-/bare-system-logger-1.0.3.tgz",
+      "integrity": "sha512-HXTXZyhIIS4ZDYun4J9zKNQZDfLgEkkK8wy9nrTFJE5xq8APsOhDxuEsxP0YcNwC23DW1jaNpqD51zDeXPzIdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-logger": "^2.0.0"
+      }
+    },
+    "node_modules/bare-tcp": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/bare-tcp/-/bare-tcp-2.5.0.tgz",
+      "integrity": "sha512-lwUy3jSVoloVBbCCyPFmmqT1KaeBk/XEkpLMHU+BCap8WNXc48iQfiWEQYgJkCRYuP6vnkZ0XHCLY222TJ29Wg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-dns": "^2.0.4",
+        "bare-events": "^2.5.4",
+        "bare-stream": "^2.6.4"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-pipe": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-pipe": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-tls": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/bare-tls/-/bare-tls-3.1.7.tgz",
+      "integrity": "sha512-AMw8tJlb3LhzAmhgXRcjDrTlNxR3gXXyj6G8eU9iwvCFtiUBD8MxAW7bwunA1gXDukgo40A970jX0APc2jMU7A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-net": "^2.0.1",
+        "bare-stream": "^2.6.4"
+      },
+      "engines": {
+        "bare": ">=1.7.0"
+      }
+    },
+    "node_modules/bare-tpl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-tpl/-/bare-tpl-1.0.1.tgz",
+      "integrity": "sha512-eOViEnDVFaPMALTbNioW5aYro9OR4b/6tdMNx73Gd1l+TjF0mL3sXCpNdbOBNzTttyFX5hhTesjJCGHrY0q7fg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-tty": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bare-tty/-/bare-tty-5.1.0.tgz",
+      "integrity": "sha512-EZLvW4A+XiJgI3TW+e1pMME9PIJsfEXe/DA/WSKzIkq/v7Yarpv/rvG6Z5pGnpo4V/Bd+qopwnCLSR71hMMBYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.2.0",
+        "bare-signals": "^4.0.0",
+        "bare-stream": "^2.0.0"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      }
+    },
+    "node_modules/bare-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bare-type/-/bare-type-1.1.0.tgz",
+      "integrity": "sha512-LdtnnEEYldOc87Dr4GpsKnStStZk3zfgoEMXy8yvEZkXrcCv9RtYDrUYWFsBQHtaB0s1EUWmcvS6XmEZYIj3Bw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.2.0"
+      }
+    },
+    "node_modules/bare-unpack": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/bare-unpack/-/bare-unpack-1.1.3.tgz",
+      "integrity": "sha512-b+OFTi74dsMaVQy9w90U6WMqhVBcx5hONJnFbOSfhTefG/9OuY6ZxU3IvybVa5/i3edzboa7rebaMG25K6/kAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-bundle": "^1.8.3",
+        "bare-fs": "^4.2.3",
+        "bare-path": "^3.0.0",
+        "paparam": "^1.8.5",
+        "promaphore": "^1.0.0"
+      },
+      "bin": {
+        "bare-unpack": "bin.js"
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/bare-utils": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/bare-utils/-/bare-utils-1.6.0.tgz",
+      "integrity": "sha512-WhQEIkkAxkSnW7u1QgrI0AfNm5JpMruETXeYsb5qnkBJ0TTfNKygZmsh6rkoHBANaV+C/7Jed7bJP9OmEHG7rQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-debug-log": "^2.0.0",
+        "bare-encoding": "^1.0.0",
+        "bare-format": "^1.0.0",
+        "bare-inspect": "^3.0.0",
+        "bare-stylize": "^0.0.1",
+        "bare-type": "^1.0.6"
+      }
+    },
+    "node_modules/bare-v8-to-istanbul": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bare-v8-to-istanbul/-/bare-v8-to-istanbul-1.0.2.tgz",
+      "integrity": "sha512-CM0wPgyQtXTQ7h4q8NjbTZ/FH5he0Jkiwgpq0lFZZA5tkVZzmQ/9ul4R7E+cNlGZJIZlQZ9v4CwbgVaFG3zOAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-assert": "^1.0.2",
+        "bare-fs": "^4.1.2",
+        "bare-module": "^6.1.2",
+        "bare-path": "^3.0.0",
+        "bare-process": "^4.2.0",
+        "bare-url": "^2.1.5",
+        "bare-utils": "^1.2.0",
+        "v8-to-istanbul": "^9.3.0",
+        "which-runtime": "^1.2.1"
+      }
+    },
+    "node_modules/bare-ws": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-ws/-/bare-ws-3.0.0.tgz",
+      "integrity": "sha512-q2v0UIQ0cFQBXQMp+0FRaoSk1EoYgOhzO7yio0TqBV6Rkfot97mbBYxb1ssw5faVCisVaFxQYY8113SMLYQBow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-crypto": "^1.2.0",
+        "bare-events": "^2.3.1",
+        "bare-http1": "^4.0.0",
+        "bare-https": "^3.0.0",
+        "bare-stream": "^2.1.2"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/big-sparse-array": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/big-sparse-array/-/big-sparse-array-1.0.3.tgz",
+      "integrity": "sha512-6RjV/3mSZORlMdpUaQ6rUSpG637cZm0//E54YYGtQg1c1O+AbZP8UTdJ/TchsDZcTVLmyWZcseBfp2HBeXUXOQ==",
+      "license": "MIT"
+    },
+    "node_modules/binary-stream-equals": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/binary-stream-equals/-/binary-stream-equals-1.0.0.tgz",
+      "integrity": "sha512-xiUT5LGfD8JiLhbXiG+ByOnbgb9f2ssRLfZDQMl3nZdf89EotQZGZuMkDN8J3n46emabE7RnJ1q0r7Hv3INExw==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.3.1"
+      }
+    },
+    "node_modules/bits-to-bytes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bits-to-bytes/-/bits-to-bytes-1.3.0.tgz",
+      "integrity": "sha512-OJoHTpFXS9bXHBCekGTByf3MqM8CGblBDIduKQeeVVeiU9dDWywSSirXIBYGgg3d1zbVuvnMa1vD4r6PA0kOKg==",
+      "license": "ISC",
+      "dependencies": {
+        "b4a": "^1.5.0"
+      }
+    },
+    "node_modules/blind-relay": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/blind-relay/-/blind-relay-1.6.1.tgz",
+      "integrity": "sha512-38YmKCl/m9NcTkwueBbcGIt9Zx3IT/Q9Nsluu6C5Gur6PqfE0zWPhPwCzia1hri/g0ICYxrqkgLtEaoWD5WeSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-events": "^2.2.0",
+        "bits-to-bytes": "^1.3.0",
+        "compact-encoding": "^3.0.0",
+        "compact-encoding-bitfield": "^1.0.0",
+        "protomux": "^3.5.1",
+        "sodium-universal": "^5.0.0",
+        "streamx": "^2.15.1"
+      }
+    },
+    "node_modules/bogon": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bogon/-/bogon-1.3.0.tgz",
+      "integrity": "sha512-04tu0G/v0f2HPuQlSfhO635WwHDBCaITJ490rhxH9ttUlgPqOirZVKV02YB6NvPf5VkmbqJCm3bnZwrPk/eDSg==",
+      "license": "MIT",
+      "dependencies": {
+        "compact-encoding": "^3.0.0",
+        "compact-encoding-net": "^1.2.0"
+      }
+    },
+    "node_modules/brittle": {
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/brittle/-/brittle-3.19.1.tgz",
+      "integrity": "sha512-4Ted1Mt9o9B6oIA6ImJJCtB/Fv++ZO3IDNQgRcHOXWSYGRUidgxchaGrUBaRn+4mlneXrgInPkCPzi0jO8qKbA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.0",
+        "bare-assert": "^1.0.2",
+        "bare-cov": "^1.1.0",
+        "bare-fs": "^4.1.6",
+        "bare-os": "^3.6.1",
+        "bare-path": "^3.0.0",
+        "bare-process": "^4.2.1",
+        "bare-subprocess": "^5.0.0",
+        "bare-url": "^2.1.6",
+        "error-stack-parser": "^2.1.4",
+        "globbie": "^1.0.2",
+        "paparam": "^1.6.2",
+        "same-object": "^1.0.2",
+        "test-tmp": "^1.4.0",
+        "tmatch": "^5.0.0"
+      },
+      "bin": {
+        "brittle": "bin/node.js",
+        "brittle-bare": "bin/bare.js",
+        "brittle-node": "bin/node.js",
+        "brittle-pear": "bin/pear.js"
+      }
+    },
+    "node_modules/codecs": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/codecs/-/codecs-3.1.0.tgz",
+      "integrity": "sha512-Dqx8NwvBvnMeuPQdVKy/XEF71igjR5apxBvCGeV0pP1tXadOiaLvDTXt7xh+/5wI1ASB195mXQGJbw3Ml4YDWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.3"
+      }
+    },
+    "node_modules/compact-encoding": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/compact-encoding/-/compact-encoding-3.2.0.tgz",
+      "integrity": "sha512-cCe/FM8f/WuXkEVpsYEoSX3ht2tec7NSNOC8rZBv/sbdFzO3h2Z/JUmZwJQBhghKJNimJSkWM40YURhgU640jw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.3.0"
+      }
+    },
+    "node_modules/compact-encoding-bitfield": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/compact-encoding-bitfield/-/compact-encoding-bitfield-1.1.0.tgz",
+      "integrity": "sha512-F6wliSKHi50BsBStmnsRJAzJgYSIYzdfSe3M0oHj4uQ1RcctJK/NQVD7wF51bj/DBMne2i5gUxrGUFkNZQns5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "compact-encoding": "^3.0.0"
+      }
+    },
+    "node_modules/compact-encoding-net": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/compact-encoding-net/-/compact-encoding-net-1.3.0.tgz",
+      "integrity": "sha512-HIYjL3aMiSENApR691aMLngXt6rkTHb9HUkEukcx3YwIZpoMUVXHXyjBzoo9kVwC7KakooBA1RRWb46Cu6qtAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "compact-encoding": "^3.0.0"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/corestore": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/corestore/-/corestore-7.10.1.tgz",
+      "integrity": "sha512-QdcNtpFSYtVHA4UcUSSf2m9gNMT9QqSs9fn+pZx6xdUivNono18JhtpEP/TYpP9heKB7yd+qLsLQP5bo65sg6A==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.7",
+        "bare-events": "^2.8.3",
+        "hypercore": "^11.32.0",
+        "hypercore-crypto": "^3.4.2",
+        "hypercore-errors": "^1.4.0",
+        "hypercore-id-encoding": "^1.3.0",
+        "ready-resource": "^1.1.1",
+        "sodium-universal": "^5.0.1",
+        "streamx": "^2.26.0",
+        "which-runtime": "^1.2.1"
+      }
+    },
+    "node_modules/debounceify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/debounceify/-/debounceify-1.1.0.tgz",
+      "integrity": "sha512-eKuHDVfJVg+u/0nPy8P+fhnLgbyuTgVxuCRrS/R7EpDSMMkBDgSes41MJtSAY1F1hcqfHz3Zy/qpqHHIp/EhdA==",
+      "license": "MIT"
+    },
+    "node_modules/device-file": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/device-file/-/device-file-2.3.1.tgz",
+      "integrity": "sha512-bmON44lwxJPle9N2OcH4tqM44pMGZKT8G6OkzXkz0urvqQ9LKkoQdTS6w0ztYfmLdUE27R4UUmx0+y2gEz4Jug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.7",
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0",
+        "fd-lock": "^2.1.0",
+        "fs-native-extensions": "^1.4.0",
+        "ready-resource": "^1.2.0"
+      }
+    },
+    "node_modules/dht-rpc": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/dht-rpc/-/dht-rpc-6.27.0.tgz",
+      "integrity": "sha512-NsfgRlFDQnkA2+H+hJXMPLmBOn/TSIIc0cRMV8q42M4xc1uAXWtpvIIQsONF5tYcYC6px0bslrUGideN1h4S4A==",
+      "license": "MIT",
+      "dependencies": {
+        "adaptive-timeout": "^1.0.1",
+        "b4a": "^1.6.1",
+        "bare-events": "^2.2.0",
+        "compact-encoding": "^3.0.0",
+        "compact-encoding-net": "^1.2.0",
+        "fast-fifo": "^1.1.0",
+        "kademlia-routing-table": "^1.0.1",
+        "nat-sampler": "^1.0.1",
+        "sodium-universal": "^5.0.0",
+        "streamx": "^2.13.2",
+        "time-ordered-set": "^2.0.0",
+        "udx-native": "^1.5.3"
+      }
+    },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
+    "node_modules/fd-lock": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fd-lock/-/fd-lock-2.1.1.tgz",
+      "integrity": "sha512-H3VkcWFl39Rk0xBokDcUyBcVs6VrYTUo/DhDWMzJOF99wXWDAvmvq/GlLTS2NTehsznZhp3fXVyrtB2ldDXhwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.5.0",
+        "fs-native-extensions": "^1.4.4",
+        "ready-resource": "^1.2.0",
+        "resource-on-exit": "^1.0.0"
+      }
+    },
+    "node_modules/flat-tree": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/flat-tree/-/flat-tree-1.13.0.tgz",
+      "integrity": "sha512-fT3HIuCPwHhFgJ20QYzDHgUG0zMmFg5cHvFiFo5h+QMSJ28TihsEVY0f8HGliuO+pOzmvjMx1odToeaEWkTnyQ==",
+      "license": "MIT"
+    },
+    "node_modules/fs-native-extensions": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/fs-native-extensions/-/fs-native-extensions-1.5.0.tgz",
+      "integrity": "sha512-nuZLFm9mGCxvyi7Llww/J4OyifKCS21nEUTAmnlTZp3FObPOvA32aCedCmt4Z+8yk+caqfClNaSCfn/P7T7FLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-addon": "^1.1.0",
+        "which-runtime": "^1.2.0"
+      }
+    },
+    "node_modules/generate-object-property": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-2.0.0.tgz",
+      "integrity": "sha512-KwuURPyqn2Mz8DdV29pJwQu0Y7tcsbkULr82eeOcY/ZllFK6I9Wm8dsRByIu7CKWlFi9BdW1b3mcXMp/kQBQsw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.0"
+      }
+    },
+    "node_modules/generate-string": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/generate-string/-/generate-string-1.0.1.tgz",
+      "integrity": "sha512-IfTY0dKZM43ACyGvXkbG7De7WY7MxTS5VO6Juhe8oJKpCmrYYXoqp/cJMskkpi0k9H8wuXq0H+eI898/BCqvXg==",
+      "license": "MIT"
+    },
+    "node_modules/globbie": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globbie/-/globbie-1.0.3.tgz",
+      "integrity": "sha512-hcryJmKcftf82xfBWTWxuUITWIIoYO3ec104V17SMHGFl6VLbm1d1Ju9LX9L+jyJTwICpemX/dmPI/HGYoKr1A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.1.2",
+        "bare-path": "^3.0.0",
+        "bare-process": "^4.2.1",
+        "picomatch": "^4.0.2"
+      }
+    },
+    "node_modules/hyperbee": {
+      "version": "2.27.3",
+      "resolved": "https://registry.npmjs.org/hyperbee/-/hyperbee-2.27.3.tgz",
+      "integrity": "sha512-PXURH2U4juUZyJRKHTrY5z1zX851pmI1Q0jfv5F/hCIErDt/ND8jOZuxc3hfOLM9f0W3qJEDTMlV5AJBkVPy8w==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.0",
+        "codecs": "^3.0.0",
+        "debounceify": "^1.0.0",
+        "hypercore-errors": "^1.0.0",
+        "mutexify": "^1.4.0",
+        "protocol-buffers-encodings": "^1.2.0",
+        "rache": "^1.0.0",
+        "ready-resource": "^1.0.0",
+        "resolve-reject-promise": "^1.1.0",
+        "safety-catch": "^1.0.2",
+        "streamx": "^2.12.4",
+        "unslab": "^1.2.0"
+      }
+    },
+    "node_modules/hyperblobs": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/hyperblobs/-/hyperblobs-2.12.1.tgz",
+      "integrity": "sha512-iX5sPkL/3eDphUkMxTG43xZGEER+cVLAFbuNIQpk/WVK8CTWnmaoCYP/+94RaFFh5U7HeGoDYidQbv6E7LeAvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.1",
+        "bare-events": "^2.5.0",
+        "compact-encoding": "^3.0.0",
+        "hypercore-crypto": "^3.6.1",
+        "hypercore-errors": "^1.1.1",
+        "mutexify": "^1.4.0",
+        "speedometer": "^1.1.0",
+        "streamx": "^2.13.2"
+      }
+    },
+    "node_modules/hypercore": {
+      "version": "11.33.1",
+      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-11.33.1.tgz",
+      "integrity": "sha512-fpAWVOM4CclWAPChmsh1nAfJy5pJlFOLUOiegRws2HYzUsj5bP/VwanZYv9ruhRXRLY1qJeddXLTEz4DJf1GQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@hyperswarm/secret-stream": "^6.0.0",
+        "b4a": "^1.1.0",
+        "bare-events": "^2.2.0",
+        "big-sparse-array": "^1.0.3",
+        "compact-encoding": "^3.0.0",
+        "fast-fifo": "^1.3.0",
+        "flat-tree": "^1.9.0",
+        "hypercore-crypto": "^3.2.1",
+        "hypercore-errors": "^1.5.0",
+        "hypercore-id-encoding": "^1.2.0",
+        "hypercore-storage": "^3.0.0",
+        "is-options": "^1.0.1",
+        "nanoassert": "^2.0.0",
+        "protomux": "^3.5.0",
+        "quickbit-universal": "^2.2.0",
+        "random-array-iterator": "^1.0.0",
+        "safety-catch": "^1.0.1",
+        "sodium-universal": "^5.0.1",
+        "streamx": "^2.12.4",
+        "unslab": "^1.3.0",
+        "z32": "^1.0.0"
+      }
+    },
+    "node_modules/hypercore-crypto": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/hypercore-crypto/-/hypercore-crypto-3.7.0.tgz",
+      "integrity": "sha512-SWxobptQf2V/+ZLCCDRTXqFzGfTPIkNIuDyLKXpEMfcpJ1/ec94N9aWgylHcWOHmRt14ng/KR7z0BugebWHK9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.6",
+        "compact-encoding": "^3.0.0",
+        "sodium-universal": "^5.0.0"
+      }
+    },
+    "node_modules/hypercore-errors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/hypercore-errors/-/hypercore-errors-1.5.0.tgz",
+      "integrity": "sha512-5KQ/SuDxsvet+7qWA35Ay6zdD9WyAHQoyWHGcPUTbmJBd300gvNIJoi3oma7kp4TTCSzii6qYumNZe/s0j/saQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "hypercore-id-encoding": "^1.3.0"
+      }
+    },
+    "node_modules/hypercore-id-encoding": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/hypercore-id-encoding/-/hypercore-id-encoding-1.3.0.tgz",
+      "integrity": "sha512-W6sHdGo5h7LXEsoWfKf/KfuROZmZRQDlGqJF2EPHW+noCK66Vvr0+zE6cL0vqQi18s0kQPeN7Sq3QyR0Ytc2VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.5.3",
+        "z32": "^1.0.0"
+      }
+    },
+    "node_modules/hypercore-storage": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/hypercore-storage/-/hypercore-storage-3.1.1.tgz",
+      "integrity": "sha512-UEOtZDT2ftGSrGEfwUTzOprhwICxNHfSYgl6BxgdJZDpV18hllbUQIBdjkH+IfRNBg5c85ehSY8VZJ6bIPwPEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.7",
+        "bare-path": "^3.0.0",
+        "compact-encoding": "^3.1.0",
+        "device-file": "^2.1.2",
+        "flat-tree": "^1.12.1",
+        "hypercore-crypto": "^3.4.2",
+        "hyperschema": "^1.21.0",
+        "index-encoder": "^3.3.2",
+        "resolve-reject-promise": "^1.0.0",
+        "rocksdb-native": "^3.11.0",
+        "scope-lock": "^1.2.4",
+        "streamx": "^2.21.1"
+      }
+    },
+    "node_modules/hyperdht": {
+      "version": "6.32.0",
+      "resolved": "https://registry.npmjs.org/hyperdht/-/hyperdht-6.32.0.tgz",
+      "integrity": "sha512-Y/SibEN7wue0E8ydh8lx9IX7SOE9o00b6tufPA7hRxAafXsisWUBrW36fIHdyxg148T4Z3olrooOGZDZ89LYag==",
+      "license": "MIT",
+      "dependencies": {
+        "@hyperswarm/secret-stream": "^6.6.2",
+        "b4a": "^1.3.1",
+        "bare-events": "^2.2.0",
+        "blind-relay": "^1.3.0",
+        "bogon": "^1.0.0",
+        "compact-encoding": "^3.0.0",
+        "dht-rpc": "^6.15.1",
+        "hypercore-crypto": "^3.3.0",
+        "hypercore-id-encoding": "^1.2.0",
+        "hyperdht-address": "^1.0.1",
+        "noise-curve-ed": "^2.0.0",
+        "noise-handshake": "^4.0.0",
+        "record-cache": "^1.1.1",
+        "safety-catch": "^1.0.1",
+        "signal-promise": "^1.0.3",
+        "sodium-universal": "^5.0.1",
+        "streamx": "^2.16.1",
+        "unslab": "^1.3.0",
+        "xache": "^1.1.0"
+      },
+      "bin": {
+        "hyperdht": "bin.js"
+      }
+    },
+    "node_modules/hyperdht-address": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hyperdht-address/-/hyperdht-address-1.1.1.tgz",
+      "integrity": "sha512-Mu/+7SW2cwvHxMXswa5mOrhrS5BJyntViAuB25k8d8wNtA8eAPs4LaIq6TwN1SS/KQY02h1r+gM8cQeN/k360w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "compact-encoding": "^3.0.0",
+        "hyperschema": "^1.20.1"
+      }
+    },
+    "node_modules/hyperdrive": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/hyperdrive/-/hyperdrive-13.3.2.tgz",
+      "integrity": "sha512-YgM/be3hppRTLN7plGGot30w58imhCBhzy+bfSToyDH0Gf4ykwplOxsW3YnDIIH5Oa/tNU2ZdZHQ6IhrTZ9aLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "hyperbee": "^2.11.1",
+        "hyperblobs": "^2.9.0",
+        "hypercore": "^11.0.0",
+        "hypercore-errors": "^1.0.0",
+        "is-options": "^1.0.2",
+        "mirror-drive": "^1.2.0",
+        "ready-resource": "^1.0.0",
+        "safety-catch": "^1.0.2",
+        "speedometer": "^1.1.0",
+        "streamx": "^2.12.4",
+        "sub-encoder": "^2.1.1",
+        "unix-path-resolve": "^1.0.2"
+      }
+    },
+    "node_modules/hyperschema": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/hyperschema/-/hyperschema-1.21.0.tgz",
+      "integrity": "sha512-lEnIbLTUQf7w6FU6X+R3yUJhBwCzF4ewRnAaYOrPdcVWe1rbOf94PzMiXb5pBKxroCXzlrPLxVujxAsTrrHc8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.0.1",
+        "compact-encoding": "^3.0.0",
+        "generate-object-property": "^2.0.0",
+        "generate-string": "^1.0.1"
+      }
+    },
+    "node_modules/hyperswarm": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/hyperswarm/-/hyperswarm-4.17.0.tgz",
+      "integrity": "sha512-oe86sK961Ueg7rvDN/veFwG8xH+Iv6vObPhGDkPJcDVxk/NduW41ZhAcVDnHzRbm7S0eLU7WaDUvehOYoKSpRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.3.1",
+        "bare-events": "^2.2.0",
+        "hyperdht": "^6.21.0",
+        "safety-catch": "^1.0.2",
+        "shuffled-priority-queue": "^2.1.0",
+        "streamx": "^2.22.1",
+        "unslab": "^1.3.0"
+      }
+    },
+    "node_modules/index-encoder": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/index-encoder/-/index-encoder-3.5.0.tgz",
+      "integrity": "sha512-idZ1cxtZz2dRV6rUiaP9Xo99UjXbSzjcMacoQmxUMu/A7fEQcNPngvwDJYeWelQUS5XFlY71/or70lKn6XnwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/is-options": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-options/-/is-options-1.0.2.tgz",
+      "integrity": "sha512-u+Ai74c8Q74aS8BuHwPdI1jptGOT1FQXgCq8/zv0xRuE+wRgSMEJLj8lVO8Zp9BeGb29BXY6AsNPinfqjkr7Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.1.1"
+      }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "license": "MIT"
+    },
+    "node_modules/kademlia-routing-table": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/kademlia-routing-table/-/kademlia-routing-table-1.0.6.tgz",
+      "integrity": "sha512-Ve6jwIlUCYvUzBnXnzVRHDZCFgXURW9gmF3r7n05kZs/2rNbLHXwGdcq0qIaSwdmJCvtosgR4JensnVU65hzNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bare-events": "^2.2.0"
+      }
+    },
+    "node_modules/localdrive": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/localdrive/-/localdrive-2.2.1.tgz",
+      "integrity": "sha512-r7AMrscOky3zIjzOrbH+90P12WmFdQaIlJ26TXaUJrM3hGQ6lIQkWhy8eQs5xDI5ukEyrXp4962EIgO9DFdm+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.1",
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0",
+        "mirror-drive": "^1.2.0",
+        "mutexify": "^1.4.0",
+        "streamx": "^2.12.5",
+        "unix-path-resolve": "^1.0.2"
+      }
+    },
+    "node_modules/lunte": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lunte/-/lunte-1.8.0.tgz",
+      "integrity": "sha512-znc/elScelBYq/N6hUngr9rPdArBKhn4yR86ofnuj6qQ0MAHAo8KalAY2c/DBKw3dO4FjUZ9PR+YCFSbCgBcWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "paparam": "^1.8.6"
+      },
+      "bin": {
+        "lunte": "bin/lunte"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.8.1",
+        "bare-fs": "^4.7.0",
+        "bare-module": "^6.1.2",
+        "bare-os": "^3.6.2",
+        "bare-path": "^3.0.0",
+        "bare-process": "^4.2.2",
+        "bare-subprocess": "^5.1.4",
+        "bare-url": "^2.3.2",
+        "bare-utils": "^1.5.1"
+      }
+    },
+    "node_modules/mirror-drive": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/mirror-drive/-/mirror-drive-1.14.2.tgz",
+      "integrity": "sha512-1ZtS/TonGXWX0eDAGK90JapGyzOaz8IxX7mARZWPgUuZ9eEIvaoSY7bxv6/4FOW26wL8g/YcpqJpt8mMZ/QZCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.8.2",
+        "binary-stream-equals": "^1.0.0",
+        "rabin-stream": "^2.0.0",
+        "same-data": "^1.0.0",
+        "speedometer": "^1.1.0",
+        "streamx": "^2.22.1",
+        "unix-path-resolve": "^1.0.2"
+      }
+    },
+    "node_modules/msix-manager": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/msix-manager/-/msix-manager-0.2.5.tgz",
+      "integrity": "sha512-bfAqCBIIoxCsBCuDCr9wCfucmL0fy8jE4GBf9Yx24ZXDxQe4L7r/CJcNcGQxWx9RdHGCqCuNKrrNLfTYOue3fw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.8.2",
+        "bare-url": "^2.3.2",
+        "require-addon": "^1.2.0"
+      }
+    },
+    "node_modules/mutexify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/mutexify/-/mutexify-1.4.0.tgz",
+      "integrity": "sha512-pbYSsOrSB/AKN5h/WzzLRMFgZhClWccf2XIB4RSMC8JbquiB0e0/SH5AIfdQMdyHmYtv4seU7yV/TvAwPLJ1Yg==",
+      "license": "MIT",
+      "dependencies": {
+        "queue-tick": "^1.0.0"
+      }
+    },
+    "node_modules/nanoassert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
+      "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA==",
+      "license": "ISC"
+    },
+    "node_modules/nat-sampler": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nat-sampler/-/nat-sampler-1.0.1.tgz",
+      "integrity": "sha512-yQvyNN7xbqR8crTKk3U8gRgpcV1Az+vfCEijiHu9oHHsnIl8n3x+yXNHl42M6L3czGynAVoOT9TqBfS87gDdcw==",
+      "license": "MIT"
+    },
+    "node_modules/noise-curve-ed": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/noise-curve-ed/-/noise-curve-ed-2.1.0.tgz",
+      "integrity": "sha512-zAzJx+VwZM3w6EA1hTmDhJfvAnCeBQn/1FAeZ0LtGxCcCtlAK/uJXQVF/eDVUOaAZ286lHlx77WJ+qj9SmsRRg==",
+      "license": "ISC",
+      "dependencies": {
+        "b4a": "^1.1.0",
+        "nanoassert": "^2.0.0",
+        "sodium-universal": "^5.0.0"
+      }
+    },
+    "node_modules/noise-handshake": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/noise-handshake/-/noise-handshake-4.2.0.tgz",
+      "integrity": "sha512-9O/VTNX/E2/AToyMTTDU0J/4WhaXMTdqc2DHs9vf+snoZ0cenSBq0dNYTVV1snYYEkmo6QeRrYMxtqtoYnY+LA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.1.0",
+        "nanoassert": "^2.0.0",
+        "sodium-universal": "^5.0.0"
+      }
+    },
+    "node_modules/paparam": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/paparam/-/paparam-1.10.1.tgz",
+      "integrity": "sha512-viyQI64VIja0Za3njIzhoEP8ZVkgPowhZPuG0E96NwBfYJ6ZIyrrlhWGtFPkdN7eYLl2L8CTWL+wla0evm1KKQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/pear-aliases": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/pear-aliases/-/pear-aliases-1.0.7.tgz",
+      "integrity": "sha512-Z85C0naSKh3XMBKm1P1L2kYbIGE+Ph0HRSjTaQz5O99JvQq/wHylu9M2df1Ysfx7LG3UJrCCwZenrud18bZytw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "hypercore-id-encoding": "^1.3.0"
+      }
+    },
+    "node_modules/pear-errors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pear-errors/-/pear-errors-1.0.1.tgz",
+      "integrity": "sha512-KQyhym09QpLT4H/z3uLW0bqixgIZic2Eip2Q8Z72QmIpFzPtp6QmnzOUwB3kuHB4dqKNa+FQWHWH0NSK5lJjlw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/pear-link": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pear-link/-/pear-link-5.0.0.tgz",
+      "integrity": "sha512-Va2xz1vdm4akNonOXOQLsvsxIcT/SWai2R03l9JA5i7YTZa9F3y9AsxtUNBRNLkC4sA6Bk6+9XIa2FzvuoK/FA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0",
+        "hypercore-id-encoding": "^1.2.0",
+        "pear-aliases": "^1.0.0",
+        "pear-errors": "^1.0.0"
+      }
+    },
+    "node_modules/pear-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/pear-runtime/-/pear-runtime-1.1.4.tgz",
+      "integrity": "sha512-HfqoCYpVV6IBgyBbRXBjG8A8Ezm3JWW+pOtTQEoWh+DZ7e8x4xg+JkbdaOnAaQpVraXHdd77qd85fI4l/Rxlpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0",
+        "bare-sidecar": "^0.4.5",
+        "corestore": "^7.9.1",
+        "hyperswarm": "^4.17.0",
+        "pear-runtime-updater": "^3.0.0",
+        "ready-resource": "^1.2.0"
+      }
+    },
+    "node_modules/pear-runtime-updater": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pear-runtime-updater/-/pear-runtime-updater-3.2.0.tgz",
+      "integrity": "sha512-KLHefj2y0ehG3lE3iAgGSxSbl51ZIM9Arpzb/BW8LTjOmC3n9ydclMgvjlbuA12efQu4MnUvE7nNQ3leISxwLw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.5.3",
+        "bare-path": "^3.0.0",
+        "bare-semver": "^1.0.2",
+        "debounceify": "^1.1.0",
+        "fs-native-extensions": "^1.4.5",
+        "hypercore-id-encoding": "^1.3.0",
+        "hyperdrive": "^13.2.1",
+        "localdrive": "^2.2.0",
+        "msix-manager": "^0.2.4",
+        "pear-link": "^5.0.0",
+        "ready-resource": "^1.2.0",
+        "which-runtime": "^1.3.2"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-config-holepunch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-config-holepunch/-/prettier-config-holepunch-2.0.0.tgz",
+      "integrity": "sha512-yuskcdPRfQYLFPkOGvxS4TFmCb7QvAowjO+YaNLPLBWRev+qu6HXoKkPWH9lfNsL9gUThV7IeZ6t/B1QSu/jng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "prettier": "^3.6.2"
+      }
+    },
+    "node_modules/promaphore": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/promaphore/-/promaphore-1.0.0.tgz",
+      "integrity": "sha512-Eg8401+KJddVvDULkpy8bR964GMX8xMPegL6NdxTeBH2Wa3L86cZlEHizbkFJikr5u+E3wFoR5dLWJ+1OPyEfw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/protocol-buffers-encodings": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-encodings/-/protocol-buffers-encodings-1.2.0.tgz",
+      "integrity": "sha512-daeNPuKh1NlLD1uDfbLpD+xyUTc07nEtfHwmBZmt/vH0B7VOM+JOCOpDcx9ZRpqHjAiIkGqyTDi+wfGSl17R9w==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.0",
+        "signed-varint": "^2.0.1",
+        "varint": "5.0.0"
+      }
+    },
+    "node_modules/protomux": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/protomux/-/protomux-3.11.0.tgz",
+      "integrity": "sha512-Ze43XaNHbL6zQ/zJwVYvue7Aj8pDB1HNnISsrFhAur3291Y+Iu2fMhOpySD73J/32BoBIUYrhl07lJsBR/fUVA==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.3.1",
+        "compact-encoding": "^3.0.0",
+        "queue-tick": "^1.0.0",
+        "safety-catch": "^1.0.1",
+        "unslab": "^1.3.0"
+      }
+    },
+    "node_modules/queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
+      "license": "MIT"
+    },
+    "node_modules/quickbit-native": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/quickbit-native/-/quickbit-native-2.4.8.tgz",
+      "integrity": "sha512-FcCcqI+nIAWGknqhtrYT5TSD7t/N+Xd8ctM+2PrIIBuwOi5hx0SxAvuPtzLIEMfT/2h9+fhBakUe2uALOHX6yw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "require-addon": "^1.1.0"
+      }
+    },
+    "node_modules/quickbit-universal": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/quickbit-universal/-/quickbit-universal-2.2.0.tgz",
+      "integrity": "sha512-w02i1R8n7+6pEKTud8DfF8zbFY9o7RtPlUc3jWbtCkDKvhbx/AvV7oNnz4/TcmsPGpSJS+fq5Ud6RH6+YPvSGg==",
+      "license": "ISC",
+      "dependencies": {
+        "b4a": "^1.6.0",
+        "simdle-universal": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "quickbit-native": "^2.2.0"
+      }
+    },
+    "node_modules/rabin-native": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rabin-native/-/rabin-native-2.0.0.tgz",
+      "integrity": "sha512-x1BlYdIWh+nk9G0scvxyscrYiDPJ7vQZepqqPlVUSInIko1Zxooi8cm6lzBghEGI9aN3DXiunC8FXLgy6kke3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-addon": "^1.1.0"
+      }
+    },
+    "node_modules/rabin-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rabin-stream/-/rabin-stream-2.0.0.tgz",
+      "integrity": "sha512-EzS2Ig/qsMBSk1PahC0O0IPdRZe3bspHHLWChhqW1feKz+J46tlVL3g4wWr4lrQdXGzABIMsOhvdT6bjXYMuUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "rabin-native": "^2.0.0",
+        "streamx": "^2.23.0"
+      }
+    },
+    "node_modules/rache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rache/-/rache-1.0.0.tgz",
+      "integrity": "sha512-e0k0g0w/8jOCB+7YqCIlOa+OJ38k0wrYS4x18pMSmqOvLKoyhmMhmQyCcvfY6VaP8D75cqkEnlakXs+RYYLqNg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/random-array-iterator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-array-iterator/-/random-array-iterator-1.0.0.tgz",
+      "integrity": "sha512-u7xCM93XqKEvPTP6xZp2ehttcAemKnh73oKNf1FvzuVCfpt6dILDt1Kxl1LeBjm2iNIeR49VGFhy4Iz3yOun+Q==",
+      "license": "MIT"
+    },
+    "node_modules/ready-resource": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ready-resource/-/ready-resource-1.2.0.tgz",
+      "integrity": "sha512-nfcco/8iAFV0M+2PYnmIc+/xY0iRb35d42HFHQ7AfjulbGEAFa+XWpByfwSyeVeiBoMLLFVMv1HixxNCqzSQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "bare-events": "^2.2.0"
+      }
+    },
+    "node_modules/record-cache": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/record-cache/-/record-cache-1.2.0.tgz",
+      "integrity": "sha512-kyy3HWCez2WrotaL3O4fTn0rsIdfRKOdQQcEJ9KpvmKmbffKVvwsloX063EgRUlpJIXHiDQFhJcTbZequ2uTZw==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.3.1"
+      }
+    },
+    "node_modules/refcounter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/refcounter/-/refcounter-1.0.0.tgz",
+      "integrity": "sha512-1WosVzUy0kPUaPMEtlNDwm99UsteALIhXXR8rerELoa63WkYIXAl0hxgwPFrIYBRWZPGUyekQ04FRtPJ7dHk9w==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/require-addon": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/require-addon/-/require-addon-1.2.0.tgz",
+      "integrity": "sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-addon-resolve": "^1.3.0"
+      },
+      "engines": {
+        "bare": ">=1.10.0"
+      }
+    },
+    "node_modules/require-asset": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/require-asset/-/require-asset-1.2.2.tgz",
+      "integrity": "sha512-uc8nWKhqAxVD9Z4rST2b4yaemrC9Xb5vA1wlCz5AiCYnBYdwGRWNqFjneA5zRILzlo1MNrB63ry9+pc8wNR26w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-module-resolve": "^1.6.2"
+      },
+      "engines": {
+        "bare": ">=1.10.0",
+        "node": ">=18"
+      }
+    },
+    "node_modules/resolve-reject-promise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-reject-promise/-/resolve-reject-promise-1.1.0.tgz",
+      "integrity": "sha512-LWsTOA91AqzBTjSGgX79Tc130pwcBK6xjpJEO+qRT5IKZ6bGnHKcc8QL3upUBcWuU8OTIDzKK2VNSwmmlqvAVg==",
+      "license": "MIT"
+    },
+    "node_modules/resource-on-exit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resource-on-exit/-/resource-on-exit-1.0.0.tgz",
+      "integrity": "sha512-ViJwJAknCkLRJRPR+9SISQQ7R5eRgtdIHLJsM2hHx1MweAJbJxJ5XnMjjq0Lc7ZGv44ufzAqds1nKxiVkdy4ag==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/rocksdb-native": {
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/rocksdb-native/-/rocksdb-native-3.15.2.tgz",
+      "integrity": "sha512-8fXcL6yVfHd14NySHCNLcMKkbTO81aFog5aMrLU92vBMHpycSgqGVIevqeILGQ/jt0FAZy9lMqWO82f4eZVh/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "compact-encoding": "^3.0.0",
+        "ready-resource": "^1.0.0",
+        "refcounter": "^1.0.0",
+        "require-addon": "^1.0.2",
+        "resolve-reject-promise": "^1.1.0",
+        "signal-promise": "^1.0.3",
+        "streamx": "^2.16.1"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      }
+    },
+    "node_modules/safety-catch": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/safety-catch/-/safety-catch-1.0.3.tgz",
+      "integrity": "sha512-Zq+J1TefpoEq/HTUabo0YXX5MNvttjWYODGohgPBO2jfko8Wqx3JYMgE823szDFVamdH5PlpByvfiWScTdSYDA==",
+      "license": "MIT"
+    },
+    "node_modules/same-data": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/same-data/-/same-data-1.0.0.tgz",
+      "integrity": "sha512-Eqn7N2yV+aKMlUHTRqUwYG1Iv0cJqjlvLKj/GoP5PozJn361QaOYX14+v87r7NqQUZC22noP/LfLrSQiPwAygw==",
+      "license": "MIT"
+    },
+    "node_modules/same-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/same-object/-/same-object-1.0.2.tgz",
+      "integrity": "sha512-csHWhvUsLbIOHDM/nP+KHWM+BLPsIzWkFa8HbzaI0G7BqKXgx+7FJpKTGgLXyz5amfdY2OVBcmXTqYOMEk04og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/scope-lock": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/scope-lock/-/scope-lock-1.2.4.tgz",
+      "integrity": "sha512-BpSd8VCuCxW9ZitcdIC/vjs3gMaP9bRBL5nkHcyfX2VrS52n13/rHuBA2xJ/S/4DPuRdAO/Bk8pWd8eD/gHCIA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/shuffled-priority-queue": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/shuffled-priority-queue/-/shuffled-priority-queue-2.1.0.tgz",
+      "integrity": "sha512-xhdh7fHyMsr0m/w2kDfRJuBFRS96b9l8ZPNWGaQ+PMvnUnZ/Eh+gJJ9NsHBd7P9k0399WYlCLzsy18EaMfyadA==",
+      "license": "MIT",
+      "dependencies": {
+        "unordered-set": "^2.0.1"
+      }
+    },
+    "node_modules/signal-promise": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/signal-promise/-/signal-promise-1.0.3.tgz",
+      "integrity": "sha512-WBgv0UnIq2C+Aeh0/n+IRpP6967eIx9WpynTUoiW3isPpfe1zu2LJzyfXdo9Tgef8yR/sGjcMvoUXD7EYdiz+g==",
+      "license": "MIT"
+    },
+    "node_modules/signed-varint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
+      "integrity": "sha512-abgDPg1106vuZZOvw7cFwdCABddfJRz5akcCcchzTbhyhYnsG31y4AlZEgp315T7W3nQq5P4xeOm186ZiPVFzw==",
+      "license": "MIT",
+      "dependencies": {
+        "varint": "~5.0.0"
+      }
+    },
+    "node_modules/simdle-native": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/simdle-native/-/simdle-native-1.3.9.tgz",
+      "integrity": "sha512-Isc8sP4OiiIU0mpslD4GHEnR0VQWvR/54WN7YtwEDkNdTJVWtpmvsSvsgRlw5BNGxdYXlVRegdnrSu10H/PhvA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "b4a": "^1.6.0",
+        "require-addon": "^1.1.0"
+      }
+    },
+    "node_modules/simdle-universal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/simdle-universal/-/simdle-universal-1.1.2.tgz",
+      "integrity": "sha512-3n3w1bs+uwgHKQjt6arez83EywNlhZzYvNOhvAASTl/8KqNIcqr6aHyGt3JRlfuUC7iB0tomJRPlJ2cRGIpBzA==",
+      "license": "ISC",
+      "dependencies": {
+        "b4a": "^1.6.0"
+      },
+      "optionalDependencies": {
+        "simdle-native": "^1.1.1"
+      }
+    },
+    "node_modules/sodium-native": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-5.1.0.tgz",
+      "integrity": "sha512-3RxgyWyJlhTsABPnJVpCI5CoTDANZTqqFrEPqr+kjfnRaBihpVtMUE3yTF40ukdoB1APXeoBNKF3MzZAIHg39g==",
+      "license": "MIT",
+      "dependencies": {
+        "bare-assert": "^1.2.0",
+        "require-addon": "^1.1.0",
+        "which-runtime": "^1.2.1"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      }
+    },
+    "node_modules/sodium-secretstream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/sodium-secretstream/-/sodium-secretstream-1.2.0.tgz",
+      "integrity": "sha512-q/DbraNFXm1KfCiiZvapmz5UC3OlpirYFIvBK2MhGaOFSb3gRyk8OXTi17UI9SGfshQNCpsVvlopogbzZNyW6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.1.1",
+        "sodium-universal": "^5.0.0"
+      }
+    },
+    "node_modules/sodium-universal": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-5.0.1.tgz",
+      "integrity": "sha512-rv+aH+tnKB5H0MAc2UadHShLMslpJsc4wjdnHRtiSIEYpOetCgu8MS4ExQRia+GL/MK3uuCyZPeEsi+J3h+Q+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "sodium-native": "^5.0.1"
+      },
+      "peerDependencies": {
+        "sodium-javascript": "~0.8.0"
+      },
+      "peerDependenciesMeta": {
+        "sodium-javascript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/speedometer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.1.0.tgz",
+      "integrity": "sha512-z/wAiTESw2XVPssY2XRcme4niTc4S5FkkJ4gknudtVoc33Zil8TdTxHy5torRcgqMqksJV2Yz8HQcvtbsnw0mQ==",
+      "license": "MIT"
+    },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/streamx": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.27.0.tgz",
+      "integrity": "sha512-WZ189TKnHoAokYHvwzaAQMpd55cgUmFIcJFzBSgGcb886jau5DL+XdDhTWV4ps3FLvk+OORp0dLRTPsLZ21CSA==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/sub-encoder": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/sub-encoder/-/sub-encoder-2.1.3.tgz",
+      "integrity": "sha512-Xxx04ygZo/1J3yHvaSA6VhDmiSaBQkw/PmO3YnnYFXle+tfOGToC6FcDpIfMztWZXJzuKG14b/57HMkiL58C6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.0",
+        "codecs": "^3.1.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/test-tmp": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/test-tmp/-/test-tmp-1.4.0.tgz",
+      "integrity": "sha512-GVggxGg+jXqP2Wbju50JVLo+9E+nIOPPyWqgr63EbOnNItIKu1cEbJpTWAJeflnyGqXOtcMI7ijHRp88GUkfDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-os": "^3.3.0",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/time-ordered-set": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/time-ordered-set/-/time-ordered-set-2.0.1.tgz",
+      "integrity": "sha512-VJEKmgSN2UiOLB8BpN8Sh2b9LGMHTP5OPrQRpnKjvOheOyzk0mufbjzjKTIG2gO4A+Y+vDJ+0TcLbpUmMLsg8A==",
+      "license": "MIT"
+    },
+    "node_modules/timeout-refresh": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/timeout-refresh/-/timeout-refresh-2.0.1.tgz",
+      "integrity": "sha512-SVqEcMZBsZF9mA78rjzCrYrUs37LMJk3ShZ851ygZYW1cMeIjs9mL57KO6Iv5mmjSQnOe/29/VAfGXo+oRCiVw==",
+      "license": "MIT"
+    },
+    "node_modules/tmatch": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-5.0.0.tgz",
+      "integrity": "sha512-Ib9OtBkpHn07tXP04SlN1SYRxFgTk6wSM2EBmjjxug4u5RXPRVLkdFJSS1PmrQidaSB8Lru9nRtViQBsbxzE5Q==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/udx-native": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/udx-native/-/udx-native-1.20.6.tgz",
+      "integrity": "sha512-x2L/dPPEINPgURSPKCLahT3ooJ9p1qLXvj2YvIx30j95E0S6T+ghzroxmyedCbJqCFN2SQQ9QFrGKx96BJEn5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.5.0",
+        "bare-events": "^2.2.0",
+        "require-addon": "^1.1.0",
+        "streamx": "^2.22.0"
+      },
+      "engines": {
+        "bare": ">=1.17.4"
+      }
+    },
+    "node_modules/unix-path-resolve": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unix-path-resolve/-/unix-path-resolve-1.0.2.tgz",
+      "integrity": "sha512-kG4g5nobBBaMnH2XbrS4sLUXEpx4nY2J3C6KAlAUcnahG2HChxSPVKWYrqEq76iTo+cyMkLUjqxGaQR2tz097Q==",
+      "license": "MIT"
+    },
+    "node_modules/unordered-set": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unordered-set/-/unordered-set-2.0.1.tgz",
+      "integrity": "sha512-eUmNTPzdx+q/WvOHW0bgGYLWvWHNT3PTKEQLg0MAQhc0AHASHVHoP/9YytYd4RBVariqno/mEUhVZN98CmD7bg==",
+      "license": "MIT"
+    },
+    "node_modules/unslab": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/unslab/-/unslab-1.3.0.tgz",
+      "integrity": "sha512-YATkfKAFj47kTzmiQrWXMyRvaVrHsW6MEALa4bm+FhiA2YG4oira+Z3DXN6LrYOYn2Y8eO94Lwl9DOHjs1FpoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.6"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/varint": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
+      "integrity": "sha512-gC13b/bWrqQoKY2EmROCZ+AR0jitc6DnDGaQ6Ls9QpKmuSgJB1eQ7H3KETtQm7qSdMWMKCmsshyCmUwMLh3OAA==",
+      "license": "MIT"
+    },
+    "node_modules/which-runtime": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/which-runtime/-/which-runtime-1.4.0.tgz",
+      "integrity": "sha512-0ugbP4CJW4e2D20jvEcC4973dCgIaHI4Rw1PT+26U9zEve7FyYdWAIwUnoeOYvoCfn+wXHoHTKb1KhkYlb60Pw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/xache": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/xache/-/xache-1.2.1.tgz",
+      "integrity": "sha512-igRS6jPreJ54ABdzhh4mCDXcz+XMaWO2q1ABRV2yWYuk29jlp8VT7UBdCqNkX7rpYBbXsebVVKkwIuYZjyZNqA==",
+      "license": "MIT"
+    },
+    "node_modules/z32": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/z32/-/z32-1.1.0.tgz",
+      "integrity": "sha512-1WUHy+VS6d0HPNspDxvLssBbeQjXMjSnpv0vH82vRAUfg847NmX3OXozp/hRP5jPhxBbrVzrgvAt+UsGNzRFQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.5.3"
+      }
+    }
+  }
+}

--- a/examples/getting-started/hello-pear-bare-daemon/package.json
+++ b/examples/getting-started/hello-pear-bare-daemon/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "hello-pear-bare",
+  "version": "0.0.0-rc.0",
+  "description": "Pear Runtime CLI boilerplate using Bare with OTA updater support.",
+  "private": true,
+  "bin": "bin.mjs",
+  "upgrade": "pear://bwkbsetjgy5uhtkckppgn4dxq36ajnh1ugokxmiizubhiwqa59uy",
+  "scripts": {
+    "format": "prettier . --write",
+    "test": "brittle-bare test/index.js",
+    "lint": "prettier . --check && lunte",
+    "start": "bare bin.mjs --no-updates",
+    "make": "node scripts/make.js",
+    "make:darwin-arm64": "bare-build --name hello-pear-bare --standalone --host darwin-arm64 --out ./out/darwin-arm64 bin.mjs",
+    "make:darwin-x64": "bare-build --name hello-pear-bare --standalone --host darwin-x64 --out ./out/darwin-x64 bin.mjs",
+    "make:linux-arm64": "bare-build --name hello-pear-bare --standalone --host linux-arm64 --out ./out/linux-arm64 bin.mjs",
+    "make:linux-x64": "bare-build --name hello-pear-bare --standalone --host linux-x64 --out ./out/linux-x64 bin.mjs",
+    "make:win32-arm64": "bare-build --name hello-pear-bare --standalone --host win32-arm64 --out ./out/win32-arm64 bin.mjs",
+    "make:win32-x64": "bare-build --name hello-pear-bare --standalone --host win32-x64 --out ./out/win32-x64 bin.mjs"
+  },
+  "dependencies": {
+    "bare-console": "^6.2.0",
+    "bare-daemon": "^1.2.4",
+    "bare-file-logger": "^1.2.1",
+    "bare-fs": "^4.7.2",
+    "bare-os": "^3.9.0",
+    "bare-path": "^3.0.0",
+    "bare-process": "^4.5.0",
+    "bare-storage": "^1.1.0",
+    "corestore": "^7.9.2",
+    "fs-native-extensions": "^1.5.0",
+    "hyperswarm": "^4.17.0",
+    "paparam": "^1.10.1",
+    "pear-runtime": "^1.1.4",
+    "ready-resource": "^1.2.0",
+    "which-runtime": "^1.4.0"
+  },
+  "devDependencies": {
+    "bare-build": "^1.0.1",
+    "bare-runtime": "^1.29.5",
+    "brittle": "^3.19.0",
+    "lunte": "^1.2.0",
+    "prettier": "^3.6.2",
+    "prettier-config-holepunch": "^2.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/holepunchto/hello-pear-bare.git"
+  },
+  "author": "Holepunch Inc",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/holepunchto/hello-pear-bare/issues"
+  }
+}

--- a/examples/getting-started/hello-pear-bare-daemon/scripts/make.js
+++ b/examples/getting-started/hello-pear-bare-daemon/scripts/make.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+'use strict'
+
+const os = require('os')
+const path = require('path')
+const { spawnSync } = require('child_process')
+
+const root = path.resolve(__dirname, '..')
+const host = `${os.platform()}-${os.arch()}`
+const script = `make:${host}`
+const supported = new Set([
+  'darwin-arm64',
+  'darwin-x64',
+  'linux-arm64',
+  'linux-x64',
+  'win32-arm64',
+  'win32-x64'
+])
+
+if (!supported.has(host)) {
+  console.error(`Unsupported platform/arch: ${host}`)
+  console.error(
+    'Supported targets: darwin-arm64, darwin-x64, linux-arm64, linux-x64, win32-arm64, win32-x64'
+  )
+  process.exit(1)
+}
+
+const isWindows = os.platform() === 'win32'
+const opts = {
+  cwd: root,
+  stdio: 'inherit'
+}
+const res = isWindows
+  ? spawnSync(`npm.cmd run ${script}`, { ...opts, shell: true })
+  : spawnSync('npm', ['run', script], opts)
+if (res.error) {
+  console.error(res.error.message)
+  process.exit(1)
+}
+if (res.status !== 0) process.exit(res.status || 1)

--- a/examples/getting-started/hello-pear-bare-daemon/test/index.js
+++ b/examples/getting-started/hello-pear-bare-daemon/test/index.js
@@ -1,0 +1,5 @@
+const { test } = require('brittle')
+
+test('REMOVE ME', (t) => {
+  t.pass()
+})

--- a/examples/getting-started/hello-pear-bare-single-thread/README.md
+++ b/examples/getting-started/hello-pear-bare-single-thread/README.md
@@ -1,0 +1,144 @@
+# hello-pear-bare
+
+> Pear Hello World for Standalone Bare Processes with `pear-runtime`
+
+End-to-end boilerplate for embedding [pear-runtime] into a Standalone [Bare] Process with peer-to-peer OTA update support.
+
+- Peer-to-Peer deployment with [pear][pear-docs] CLI
+- Peer-to-Peer Over-the-Air updates with [`pear-runtime`][pear-runtime] module
+- Cross-platform standalone distributables via [`bare-build`][bare-build]
+
+## Variants
+
+- [`main`](https://github.com/holepunchto/hello-pear-bare/tree/main): runs `pear-runtime` inside a Bare worker thread.
+- (current) [`single-thread`](https://github.com/holepunchto/hello-pear-bare/tree/variant/single-thread): workerless with `pear-runtime` updates.
+- [`daemon`](https://github.com/holepunchto/hello-pear-bare/tree/variant/daemon): runs `pear-runtime` in a detached updater daemon.
+
+## Table of Contents
+
+- [OS Support](#os-support)
+- [Requirements](#requirements)
+- [Development](#development)
+  - [Install Dependencies](#install-dependencies)
+  - [Create an upgrade link](#create-an-upgrade-link)
+  - [Start](#start)
+- [Architecture](#architecture)
+  - [Updates](#updates)
+- [Peer-to-Peer Deployments](#peer-to-peer-deployments)
+- [Installing Distributables](#installing-distributables)
+- [Scripts](#scripts)
+- [Project Structure](#project-structure)
+- [Troubleshooting](#troubleshooting)
+
+## OS Support
+
+- **macOS** — arm64, x64
+- **Linux** — arm64, x64
+- **Windows** — arm64, x64
+
+## Requirements
+
+- `npm` via [Node.js][nodejs]
+- [pear][pear-docs] - `npx pear`
+
+## Development
+
+### Install Dependencies
+
+```sh
+npm install
+```
+
+### Create an upgrade link
+
+This template expects `package.json` to contain a valid `pear://` link in the `upgrade` field. If it still contains the placeholder `pear://<YOUR_KEY_HERE>`, startup will fail with `INVALID_URL`.
+
+Create a link with [`pear touch`](https://docs.pears.com/reference/cli.html#pear-touch-flags-channel):
+
+```sh
+pear touch
+```
+
+Copy the generated `pear://...` link into the `upgrade` field in `package.json`.
+
+### Start
+
+Start app in development mode:
+
+```sh
+npm start
+```
+
+By default this repo starts with `--no-updates` in development to avoid local dev binaries being swapped while you iterate.
+
+Enable updates for local flow testing:
+
+```sh
+npm start -- --updates
+```
+
+## Architecture
+
+### Updates
+
+Updates are managed by the `App` class in `app.js`, which wraps the updater lifecycle as a ready resource and emits update events for `bin.mjs` to log.
+
+It uses the configured `upgrade` link in `package.json`.
+
+Per-run disable updates:
+
+```sh
+npm start -- --no-updates
+```
+
+## Peer-to-Peer Deployments
+
+Use the [`pear`][pear-docs] CLI to deploy applications.
+
+Set the `upgrade` field in `package.json` to your distribution drive link, then follow the default flow from section 4 onward:
+
+[hello-pear-electron: 4. Build Deployment Directory and onward](https://github.com/holepunchto/hello-pear-electron#4-build-deployment-directory-)
+
+## Installing Distributables
+
+Once the `pear://<key>` upgrade link is seeding the build deployment folder the standalone binary can be installed peer-to-peer directly onto the system with Pear:
+
+```sh
+npx pear-install pear://<key>
+```
+
+## Scripts
+
+- `npm start` - run the Bare Process in dev mode (`bare bin.mjs --no-updates`)
+- `npm test` - run `brittle-bare` tests
+- `npm run lint` - run prettier check and lunte
+- `npm run format` - format repository with prettier
+- `npm run make` - auto-detect host OS/arch and run matching build target
+- `npm run make:darwin-arm64` - build standalone to `out/darwin-arm64`
+- `npm run make:darwin-x64` - build standalone to `out/darwin-x64`
+- `npm run make:linux-arm64` - build standalone to `out/linux-arm64`
+- `npm run make:linux-x64` - build standalone to `out/linux-x64`
+- `npm run make:win32-arm64` - build standalone to `out/win32-arm64`
+- `npm run make:win32-x64` - build standalone to `out/win32-x64`
+
+## Project Structure
+
+- `bin.mjs` - entrypoint and runtime wiring
+- `app.js` - update resource used by the entrypoint
+- `scripts/make.js` - platform/arch build target selector
+- `test/index.js` - brittle-bare tests
+
+## Troubleshooting
+
+- `INVALID_URL: Invalid URL 'pear://<YOUR_KEY_HERE>'` means the placeholder `upgrade` link in `package.json` has not been replaced. Run `pear touch`, then put the generated `pear://...` link in `package.json`.
+- If updates do not trigger, verify `package.json` contains a valid `upgrade` Pear link and that peers are seeding the target drive.
+- If `npm run make` fails on unsupported hosts, run a specific `make:<platform>-<arch>` script or build on a supported host.
+- This template does not implement app-level data persistence; it is a minimal CLI + updater example.
+
+<!-- Reference Links -->
+
+[pear-docs]: https://docs.pears.com
+[pear-runtime]: https://github.com/holepunchto/pear-runtime
+[Bare]: https://github.com/holepunchto/bare
+[nodejs]: https://nodejs.org
+[bare-build]: https://github.com/holepunchto/bare-build

--- a/examples/getting-started/hello-pear-bare-single-thread/app.js
+++ b/examples/getting-started/hello-pear-bare-single-thread/app.js
@@ -1,0 +1,90 @@
+const path = require('bare-path')
+const Corestore = require('corestore')
+const Hyperswarm = require('hyperswarm')
+const PearRuntime = require('pear-runtime')
+const ReadyResource = require('ready-resource')
+
+module.exports = class App extends ReadyResource {
+  constructor({ dir, app, updates, version, upgrade, name }) {
+    super()
+
+    this.dir = dir
+    this.app = app
+    this.updates = updates
+    this.version = version
+    this.upgrade = upgrade
+    this.name = name
+
+    this.store = null
+    this.swarm = null
+    this.pear = null
+  }
+
+  _open() {
+    const store = new Corestore(path.join(this.dir, 'pear-runtime', 'corestore'))
+    const swarm = new Hyperswarm()
+
+    this.store = store
+    this.swarm = swarm
+
+    const pear = new PearRuntime({
+      dir: this.dir,
+      app: this.app,
+      updates: this.updates,
+      version: this.version,
+      upgrade: this.upgrade,
+      name: this.name,
+      store,
+      swarm
+    })
+
+    this.pear = pear
+
+    pear.on('error', (err) => this.emit('error', err))
+    pear.updater.on('error', (err) => this.emit('error', err))
+
+    if (this.updates === false) return
+
+    pear.updater.on('updating', () => this.emit('updating'))
+    pear.updater.on('updating-delta', (delta) => this.emit('updating-delta', delta))
+    pear.updater.on('updated', () => this._applyUpdate())
+
+    swarm.on('connection', (connection) => store.replicate(connection))
+    swarm.join(pear.updater.drive.core.discoveryKey, {
+      client: true,
+      server: false
+    })
+  }
+
+  async _close() {
+    const store = this.store
+    const swarm = this.swarm
+    const pear = this.pear
+
+    this.store = null
+    this.swarm = null
+    this.pear = null
+
+    await swarm?.destroy()
+    await pear?.close()
+    await store?.close()
+  }
+
+  async _applyUpdate() {
+    this.emit('updated')
+    const pear = this.pear
+    if (pear === null) return
+
+    try {
+      await pear.updater.applyUpdate()
+      this.emit('update-applied')
+    } catch (err) {
+      this.emit('error', err)
+    }
+  }
+
+  async exit(code = 0) {
+    Bare.exitCode = code
+    await this.close()
+  }
+}

--- a/examples/getting-started/hello-pear-bare-single-thread/bin.mjs
+++ b/examples/getting-started/hello-pear-bare-single-thread/bin.mjs
@@ -1,0 +1,63 @@
+import { command, flag, summary } from 'paparam'
+import { persistent } from 'bare-storage'
+import process from 'bare-process'
+import os from 'bare-os'
+import { isWindows } from 'which-runtime'
+import path from 'bare-path'
+import pkg from './package.json'
+import App from './app.js'
+
+const appName = pkg.productName || pkg.name
+const isDev = path.basename(Bare.argv[0]) === 'bare'
+
+const cmd = command(
+  appName,
+  summary(pkg.description),
+  flag('--version|-v', 'Print the current version'),
+  flag('--storage <dir>', 'custom storage directory'),
+  flag('--no-updates', 'disable OTA updates for this run')
+)
+
+cmd.parse(Bare.argv.slice(isDev ? 2 : 1))
+if (cmd.flags.help) Bare.exit()
+if (cmd.flags.version) {
+  console.log(`${appName} v${pkg.version}`)
+  Bare.exit()
+}
+
+const updates = cmd.flags.updates
+const storage = cmd.flags.storage || (isDev ? null : path.join(persistent(), appName))
+const dir = storage || path.join(os.tmpdir(), 'pear', appName)
+
+console.log(`Updates: ${updates === false ? 'disabled' : 'enabled'}`)
+
+const app = new App({
+  dir,
+  app: isDev ? null : os.execPath(),
+  updates,
+  version: pkg.version,
+  upgrade: pkg.upgrade,
+  name: isWindows ? appName + '.exe' : appName
+})
+
+app.on('updating', () => console.log('[updater] getting new update'))
+app.on('updating-delta', (delta) => console.log('[updater]', delta))
+app.on('updated', () => console.log('[updater] update complete... applying'))
+app.on('update-applied', () =>
+  console.log('[updater] applied update, restart to run latest version')
+)
+app.on('error', (err) => console.error('[app:error]', err))
+
+process.on('SIGHUP', () => app.exit(129))
+process.on('SIGINT', () => app.exit(130))
+process.on('SIGQUIT', () => app.exit(131))
+process.on('SIGTERM', () => app.exit(143))
+
+try {
+  await app.ready()
+  console.log('Application storage:', app.pear.storage)
+  console.log('\nCLI ready. Press Ctrl+C to stop.\n')
+} catch (err) {
+  console.error('[app:error]', err)
+  await app.close().finally(() => Bare.exit(1))
+}

--- a/examples/getting-started/hello-pear-bare-single-thread/package-lock.json
+++ b/examples/getting-started/hello-pear-bare-single-thread/package-lock.json
@@ -1,0 +1,2679 @@
+{
+  "name": "hello-pear-bare",
+  "version": "0.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hello-pear-bare",
+      "version": "0.0.0-rc.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.9.0",
+        "bare-path": "^3.0.0",
+        "bare-process": "^4.5.0",
+        "bare-storage": "^1.1.0",
+        "corestore": "^7.9.2",
+        "hyperswarm": "^4.17.0",
+        "paparam": "^1.10.1",
+        "pear-runtime": "^1.1.4",
+        "ready-resource": "^1.2.0",
+        "which-runtime": "^1.4.0"
+      },
+      "bin": {
+        "hello-pear-bare": "bin.mjs"
+      },
+      "devDependencies": {
+        "bare-build": "^1.0.1",
+        "bare-runtime": "^1.29.5",
+        "brittle": "^3.19.0",
+        "lunte": "^1.2.0",
+        "prettier": "^3.6.2",
+        "prettier-config-holepunch": "^2.0.0"
+      }
+    },
+    "node_modules/@hyperswarm/secret-stream": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@hyperswarm/secret-stream/-/secret-stream-6.9.1.tgz",
+      "integrity": "sha512-xb0S5y3YJwBakD77JOGBHlBxdp63mHClZoXBYoLv+9wH8e054ESKlmQptWqjJK5dv5VMUIVYOJB4MaOpB0JdGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.1.0",
+        "hypercore-crypto": "^3.3.1",
+        "noise-curve-ed": "^2.0.1",
+        "noise-handshake": "^4.0.0",
+        "sodium-secretstream": "^1.1.0",
+        "sodium-universal": "^5.0.0",
+        "streamx": "^2.14.0",
+        "timeout-refresh": "^2.0.0",
+        "unslab": "^1.3.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/adaptive-timeout": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/adaptive-timeout/-/adaptive-timeout-1.0.1.tgz",
+      "integrity": "sha512-+seGiBtHqbnyZ0Quq/ZGxxwP66153WBABawa07/QeyuPFzbduPBjiGQAyCiriiLDzt3dkbMBskSlfqtRwblK8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xache": "^1.2.1"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-abort": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/bare-abort/-/bare-abort-2.0.13.tgz",
+      "integrity": "sha512-zdc8l88eB11Jsz5rDd6sCAgv2kUFXgdrZWoMlgU6JMkfAi1/uuGFC3IEHswKbIRQTk5H3T5CMuechsXYxiaHlQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-addon-resolve": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.10.0.tgz",
+      "integrity": "sha512-sSd0jieRJlDaODOzj0oe0RjFVC1QI0ZIjGIdPkbrTXsdVVtENg14c+lHHAhHwmWCZ2nQlMhy8jA3Y5LYPc/isA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-module-resolve": "^1.10.0",
+        "bare-semver": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-ansi-escapes": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/bare-ansi-escapes/-/bare-ansi-escapes-2.2.3.tgz",
+      "integrity": "sha512-02ES4/E2RbrtZSnHJ9LntBhYkLA6lPpSEeP8iqS3MccBIVhVBlEmruF1I7HZqx5Q8aiTeYfQVeqmrU9YO2yYoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-stream": "^2.6.5"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-apk": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/bare-apk/-/bare-apk-0.1.3.tgz",
+      "integrity": "sha512-LakK8fcKDQaMDZvfaMAH7vB1tkDrKGi8rffSG4QkagM+Db8kn6pOEr02Iacix0cG3G83HlKqJ7xmIl4uZHkIhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-env": "^3.0.0",
+        "bare-fs": "^4.5.2",
+        "bare-os": "^3.6.2",
+        "bare-path": "^3.0.0",
+        "bare-subprocess": "^5.2.1",
+        "require-asset": "^1.2.1"
+      }
+    },
+    "node_modules/bare-app-image": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/bare-app-image/-/bare-app-image-0.1.1.tgz",
+      "integrity": "sha512-FOmSjy+0bx6Qkztl+n7PHhrqxSnu4ccsokjHPwQUFnDNcAetYlxsLQHquq7B/vJeZiowBVJV+ulrTdwuVBfXpA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "dependencies": {
+        "bare-fs": "^4.5.1",
+        "bare-path": "^3.0.0",
+        "bare-subprocess": "^5.1.5",
+        "require-asset": "^1.1.0"
+      }
+    },
+    "node_modules/bare-assert": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bare-assert/-/bare-assert-1.2.0.tgz",
+      "integrity": "sha512-c6uvgvTJBspTDxtVnPgrBKmLgcpW3Fp72NVKDLg6oT4QjQbhGtvrkHMhGYMK1sh4vjBHOBmuUalyt9hSzV37fQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-inspect": "^3.1.2"
+      }
+    },
+    "node_modules/bare-buffer": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/bare-buffer/-/bare-buffer-3.6.1.tgz",
+      "integrity": "sha512-8mzp60t6jdSD3cEGmyxAV1YrAN2+mnxiUvBPQHJJ4WNk0hSVLJGSIEolRj09ZP8yt/+oSj2N2f5kDVW8297n4A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "bare": ">=1.20.0"
+      }
+    },
+    "node_modules/bare-build": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build/-/bare-build-1.0.1.tgz",
+      "integrity": "sha512-UUaJT/Wpz6wiStnQcKFiB+BliI4dw3l+9IrKSt1EHB/xsYiPi32mOmlJX/oHhX6dpAW/kyIYGM7OcjWBerQ+Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "workspaces": [
+        "npm/*",
+        "test/fixtures/*"
+      ],
+      "dependencies": {
+        "bare-build-android-arm": "1.0.1",
+        "bare-build-android-arm64": "1.0.1",
+        "bare-build-android-ia32": "1.0.1",
+        "bare-build-android-x64": "1.0.1",
+        "bare-build-darwin-arm64": "1.0.1",
+        "bare-build-darwin-x64": "1.0.1",
+        "bare-build-ios-arm64": "1.0.1",
+        "bare-build-ios-arm64-simulator": "1.0.1",
+        "bare-build-ios-x64-simulator": "1.0.1",
+        "bare-build-linux-arm64": "1.0.1",
+        "bare-build-linux-x64": "1.0.1",
+        "bare-build-win32-arm64": "1.0.1",
+        "bare-build-win32-x64": "1.0.1",
+        "bare-bundle-id": "^1.0.2",
+        "bare-fs": "^4.5.1",
+        "bare-lief": "^0.1.3",
+        "bare-link": "^3.1.0",
+        "bare-module-resolve": "^1.12.0",
+        "bare-module-traverse": "^2.0.0",
+        "bare-os": "^3.6.2",
+        "bare-pack": "^2.0.0",
+        "bare-path": "^3.0.0",
+        "bare-semver": "^1.0.3",
+        "bare-subprocess": "^5.1.5",
+        "bare-tpl": "^1.0.0",
+        "bare-unpack": "^1.1.3",
+        "bare-url": "^2.3.2",
+        "paparam": "^1.8.0"
+      },
+      "bin": {
+        "bare-build": "bin.js"
+      },
+      "optionalDependencies": {
+        "bare-apk": "^0.1.2",
+        "bare-app-image": "^0.1.0"
+      }
+    },
+    "node_modules/bare-build-android-arm": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build-android-arm/-/bare-build-android-arm-1.0.1.tgz",
+      "integrity": "sha512-3XEH1SWFHJnkeOYh59dch1Te6U8Qh+imqtbdyvc31cQdBP19FHnUksMlC8+iXDiH4i4XA8tm/o+RIEYRsWVJkQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      }
+    },
+    "node_modules/bare-build-android-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build-android-arm64/-/bare-build-android-arm64-1.0.1.tgz",
+      "integrity": "sha512-yKBeQ3/mXP09osdS49I3I7yw3ZnDllZeJDLXgIE1UvMRBPMMQ+ha8xc3//zAlaTLqEzcDvyDEbg4whqLdqpe2A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      }
+    },
+    "node_modules/bare-build-android-ia32": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build-android-ia32/-/bare-build-android-ia32-1.0.1.tgz",
+      "integrity": "sha512-xSGPnvGePkdnpEIWdK8uERzsLOaiPvYNeCat5mYZNaV+7muo6BGUghyHlZYhErru6gvG8I2xT9kXa+Zrfci79g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      }
+    },
+    "node_modules/bare-build-android-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build-android-x64/-/bare-build-android-x64-1.0.1.tgz",
+      "integrity": "sha512-B/N4c5LPtI+VnE7IPSfJwf4hUTsXN9l5CIZMGD8GBSJDB4gnmroOoYljVI4FURtXvhT6eibH8zGzSyzWWNC85Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      }
+    },
+    "node_modules/bare-build-darwin-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build-darwin-arm64/-/bare-build-darwin-arm64-1.0.1.tgz",
+      "integrity": "sha512-WQPJrU/rdqUuHE5dhkmG1m86yxZFdW8YxoQPPWKps3UMVnUi2nurUiVrbXjABytKRnTXOU5Zcn/gFuTHmj2Czg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      }
+    },
+    "node_modules/bare-build-darwin-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build-darwin-x64/-/bare-build-darwin-x64-1.0.1.tgz",
+      "integrity": "sha512-eqWc3QevrHveHebIrsDKPrKMIaiw0bfQDTnEeQkxovUVv6mxLa7iLl/e/MVZDJS/iwaKbTNdfgBOwxr9QGGYSA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      }
+    },
+    "node_modules/bare-build-ios-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build-ios-arm64/-/bare-build-ios-arm64-1.0.1.tgz",
+      "integrity": "sha512-oidAnaBbRhZMHxRMkMbsQUSnxMgIZYlbnBAS89M+Lz14gU7H15CPcNPEtVMIkT3FmMF4yJqh9LVrRPMerV3PIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      }
+    },
+    "node_modules/bare-build-ios-arm64-simulator": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build-ios-arm64-simulator/-/bare-build-ios-arm64-simulator-1.0.1.tgz",
+      "integrity": "sha512-IuEj0rob1Q/d/8k9CfhQto30T6/7egMzBTvkpSgrkCJg7HjUomWDmhL5pmF9QAECRHkcQfeYMcsIV1/gm3Nd9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      }
+    },
+    "node_modules/bare-build-ios-x64-simulator": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build-ios-x64-simulator/-/bare-build-ios-x64-simulator-1.0.1.tgz",
+      "integrity": "sha512-0b1K2upUhdMu/03+XSVFhzaw+0JFPjLxBXKitfbEVhXsJ1lkpDvk+gmxqgZ5ayM0cYwV+kATvSc1UWPQ/Jdm9w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      }
+    },
+    "node_modules/bare-build-linux-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build-linux-arm64/-/bare-build-linux-arm64-1.0.1.tgz",
+      "integrity": "sha512-DBfWBeNHVxVAr+mOVQJsAqu7q6xaW6Cl1KDCAsgZyu+GtnfzKORRVM6m36AVINpqkPJLFS322oPhOEndltriUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      }
+    },
+    "node_modules/bare-build-linux-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build-linux-x64/-/bare-build-linux-x64-1.0.1.tgz",
+      "integrity": "sha512-IzIAVGvcdSeM/Vc1LP/f2Q0VXnEJBkiI1bgRY4AXBX9mH1GZLC4KiH513IFtlWZREvhijBrRWMK+vs/BLakrqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      }
+    },
+    "node_modules/bare-build-win32-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build-win32-arm64/-/bare-build-win32-arm64-1.0.1.tgz",
+      "integrity": "sha512-u1IzNH28KyvywAwJpx8MaFlyZxI8epW+Nlc5LOn9REVNscZIQ3OFiIbIwedU5zA6H4dVCnV8B7iQBYS57Cz/8Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      }
+    },
+    "node_modules/bare-build-win32-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-build-win32-x64/-/bare-build-win32-x64-1.0.1.tgz",
+      "integrity": "sha512-j59qDgopfW2x5AnnDo5TFggf0o6Pestd1XDad1b6MvL1J0n1ixNRdqsT9HRRqEm95nZvQeO4F2EhdD6HPOz36A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      }
+    },
+    "node_modules/bare-bundle": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/bare-bundle/-/bare-bundle-1.10.0.tgz",
+      "integrity": "sha512-4LVlnJAHr00Hh6Vu6ZUJS38rcEtJT3b3vChXSsBsJ2mk1TN0lQ+gzd+Dw5L0aV7uqDZv84smuwW+O02X7PfDlw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-bundle-id": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bare-bundle-id/-/bare-bundle-id-1.0.2.tgz",
+      "integrity": "sha512-RG/y1J/s6zWmsqUIDtclXh+xxMRTh1jo/10vFL58FKhe9UESchMNkwn0Cz10o5AdA/35WR/KUGoHhIGdyCjQrg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "sodium-native": "^5.0.9"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-bundle": "*"
+      }
+    },
+    "node_modules/bare-compat-napi": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/bare-compat-napi/-/bare-compat-napi-1.3.9.tgz",
+      "integrity": "sha512-1xmFuB8x2BIyBSPoZYsS2v2vRMSKUGgmcvjKPfHNqmeqtnjVDcANjVv7mucK0Yb01rlBlYB1ftT1n/zXaNmtmA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-cov": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/bare-cov/-/bare-cov-1.2.2.tgz",
+      "integrity": "sha512-d/b4HdL5ohZDwBvDegJeSkmo1X2MGlm22jXzuY2D7wl2W1+7nk/b7+HMogwgUa+zi8rVVRJQKHCHPHYBJpvlvw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.1.2",
+        "bare-inspector": "^6.0.1",
+        "bare-path": "^3.0.0",
+        "bare-process": "^4.2.1",
+        "bare-url": "^2.1.5",
+        "bare-v8-to-istanbul": "^1.0.2",
+        "picomatch": "^4.0.2",
+        "which-runtime": "^1.2.1"
+      }
+    },
+    "node_modules/bare-crypto": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/bare-crypto/-/bare-crypto-1.15.3.tgz",
+      "integrity": "sha512-macV9lbyJTsLPRXJkBtz8ivTGEo3LCyJInLT9IB/PWJ7pRXwvHs/FP4bx/fWw+HZkiepIYCAV2cuU5CR92XWCw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-assert": "^1.2.0",
+        "bare-stream": "^2.6.3"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-debug-log": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bare-debug-log/-/bare-debug-log-2.0.0.tgz",
+      "integrity": "sha512-Vi42PkMQsNV9PUpx2Gl1hikshx5O9FzMJ6o9Nnopseg7qLBBK7Nl31d0RHcfwLEAfmcPApytpc0ZFfq68u22FQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-dns": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/bare-dns/-/bare-dns-2.1.4.tgz",
+      "integrity": "sha512-abwjHmpWqSRNB7V5615QxPH92L71AVzFm/kKTs8VYiNTAi2xVdonpv0BjJ0hwXLwomoW+xsSOPjW6PZPO14asg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.7.0"
+      }
+    },
+    "node_modules/bare-encoding": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bare-encoding/-/bare-encoding-1.0.3.tgz",
+      "integrity": "sha512-Kqf+t/azs13lUeyK4Tb7ha4wdLRXKWCXQ8w1rVmt7KtoPCPdHD/Xwt7LBIsCSwwGglrcmblo5VOLa5avkJqULA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-env": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-env/-/bare-env-3.0.0.tgz",
+      "integrity": "sha512-0u964P5ZLAxTi+lW4Kjp7YRJQ5gZr9ycYOtjLxsSrupgMz3sn5Z9n4SH/JIifHwvadsf1brA2JAjP+9IOWwTiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-format": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bare-format/-/bare-format-1.0.2.tgz",
+      "integrity": "sha512-GswdhnOnP9QtwRbrf4wLApw5widkaLMsLe2XOs35fQD2YfEN1ApoGka+cZ7PfvzxMgfYXmMhj/2OGlVn5/Dxgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-inspect": "^3.0.0"
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-hrtime": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bare-hrtime/-/bare-hrtime-2.1.1.tgz",
+      "integrity": "sha512-VMb3tHo05gsnbu3OXTmkDiwTjMlOsbQmKoysKqKEyR09m77TuDrYFbj3Q5GGk10dAKsUHrnXmwCaeJqzVpB5ZA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-http-parser": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bare-http-parser/-/bare-http-parser-1.1.5.tgz",
+      "integrity": "sha512-sPaDetLbWRmth04JmuTCvw/hoNdWJvYUJN8n1tYdGW3HM0mMnCvK2f0oIxE6HK7iOq+WlsRzEMg1LT/b0wGbLQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-http1": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/bare-http1/-/bare-http1-4.5.7.tgz",
+      "integrity": "sha512-PRuzs9ywt4vUvrC3mnHhQyaQfLYzdFy8XKOH0oKeKmYfyYYUqXBkdbJE2csESLBxJEbKDBjxPGLU+Qa0l1ds4A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.6.0",
+        "bare-http-parser": "^1.1.1",
+        "bare-stream": "^2.10.0",
+        "bare-tcp": "^2.2.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-https": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-https/-/bare-https-3.0.0.tgz",
+      "integrity": "sha512-W1GRSCzn+xXKf5bMcPs/hg6Ga1bxPqb7owGfS+tvlBQfPe5Q2STcanRuKZrgU60v5uKrhXH5cgWwM+DLqvXZgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-http1": "^4.4.0",
+        "bare-tcp": "^2.2.0",
+        "bare-tls": "^3.0.0"
+      }
+    },
+    "node_modules/bare-inspect": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/bare-inspect/-/bare-inspect-3.1.4.tgz",
+      "integrity": "sha512-jfW5KRA84o3REpI6Vr4nbvMn+hqVAw8GU1mMdRwUsY5yJovQamxYeKGVKGqdzs+8ZbG4jRzGUXP/3Ji/DnqfPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-ansi-escapes": "^2.1.0",
+        "bare-type": "^1.0.0"
+      },
+      "engines": {
+        "bare": ">=1.18.0"
+      }
+    },
+    "node_modules/bare-inspector": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/bare-inspector/-/bare-inspector-6.0.1.tgz",
+      "integrity": "sha512-rL+aKJ74FhF+6iJS2cV3C8js8nGF37H05ldiyMojgFP/N5eYShZ/mhSbTcDh1yriW5jndYd6xWQU0E/CE14Tiw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.1.0",
+        "bare-http1": "^4.0.0",
+        "bare-stream": "^2.0.0",
+        "bare-url": "^2.0.0",
+        "bare-ws": "^3.0.0"
+      },
+      "engines": {
+        "bare": ">=1.25.0"
+      },
+      "peerDependencies": {
+        "bare-tcp": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-tcp": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-lief": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bare-lief/-/bare-lief-0.1.6.tgz",
+      "integrity": "sha512-eNqgZGoHVPGtbkLoDPVyKKEe9uTkXFqOvTevb1iDv3SXv/eU7kMgJoAukSdvFUg7QWNiqd2o/pZwaMy5n3cjNw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-addon": "^1.2.0"
+      }
+    },
+    "node_modules/bare-link": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/bare-link/-/bare-link-3.2.2.tgz",
+      "integrity": "sha512-8URo/GQp1tQloDmCbM2fw3vUaSWs6aNbq3yyy6ioVy4z2zatWHzfeSncI6FXRn7MBcuXgMyBCCdg/NM3sAPUiw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.0.0",
+        "bare-lief": "^0.2.0",
+        "bare-module-resolve": "^1.12.0",
+        "bare-os": "^3.2.0",
+        "bare-path": "^3.0.0",
+        "bare-subprocess": "^6.0.0",
+        "bare-url": "^2.0.9",
+        "paparam": "^1.5.0"
+      },
+      "bin": {
+        "bare-link": "bin.js"
+      }
+    },
+    "node_modules/bare-link/node_modules/bare-lief": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/bare-lief/-/bare-lief-0.2.4.tgz",
+      "integrity": "sha512-h9urnxzacY8z2BKc4ABdbyGXBivfern5IPXzbtU94KyXD8r0nGBKtjQTU0BNHq0POxE6qe8zLGfuQSd9IoqpQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-assert": "^1.2.0",
+        "require-addon": "^1.2.0"
+      }
+    },
+    "node_modules/bare-link/node_modules/bare-subprocess": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/bare-subprocess/-/bare-subprocess-6.1.0.tgz",
+      "integrity": "sha512-8L6KtbmreDy4Fc1BdDqaDo9fg0nbedUmTSFQxYPV0uHIM2BBAX8+E0LyMDKgkk0I+mlKto80WYzOnIhT8VDdOg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-env": "^3.0.0",
+        "bare-events": "^2.5.4",
+        "bare-os": "^3.0.1",
+        "bare-pipe": "^4.2.0",
+        "bare-structured-clone": "^1.5.2",
+        "bare-tcp": "^2.4.1",
+        "bare-url": "^2.2.2"
+      },
+      "engines": {
+        "bare": ">=1.7.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-module": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/bare-module/-/bare-module-6.2.0.tgz",
+      "integrity": "sha512-CoCTG8y8HKPnNW317OW1hynl28DasVPtbX033ZEAXk0Q3SYCUXi3OOnNAr6wTrDgMgpOsW0kl7Nifcom5GGH8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-bundle": "^1.3.0",
+        "bare-module-lexer": "^1.0.0",
+        "bare-module-resolve": "^1.8.0",
+        "bare-path": "^3.0.0",
+        "bare-url": "^2.0.1"
+      },
+      "engines": {
+        "bare": ">=1.23.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-module-lexer": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bare-module-lexer/-/bare-module-lexer-1.5.0.tgz",
+      "integrity": "sha512-FXjqDdVrR9zizyHcZvJtkUNe9CanFo9eOmo33O8CGEL45xYMiZDUvAqoQhsHb/RK2QKsryAyKiNv0W5kiALzmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-addon": "^1.0.2"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-module-resolve": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.2.tgz",
+      "integrity": "sha512-j+hiD5k99qec4KjJvYsI67q5AOBifmy9JG3oeMVxTmvrhn2sIdp8StrUvZu4YNgwTpO+NhniQG16N1ETDe1k5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-semver": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-module-traverse": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bare-module-traverse/-/bare-module-traverse-2.1.1.tgz",
+      "integrity": "sha512-+gNplZqErqrFwgAEqkGBz25sOaqkUMJV+2ZCM8qtAyg/WU+6jX2n6k5eJEe6QIqpWqTHpuSkXYQSVC0S+GtOAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-addon-resolve": "^1.5.0",
+        "bare-module-lexer": "^1.4.0",
+        "bare-module-resolve": "^1.7.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-net": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/bare-net/-/bare-net-2.3.2.tgz",
+      "integrity": "sha512-I+yz+pqbYsBkxDsnu5vkKvy7RSNY9CcAvu2jZT6PsmdXJQG1i3dmD5V7xc3334OVp2absgtUEYLmmuNFlphBzg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.2.2",
+        "bare-pipe": "^4.0.0",
+        "bare-stream": "^2.0.0",
+        "bare-tcp": "^2.0.0"
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-pack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bare-pack/-/bare-pack-2.1.0.tgz",
+      "integrity": "sha512-0iJ/2NRWYbB8iL8bWfQrKbtQzJHUyt3pdgyjDCNKhM3SeRNVi7rzrW6e6a/albzmwDm+x0frxiV2mNgAO0VdKg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-bundle": "^1.8.3",
+        "bare-bundle-id": "^1.0.0",
+        "bare-fs": "^4.2.1",
+        "bare-module-traverse": "~2.1.1",
+        "bare-path": "^3.0.0",
+        "paparam": "^1.5.0",
+        "promaphore": "^1.0.0"
+      },
+      "bin": {
+        "bare-pack": "bin.js"
+      },
+      "peerDependencies": {
+        "bare-buffer": "^3.6.0",
+        "bare-url": "^2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-pipe": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/bare-pipe/-/bare-pipe-4.2.1.tgz",
+      "integrity": "sha512-il5ssf8MGPHtuaHnqjAiJHUzNQ3dahjkIMAo1k+7+zxdqscZZf8gLyptjFGQHVNHb24z8zwmAXpMBeNcFjwMBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.0.0",
+        "bare-stream": "^2.0.0"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      }
+    },
+    "node_modules/bare-posix": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-posix/-/bare-posix-1.0.1.tgz",
+      "integrity": "sha512-b4quA8dyRVvX0aFIAIiev5zFATHwIUGr42Gmt+CqiBNg/bdsNkrj4bbkeotMOMiljJS4DCME5kywJO/TFwKo1A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-process": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/bare-process/-/bare-process-4.5.0.tgz",
+      "integrity": "sha512-NTtYDiwleJjWWNg4+yzS6B/RovL/LLPHVvoOM+18W+dYAXCmky0zFfN66hqqBbrlGAlb52/QgKrdzPR3x1QyHA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-abort": "^2.0.13",
+        "bare-env": "^3.0.0",
+        "bare-events": "^2.3.1",
+        "bare-hrtime": "^2.0.0",
+        "bare-os": "^3.7.1",
+        "bare-posix": "^1.0.1",
+        "bare-signals": "^4.0.0",
+        "bare-stdio": "^1.0.1"
+      }
+    },
+    "node_modules/bare-runtime": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime/-/bare-runtime-1.29.5.tgz",
+      "integrity": "sha512-PlKgMADJHL4SkzoQCE7uXzOJ0ZZKfDsdwcxFlTZ+ZKX8FJcuNqr8WHkG27ohirFEvNelYki8eBBk16bJGSfkVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "workspaces": [
+        "npm/*"
+      ],
+      "dependencies": {
+        "bare-fs": "^4.4.4",
+        "bare-os": "^3.0.1",
+        "bare-path": "^3.0.0",
+        "bare-process": "^4.2.1",
+        "bare-subprocess": "^6.1.0"
+      },
+      "bin": {
+        "bare": "bin/bare"
+      },
+      "optionalDependencies": {
+        "bare-runtime-android-arm": "1.29.5",
+        "bare-runtime-android-arm64": "1.29.5",
+        "bare-runtime-android-ia32": "1.29.5",
+        "bare-runtime-android-x64": "1.29.5",
+        "bare-runtime-darwin-arm64": "1.29.5",
+        "bare-runtime-darwin-x64": "1.29.5",
+        "bare-runtime-ios-arm64": "1.29.5",
+        "bare-runtime-ios-arm64-simulator": "1.29.5",
+        "bare-runtime-ios-x64-simulator": "1.29.5",
+        "bare-runtime-linux-arm64": "1.29.5",
+        "bare-runtime-linux-x64": "1.29.5",
+        "bare-runtime-win32-arm64": "1.29.5",
+        "bare-runtime-win32-x64": "1.29.5"
+      }
+    },
+    "node_modules/bare-runtime-android-arm": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime-android-arm/-/bare-runtime-android-arm-1.29.5.tgz",
+      "integrity": "sha512-b8syj2a++blVZCxu/3dBpnP93g8+st4Jl9N/TUL01iIFw5azLiImraJFylT9kJBCM1JN6qMQqPP2ImwspZIdMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      },
+      "bin": {
+        "bare": "bin/bare"
+      }
+    },
+    "node_modules/bare-runtime-android-arm64": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime-android-arm64/-/bare-runtime-android-arm64-1.29.5.tgz",
+      "integrity": "sha512-/0ltvJfco7D19m42/ZbOPugRexaZDXYIbBeuyh5eMUwA4YVtvXfBbQOPz/Tfm3V740PhdL/Oeuya54ABAZ8akw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      },
+      "bin": {
+        "bare": "bin/bare"
+      }
+    },
+    "node_modules/bare-runtime-android-ia32": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime-android-ia32/-/bare-runtime-android-ia32-1.29.5.tgz",
+      "integrity": "sha512-HV7xsZjpg57a4f5MkTR/JpxM+VhzgD4kpWyXP09MleqHUQEYYyuI9jSo9ZN6yT9pkRgrSaFDBTXIKtiqY8QZGA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      },
+      "bin": {
+        "bare": "bin/bare"
+      }
+    },
+    "node_modules/bare-runtime-android-x64": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime-android-x64/-/bare-runtime-android-x64-1.29.5.tgz",
+      "integrity": "sha512-/7mnA0aArtXgfntX6ie48R7Mcbt2sTDXoSgF1XaheTzFpYhSJa7EX6zELcZfIHXZ/H9vj7DP6FJWykJlpMCmQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      },
+      "bin": {
+        "bare": "bin/bare"
+      }
+    },
+    "node_modules/bare-runtime-darwin-arm64": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime-darwin-arm64/-/bare-runtime-darwin-arm64-1.29.5.tgz",
+      "integrity": "sha512-0lnroA/FmXKsWjIg9yQEJjOaW1G6W8CAs2Uq/w+3eIoF6sUNYrxTnbt+C1aT5apae3QFGgPeuDoOXezCEKtB5g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      },
+      "bin": {
+        "bare": "bin/bare"
+      }
+    },
+    "node_modules/bare-runtime-darwin-x64": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime-darwin-x64/-/bare-runtime-darwin-x64-1.29.5.tgz",
+      "integrity": "sha512-xyJn0JUy7r2ymukoSBR5FyHf1JTLVM9F/OXKpHzKL8/3/wY4hXDEDzAH4nTJB2U6p5+Tfrk59x4lLQM2LyMpKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      },
+      "bin": {
+        "bare": "bin/bare"
+      }
+    },
+    "node_modules/bare-runtime-ios-arm64": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime-ios-arm64/-/bare-runtime-ios-arm64-1.29.5.tgz",
+      "integrity": "sha512-pJEYLL8U1S8JGavDiAWJQdBwSFrkNgU8ISoX1BGstXN+R1kEzXXdtRULpJV9W3+ekMrG8DPjpWwnucFqfMcPzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "ios"
+      ],
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      },
+      "bin": {
+        "bare": "bin/bare"
+      }
+    },
+    "node_modules/bare-runtime-ios-arm64-simulator": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime-ios-arm64-simulator/-/bare-runtime-ios-arm64-simulator-1.29.5.tgz",
+      "integrity": "sha512-cqCTS2ITf1OOfvCYo78LbROvaZdpXzeYuEF+4eVauNecd/gmENLDN2eViBA1cMs2oEjfQOrmErolkmouaKHKLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "ios"
+      ],
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      },
+      "bin": {
+        "bare": "bin/bare"
+      }
+    },
+    "node_modules/bare-runtime-ios-x64-simulator": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime-ios-x64-simulator/-/bare-runtime-ios-x64-simulator-1.29.5.tgz",
+      "integrity": "sha512-5e+Wbw6zm5scjqyOvYgifR2A9aPWTMq/Lrat7llaXRd3g+T2gdYyJAP3n6RVYzvreDthvZVl7RfiXVKo3A1wBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "ios"
+      ],
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      },
+      "bin": {
+        "bare": "bin/bare"
+      }
+    },
+    "node_modules/bare-runtime-linux-arm64": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime-linux-arm64/-/bare-runtime-linux-arm64-1.29.5.tgz",
+      "integrity": "sha512-v6/FSrJ5oHeisOY0GHqTX4u/JwwIw1mRUIS85dXGwd8dnHyqFOECCguu4hNazqxuTiwsvZZ32ECnotwpPKinow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      },
+      "bin": {
+        "bare": "bin/bare"
+      }
+    },
+    "node_modules/bare-runtime-linux-x64": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime-linux-x64/-/bare-runtime-linux-x64-1.29.5.tgz",
+      "integrity": "sha512-OJgxNF85+mEB56zA1KVF4MSEKI6iNuZdaC5STE3UwySYrUkCTEDDmDh5ISSt81mTFz34qqQqQSEqTX02gXV1sw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      },
+      "bin": {
+        "bare": "bin/bare"
+      }
+    },
+    "node_modules/bare-runtime-win32-arm64": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime-win32-arm64/-/bare-runtime-win32-arm64-1.29.5.tgz",
+      "integrity": "sha512-rg5Zzd0Jp7LLu0fmj4MNQSRjqnFPRybO8tpfY4h/mnOBmsDhHjlJ+d+sltXCfioQvUCdkapNTEWPkMkU4Az9YA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      },
+      "bin": {
+        "bare": "bin/bare.exe"
+      }
+    },
+    "node_modules/bare-runtime-win32-x64": {
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/bare-runtime-win32-x64/-/bare-runtime-win32-x64-1.29.5.tgz",
+      "integrity": "sha512-vWYLRXo2R7v//jFz/dRD306NgZsgZMADaiEVlUcHjYWb16AtPaR/cIr7OJBWnEFMvqixTiUfEA0Hd9n91P3KMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "dependencies": {
+        "require-asset": "^1.0.2"
+      },
+      "bin": {
+        "bare": "bin/bare.exe"
+      }
+    },
+    "node_modules/bare-runtime/node_modules/bare-subprocess": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/bare-subprocess/-/bare-subprocess-6.1.0.tgz",
+      "integrity": "sha512-8L6KtbmreDy4Fc1BdDqaDo9fg0nbedUmTSFQxYPV0uHIM2BBAX8+E0LyMDKgkk0I+mlKto80WYzOnIhT8VDdOg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-env": "^3.0.0",
+        "bare-events": "^2.5.4",
+        "bare-os": "^3.0.1",
+        "bare-pipe": "^4.2.0",
+        "bare-structured-clone": "^1.5.2",
+        "bare-tcp": "^2.4.1",
+        "bare-url": "^2.2.2"
+      },
+      "engines": {
+        "bare": ">=1.7.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-semver": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.0.3.tgz",
+      "integrity": "sha512-HS/A30bi2+PiRJfU6R4+Kp+6KeLSCSByjYM2iiobOKzLAvtu1CT+S8xWfiU7wz0erknjkUoC+yXy108tzIuP5Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-sidecar": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/bare-sidecar/-/bare-sidecar-0.4.6.tgz",
+      "integrity": "sha512-imHop80OGC9HE5gVNQtAGJg5duUH2DL/7v7is0JrcdzE7WtleemWZ7BnlESB24l4xgAMEQnADkAgcMNiweMcNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.5.1",
+        "bare-module": "^6.1.3",
+        "bare-os": "^3.6.2",
+        "bare-path": "^3.0.0",
+        "bare-pipe": "^4.1.3",
+        "bare-stream": "^2.7.0",
+        "bare-subprocess": "^6.0.0",
+        "bare-url": "^2.3.2",
+        "require-asset": "^1.1.0"
+      }
+    },
+    "node_modules/bare-sidecar/node_modules/bare-subprocess": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/bare-subprocess/-/bare-subprocess-6.1.0.tgz",
+      "integrity": "sha512-8L6KtbmreDy4Fc1BdDqaDo9fg0nbedUmTSFQxYPV0uHIM2BBAX8+E0LyMDKgkk0I+mlKto80WYzOnIhT8VDdOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-env": "^3.0.0",
+        "bare-events": "^2.5.4",
+        "bare-os": "^3.0.1",
+        "bare-pipe": "^4.2.0",
+        "bare-structured-clone": "^1.5.2",
+        "bare-tcp": "^2.4.1",
+        "bare-url": "^2.2.2"
+      },
+      "engines": {
+        "bare": ">=1.7.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-signals": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/bare-signals/-/bare-signals-4.2.0.tgz",
+      "integrity": "sha512-fNHMOdQIlYuTvMB3Oh9Apk99hLKn351+Ir8vz+khiPTcOqIyGG4uWWjdLTzxWdYGsA0eT+We3y0K74hjj2nq7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.3",
+        "bare-os": "^3.3.1"
+      },
+      "engines": {
+        "bare": ">=1.7.0"
+      }
+    },
+    "node_modules/bare-stdio": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bare-stdio/-/bare-stdio-1.0.2.tgz",
+      "integrity": "sha512-3WJDqtvVGP4f+j68kyEC05umOYNwKJ1xG+YAXL8yZ605WgNqiRhVaFq+mVIhBt2eKNp7pa5vCQdhOt1pNh79SA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.5.2",
+        "bare-pipe": "^4.1.5",
+        "bare-tty": "^5.0.3"
+      }
+    },
+    "node_modules/bare-storage": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bare-storage/-/bare-storage-1.1.0.tgz",
+      "integrity": "sha512-zaQ4dtK4WeYPA1Hz8c9xCimkQLdZbeZnFp/6TmHh6/X5W6o/qXclxNno8DOeZRvdVjziMcADAId2TZJobWydkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-compat-napi": "^1.3.9",
+        "bare-env": "^3.0.0",
+        "bare-fs": "^4.5.3",
+        "bare-os": "^3.0.0",
+        "bare-path": "^3.0.0",
+        "require-addon": "^1.2.0"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-structured-clone": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/bare-structured-clone/-/bare-structured-clone-1.5.5.tgz",
+      "integrity": "sha512-b1x++7qt6x7T0Rm8NAg/EnU13+rn3Gfglv8N5PGtFcfdi4yAfLJs/mLbrVfc+C66DFrO+CxdIsl1NcnE6Ra+xQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-buffer": "^3.6.0",
+        "bare-type": "^1.1.0",
+        "bare-url": "^2.4.0",
+        "compact-encoding": "^3.0.1"
+      },
+      "engines": {
+        "bare": ">=1.2.0"
+      }
+    },
+    "node_modules/bare-stylize": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/bare-stylize/-/bare-stylize-0.0.1.tgz",
+      "integrity": "sha512-l3MjmIl476bWijYWf3RbE+osl4iuXSOMudzp0vAqzIK7gPgn/+G3oAxp8Oin9CFF911KBP0LO9kts8Ci8mGZaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-ansi-escapes": "^2.2.3",
+        "bare-process": "^4.2.1"
+      }
+    },
+    "node_modules/bare-subprocess": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bare-subprocess/-/bare-subprocess-5.2.3.tgz",
+      "integrity": "sha512-07wwswlV7M3sC9IykbZRZ/jHAkrXFWVLqdBWGv1y0ojCimtRD9hGwxdHmR5FUFmDUZLNsBmTYJNQqgio5+A85Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-env": "^3.0.0",
+        "bare-events": "^2.5.4",
+        "bare-os": "^3.0.1",
+        "bare-pipe": "^4.0.0",
+        "bare-url": "^2.2.2"
+      },
+      "engines": {
+        "bare": ">=1.7.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-tcp": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/bare-tcp/-/bare-tcp-2.5.0.tgz",
+      "integrity": "sha512-lwUy3jSVoloVBbCCyPFmmqT1KaeBk/XEkpLMHU+BCap8WNXc48iQfiWEQYgJkCRYuP6vnkZ0XHCLY222TJ29Wg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-dns": "^2.0.4",
+        "bare-events": "^2.5.4",
+        "bare-stream": "^2.6.4"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-pipe": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-pipe": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-tls": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/bare-tls/-/bare-tls-3.1.7.tgz",
+      "integrity": "sha512-AMw8tJlb3LhzAmhgXRcjDrTlNxR3gXXyj6G8eU9iwvCFtiUBD8MxAW7bwunA1gXDukgo40A970jX0APc2jMU7A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-net": "^2.0.1",
+        "bare-stream": "^2.6.4"
+      },
+      "engines": {
+        "bare": ">=1.7.0"
+      }
+    },
+    "node_modules/bare-tpl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bare-tpl/-/bare-tpl-1.0.1.tgz",
+      "integrity": "sha512-eOViEnDVFaPMALTbNioW5aYro9OR4b/6tdMNx73Gd1l+TjF0mL3sXCpNdbOBNzTttyFX5hhTesjJCGHrY0q7fg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-tty": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bare-tty/-/bare-tty-5.1.0.tgz",
+      "integrity": "sha512-EZLvW4A+XiJgI3TW+e1pMME9PIJsfEXe/DA/WSKzIkq/v7Yarpv/rvG6Z5pGnpo4V/Bd+qopwnCLSR71hMMBYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.2.0",
+        "bare-signals": "^4.0.0",
+        "bare-stream": "^2.0.0"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      }
+    },
+    "node_modules/bare-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bare-type/-/bare-type-1.1.0.tgz",
+      "integrity": "sha512-LdtnnEEYldOc87Dr4GpsKnStStZk3zfgoEMXy8yvEZkXrcCv9RtYDrUYWFsBQHtaB0s1EUWmcvS6XmEZYIj3Bw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.2.0"
+      }
+    },
+    "node_modules/bare-unpack": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/bare-unpack/-/bare-unpack-1.1.3.tgz",
+      "integrity": "sha512-b+OFTi74dsMaVQy9w90U6WMqhVBcx5hONJnFbOSfhTefG/9OuY6ZxU3IvybVa5/i3edzboa7rebaMG25K6/kAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-bundle": "^1.8.3",
+        "bare-fs": "^4.2.3",
+        "bare-path": "^3.0.0",
+        "paparam": "^1.8.5",
+        "promaphore": "^1.0.0"
+      },
+      "bin": {
+        "bare-unpack": "bin.js"
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/bare-utils": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/bare-utils/-/bare-utils-1.6.0.tgz",
+      "integrity": "sha512-WhQEIkkAxkSnW7u1QgrI0AfNm5JpMruETXeYsb5qnkBJ0TTfNKygZmsh6rkoHBANaV+C/7Jed7bJP9OmEHG7rQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-debug-log": "^2.0.0",
+        "bare-encoding": "^1.0.0",
+        "bare-format": "^1.0.0",
+        "bare-inspect": "^3.0.0",
+        "bare-stylize": "^0.0.1",
+        "bare-type": "^1.0.6"
+      }
+    },
+    "node_modules/bare-v8-to-istanbul": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bare-v8-to-istanbul/-/bare-v8-to-istanbul-1.0.2.tgz",
+      "integrity": "sha512-CM0wPgyQtXTQ7h4q8NjbTZ/FH5he0Jkiwgpq0lFZZA5tkVZzmQ/9ul4R7E+cNlGZJIZlQZ9v4CwbgVaFG3zOAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-assert": "^1.0.2",
+        "bare-fs": "^4.1.2",
+        "bare-module": "^6.1.2",
+        "bare-path": "^3.0.0",
+        "bare-process": "^4.2.0",
+        "bare-url": "^2.1.5",
+        "bare-utils": "^1.2.0",
+        "v8-to-istanbul": "^9.3.0",
+        "which-runtime": "^1.2.1"
+      }
+    },
+    "node_modules/bare-ws": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-ws/-/bare-ws-3.0.0.tgz",
+      "integrity": "sha512-q2v0UIQ0cFQBXQMp+0FRaoSk1EoYgOhzO7yio0TqBV6Rkfot97mbBYxb1ssw5faVCisVaFxQYY8113SMLYQBow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-crypto": "^1.2.0",
+        "bare-events": "^2.3.1",
+        "bare-http1": "^4.0.0",
+        "bare-https": "^3.0.0",
+        "bare-stream": "^2.1.2"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/big-sparse-array": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/big-sparse-array/-/big-sparse-array-1.0.3.tgz",
+      "integrity": "sha512-6RjV/3mSZORlMdpUaQ6rUSpG637cZm0//E54YYGtQg1c1O+AbZP8UTdJ/TchsDZcTVLmyWZcseBfp2HBeXUXOQ==",
+      "license": "MIT"
+    },
+    "node_modules/binary-stream-equals": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/binary-stream-equals/-/binary-stream-equals-1.0.0.tgz",
+      "integrity": "sha512-xiUT5LGfD8JiLhbXiG+ByOnbgb9f2ssRLfZDQMl3nZdf89EotQZGZuMkDN8J3n46emabE7RnJ1q0r7Hv3INExw==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.3.1"
+      }
+    },
+    "node_modules/bits-to-bytes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bits-to-bytes/-/bits-to-bytes-1.3.0.tgz",
+      "integrity": "sha512-OJoHTpFXS9bXHBCekGTByf3MqM8CGblBDIduKQeeVVeiU9dDWywSSirXIBYGgg3d1zbVuvnMa1vD4r6PA0kOKg==",
+      "license": "ISC",
+      "dependencies": {
+        "b4a": "^1.5.0"
+      }
+    },
+    "node_modules/blind-relay": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/blind-relay/-/blind-relay-1.6.1.tgz",
+      "integrity": "sha512-38YmKCl/m9NcTkwueBbcGIt9Zx3IT/Q9Nsluu6C5Gur6PqfE0zWPhPwCzia1hri/g0ICYxrqkgLtEaoWD5WeSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-events": "^2.2.0",
+        "bits-to-bytes": "^1.3.0",
+        "compact-encoding": "^3.0.0",
+        "compact-encoding-bitfield": "^1.0.0",
+        "protomux": "^3.5.1",
+        "sodium-universal": "^5.0.0",
+        "streamx": "^2.15.1"
+      }
+    },
+    "node_modules/bogon": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bogon/-/bogon-1.3.0.tgz",
+      "integrity": "sha512-04tu0G/v0f2HPuQlSfhO635WwHDBCaITJ490rhxH9ttUlgPqOirZVKV02YB6NvPf5VkmbqJCm3bnZwrPk/eDSg==",
+      "license": "MIT",
+      "dependencies": {
+        "compact-encoding": "^3.0.0",
+        "compact-encoding-net": "^1.2.0"
+      }
+    },
+    "node_modules/brittle": {
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/brittle/-/brittle-3.19.1.tgz",
+      "integrity": "sha512-4Ted1Mt9o9B6oIA6ImJJCtB/Fv++ZO3IDNQgRcHOXWSYGRUidgxchaGrUBaRn+4mlneXrgInPkCPzi0jO8qKbA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.0",
+        "bare-assert": "^1.0.2",
+        "bare-cov": "^1.1.0",
+        "bare-fs": "^4.1.6",
+        "bare-os": "^3.6.1",
+        "bare-path": "^3.0.0",
+        "bare-process": "^4.2.1",
+        "bare-subprocess": "^5.0.0",
+        "bare-url": "^2.1.6",
+        "error-stack-parser": "^2.1.4",
+        "globbie": "^1.0.2",
+        "paparam": "^1.6.2",
+        "same-object": "^1.0.2",
+        "test-tmp": "^1.4.0",
+        "tmatch": "^5.0.0"
+      },
+      "bin": {
+        "brittle": "bin/node.js",
+        "brittle-bare": "bin/bare.js",
+        "brittle-node": "bin/node.js",
+        "brittle-pear": "bin/pear.js"
+      }
+    },
+    "node_modules/codecs": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/codecs/-/codecs-3.1.0.tgz",
+      "integrity": "sha512-Dqx8NwvBvnMeuPQdVKy/XEF71igjR5apxBvCGeV0pP1tXadOiaLvDTXt7xh+/5wI1ASB195mXQGJbw3Ml4YDWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.3"
+      }
+    },
+    "node_modules/compact-encoding": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/compact-encoding/-/compact-encoding-3.2.0.tgz",
+      "integrity": "sha512-cCe/FM8f/WuXkEVpsYEoSX3ht2tec7NSNOC8rZBv/sbdFzO3h2Z/JUmZwJQBhghKJNimJSkWM40YURhgU640jw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.3.0"
+      }
+    },
+    "node_modules/compact-encoding-bitfield": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/compact-encoding-bitfield/-/compact-encoding-bitfield-1.1.0.tgz",
+      "integrity": "sha512-F6wliSKHi50BsBStmnsRJAzJgYSIYzdfSe3M0oHj4uQ1RcctJK/NQVD7wF51bj/DBMne2i5gUxrGUFkNZQns5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "compact-encoding": "^3.0.0"
+      }
+    },
+    "node_modules/compact-encoding-net": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/compact-encoding-net/-/compact-encoding-net-1.3.0.tgz",
+      "integrity": "sha512-HIYjL3aMiSENApR691aMLngXt6rkTHb9HUkEukcx3YwIZpoMUVXHXyjBzoo9kVwC7KakooBA1RRWb46Cu6qtAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "compact-encoding": "^3.0.0"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/corestore": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/corestore/-/corestore-7.10.1.tgz",
+      "integrity": "sha512-QdcNtpFSYtVHA4UcUSSf2m9gNMT9QqSs9fn+pZx6xdUivNono18JhtpEP/TYpP9heKB7yd+qLsLQP5bo65sg6A==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.7",
+        "bare-events": "^2.8.3",
+        "hypercore": "^11.32.0",
+        "hypercore-crypto": "^3.4.2",
+        "hypercore-errors": "^1.4.0",
+        "hypercore-id-encoding": "^1.3.0",
+        "ready-resource": "^1.1.1",
+        "sodium-universal": "^5.0.1",
+        "streamx": "^2.26.0",
+        "which-runtime": "^1.2.1"
+      }
+    },
+    "node_modules/debounceify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/debounceify/-/debounceify-1.1.0.tgz",
+      "integrity": "sha512-eKuHDVfJVg+u/0nPy8P+fhnLgbyuTgVxuCRrS/R7EpDSMMkBDgSes41MJtSAY1F1hcqfHz3Zy/qpqHHIp/EhdA==",
+      "license": "MIT"
+    },
+    "node_modules/device-file": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/device-file/-/device-file-2.3.1.tgz",
+      "integrity": "sha512-bmON44lwxJPle9N2OcH4tqM44pMGZKT8G6OkzXkz0urvqQ9LKkoQdTS6w0ztYfmLdUE27R4UUmx0+y2gEz4Jug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.7",
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0",
+        "fd-lock": "^2.1.0",
+        "fs-native-extensions": "^1.4.0",
+        "ready-resource": "^1.2.0"
+      }
+    },
+    "node_modules/dht-rpc": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/dht-rpc/-/dht-rpc-6.27.0.tgz",
+      "integrity": "sha512-NsfgRlFDQnkA2+H+hJXMPLmBOn/TSIIc0cRMV8q42M4xc1uAXWtpvIIQsONF5tYcYC6px0bslrUGideN1h4S4A==",
+      "license": "MIT",
+      "dependencies": {
+        "adaptive-timeout": "^1.0.1",
+        "b4a": "^1.6.1",
+        "bare-events": "^2.2.0",
+        "compact-encoding": "^3.0.0",
+        "compact-encoding-net": "^1.2.0",
+        "fast-fifo": "^1.1.0",
+        "kademlia-routing-table": "^1.0.1",
+        "nat-sampler": "^1.0.1",
+        "sodium-universal": "^5.0.0",
+        "streamx": "^2.13.2",
+        "time-ordered-set": "^2.0.0",
+        "udx-native": "^1.5.3"
+      }
+    },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
+    "node_modules/fd-lock": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fd-lock/-/fd-lock-2.1.1.tgz",
+      "integrity": "sha512-H3VkcWFl39Rk0xBokDcUyBcVs6VrYTUo/DhDWMzJOF99wXWDAvmvq/GlLTS2NTehsznZhp3fXVyrtB2ldDXhwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.5.0",
+        "fs-native-extensions": "^1.4.4",
+        "ready-resource": "^1.2.0",
+        "resource-on-exit": "^1.0.0"
+      }
+    },
+    "node_modules/flat-tree": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/flat-tree/-/flat-tree-1.13.0.tgz",
+      "integrity": "sha512-fT3HIuCPwHhFgJ20QYzDHgUG0zMmFg5cHvFiFo5h+QMSJ28TihsEVY0f8HGliuO+pOzmvjMx1odToeaEWkTnyQ==",
+      "license": "MIT"
+    },
+    "node_modules/fs-native-extensions": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/fs-native-extensions/-/fs-native-extensions-1.5.0.tgz",
+      "integrity": "sha512-nuZLFm9mGCxvyi7Llww/J4OyifKCS21nEUTAmnlTZp3FObPOvA32aCedCmt4Z+8yk+caqfClNaSCfn/P7T7FLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-addon": "^1.1.0",
+        "which-runtime": "^1.2.0"
+      }
+    },
+    "node_modules/generate-object-property": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-2.0.0.tgz",
+      "integrity": "sha512-KwuURPyqn2Mz8DdV29pJwQu0Y7tcsbkULr82eeOcY/ZllFK6I9Wm8dsRByIu7CKWlFi9BdW1b3mcXMp/kQBQsw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.0"
+      }
+    },
+    "node_modules/generate-string": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/generate-string/-/generate-string-1.0.1.tgz",
+      "integrity": "sha512-IfTY0dKZM43ACyGvXkbG7De7WY7MxTS5VO6Juhe8oJKpCmrYYXoqp/cJMskkpi0k9H8wuXq0H+eI898/BCqvXg==",
+      "license": "MIT"
+    },
+    "node_modules/globbie": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globbie/-/globbie-1.0.3.tgz",
+      "integrity": "sha512-hcryJmKcftf82xfBWTWxuUITWIIoYO3ec104V17SMHGFl6VLbm1d1Ju9LX9L+jyJTwICpemX/dmPI/HGYoKr1A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.1.2",
+        "bare-path": "^3.0.0",
+        "bare-process": "^4.2.1",
+        "picomatch": "^4.0.2"
+      }
+    },
+    "node_modules/hyperbee": {
+      "version": "2.27.3",
+      "resolved": "https://registry.npmjs.org/hyperbee/-/hyperbee-2.27.3.tgz",
+      "integrity": "sha512-PXURH2U4juUZyJRKHTrY5z1zX851pmI1Q0jfv5F/hCIErDt/ND8jOZuxc3hfOLM9f0W3qJEDTMlV5AJBkVPy8w==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.0",
+        "codecs": "^3.0.0",
+        "debounceify": "^1.0.0",
+        "hypercore-errors": "^1.0.0",
+        "mutexify": "^1.4.0",
+        "protocol-buffers-encodings": "^1.2.0",
+        "rache": "^1.0.0",
+        "ready-resource": "^1.0.0",
+        "resolve-reject-promise": "^1.1.0",
+        "safety-catch": "^1.0.2",
+        "streamx": "^2.12.4",
+        "unslab": "^1.2.0"
+      }
+    },
+    "node_modules/hyperblobs": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/hyperblobs/-/hyperblobs-2.12.1.tgz",
+      "integrity": "sha512-iX5sPkL/3eDphUkMxTG43xZGEER+cVLAFbuNIQpk/WVK8CTWnmaoCYP/+94RaFFh5U7HeGoDYidQbv6E7LeAvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.1",
+        "bare-events": "^2.5.0",
+        "compact-encoding": "^3.0.0",
+        "hypercore-crypto": "^3.6.1",
+        "hypercore-errors": "^1.1.1",
+        "mutexify": "^1.4.0",
+        "speedometer": "^1.1.0",
+        "streamx": "^2.13.2"
+      }
+    },
+    "node_modules/hypercore": {
+      "version": "11.33.1",
+      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-11.33.1.tgz",
+      "integrity": "sha512-fpAWVOM4CclWAPChmsh1nAfJy5pJlFOLUOiegRws2HYzUsj5bP/VwanZYv9ruhRXRLY1qJeddXLTEz4DJf1GQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@hyperswarm/secret-stream": "^6.0.0",
+        "b4a": "^1.1.0",
+        "bare-events": "^2.2.0",
+        "big-sparse-array": "^1.0.3",
+        "compact-encoding": "^3.0.0",
+        "fast-fifo": "^1.3.0",
+        "flat-tree": "^1.9.0",
+        "hypercore-crypto": "^3.2.1",
+        "hypercore-errors": "^1.5.0",
+        "hypercore-id-encoding": "^1.2.0",
+        "hypercore-storage": "^3.0.0",
+        "is-options": "^1.0.1",
+        "nanoassert": "^2.0.0",
+        "protomux": "^3.5.0",
+        "quickbit-universal": "^2.2.0",
+        "random-array-iterator": "^1.0.0",
+        "safety-catch": "^1.0.1",
+        "sodium-universal": "^5.0.1",
+        "streamx": "^2.12.4",
+        "unslab": "^1.3.0",
+        "z32": "^1.0.0"
+      }
+    },
+    "node_modules/hypercore-crypto": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/hypercore-crypto/-/hypercore-crypto-3.7.0.tgz",
+      "integrity": "sha512-SWxobptQf2V/+ZLCCDRTXqFzGfTPIkNIuDyLKXpEMfcpJ1/ec94N9aWgylHcWOHmRt14ng/KR7z0BugebWHK9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.6",
+        "compact-encoding": "^3.0.0",
+        "sodium-universal": "^5.0.0"
+      }
+    },
+    "node_modules/hypercore-errors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/hypercore-errors/-/hypercore-errors-1.5.0.tgz",
+      "integrity": "sha512-5KQ/SuDxsvet+7qWA35Ay6zdD9WyAHQoyWHGcPUTbmJBd300gvNIJoi3oma7kp4TTCSzii6qYumNZe/s0j/saQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "hypercore-id-encoding": "^1.3.0"
+      }
+    },
+    "node_modules/hypercore-id-encoding": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/hypercore-id-encoding/-/hypercore-id-encoding-1.3.0.tgz",
+      "integrity": "sha512-W6sHdGo5h7LXEsoWfKf/KfuROZmZRQDlGqJF2EPHW+noCK66Vvr0+zE6cL0vqQi18s0kQPeN7Sq3QyR0Ytc2VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.5.3",
+        "z32": "^1.0.0"
+      }
+    },
+    "node_modules/hypercore-storage": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/hypercore-storage/-/hypercore-storage-3.1.1.tgz",
+      "integrity": "sha512-UEOtZDT2ftGSrGEfwUTzOprhwICxNHfSYgl6BxgdJZDpV18hllbUQIBdjkH+IfRNBg5c85ehSY8VZJ6bIPwPEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.7",
+        "bare-path": "^3.0.0",
+        "compact-encoding": "^3.1.0",
+        "device-file": "^2.1.2",
+        "flat-tree": "^1.12.1",
+        "hypercore-crypto": "^3.4.2",
+        "hyperschema": "^1.21.0",
+        "index-encoder": "^3.3.2",
+        "resolve-reject-promise": "^1.0.0",
+        "rocksdb-native": "^3.11.0",
+        "scope-lock": "^1.2.4",
+        "streamx": "^2.21.1"
+      }
+    },
+    "node_modules/hyperdht": {
+      "version": "6.32.0",
+      "resolved": "https://registry.npmjs.org/hyperdht/-/hyperdht-6.32.0.tgz",
+      "integrity": "sha512-Y/SibEN7wue0E8ydh8lx9IX7SOE9o00b6tufPA7hRxAafXsisWUBrW36fIHdyxg148T4Z3olrooOGZDZ89LYag==",
+      "license": "MIT",
+      "dependencies": {
+        "@hyperswarm/secret-stream": "^6.6.2",
+        "b4a": "^1.3.1",
+        "bare-events": "^2.2.0",
+        "blind-relay": "^1.3.0",
+        "bogon": "^1.0.0",
+        "compact-encoding": "^3.0.0",
+        "dht-rpc": "^6.15.1",
+        "hypercore-crypto": "^3.3.0",
+        "hypercore-id-encoding": "^1.2.0",
+        "hyperdht-address": "^1.0.1",
+        "noise-curve-ed": "^2.0.0",
+        "noise-handshake": "^4.0.0",
+        "record-cache": "^1.1.1",
+        "safety-catch": "^1.0.1",
+        "signal-promise": "^1.0.3",
+        "sodium-universal": "^5.0.1",
+        "streamx": "^2.16.1",
+        "unslab": "^1.3.0",
+        "xache": "^1.1.0"
+      },
+      "bin": {
+        "hyperdht": "bin.js"
+      }
+    },
+    "node_modules/hyperdht-address": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hyperdht-address/-/hyperdht-address-1.1.1.tgz",
+      "integrity": "sha512-Mu/+7SW2cwvHxMXswa5mOrhrS5BJyntViAuB25k8d8wNtA8eAPs4LaIq6TwN1SS/KQY02h1r+gM8cQeN/k360w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "compact-encoding": "^3.0.0",
+        "hyperschema": "^1.20.1"
+      }
+    },
+    "node_modules/hyperdrive": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/hyperdrive/-/hyperdrive-13.3.2.tgz",
+      "integrity": "sha512-YgM/be3hppRTLN7plGGot30w58imhCBhzy+bfSToyDH0Gf4ykwplOxsW3YnDIIH5Oa/tNU2ZdZHQ6IhrTZ9aLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "hyperbee": "^2.11.1",
+        "hyperblobs": "^2.9.0",
+        "hypercore": "^11.0.0",
+        "hypercore-errors": "^1.0.0",
+        "is-options": "^1.0.2",
+        "mirror-drive": "^1.2.0",
+        "ready-resource": "^1.0.0",
+        "safety-catch": "^1.0.2",
+        "speedometer": "^1.1.0",
+        "streamx": "^2.12.4",
+        "sub-encoder": "^2.1.1",
+        "unix-path-resolve": "^1.0.2"
+      }
+    },
+    "node_modules/hyperschema": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/hyperschema/-/hyperschema-1.21.0.tgz",
+      "integrity": "sha512-lEnIbLTUQf7w6FU6X+R3yUJhBwCzF4ewRnAaYOrPdcVWe1rbOf94PzMiXb5pBKxroCXzlrPLxVujxAsTrrHc8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.0.1",
+        "compact-encoding": "^3.0.0",
+        "generate-object-property": "^2.0.0",
+        "generate-string": "^1.0.1"
+      }
+    },
+    "node_modules/hyperswarm": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/hyperswarm/-/hyperswarm-4.17.0.tgz",
+      "integrity": "sha512-oe86sK961Ueg7rvDN/veFwG8xH+Iv6vObPhGDkPJcDVxk/NduW41ZhAcVDnHzRbm7S0eLU7WaDUvehOYoKSpRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.3.1",
+        "bare-events": "^2.2.0",
+        "hyperdht": "^6.21.0",
+        "safety-catch": "^1.0.2",
+        "shuffled-priority-queue": "^2.1.0",
+        "streamx": "^2.22.1",
+        "unslab": "^1.3.0"
+      }
+    },
+    "node_modules/index-encoder": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/index-encoder/-/index-encoder-3.5.0.tgz",
+      "integrity": "sha512-idZ1cxtZz2dRV6rUiaP9Xo99UjXbSzjcMacoQmxUMu/A7fEQcNPngvwDJYeWelQUS5XFlY71/or70lKn6XnwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/is-options": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-options/-/is-options-1.0.2.tgz",
+      "integrity": "sha512-u+Ai74c8Q74aS8BuHwPdI1jptGOT1FQXgCq8/zv0xRuE+wRgSMEJLj8lVO8Zp9BeGb29BXY6AsNPinfqjkr7Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.1.1"
+      }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "license": "MIT"
+    },
+    "node_modules/kademlia-routing-table": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/kademlia-routing-table/-/kademlia-routing-table-1.0.6.tgz",
+      "integrity": "sha512-Ve6jwIlUCYvUzBnXnzVRHDZCFgXURW9gmF3r7n05kZs/2rNbLHXwGdcq0qIaSwdmJCvtosgR4JensnVU65hzNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bare-events": "^2.2.0"
+      }
+    },
+    "node_modules/localdrive": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/localdrive/-/localdrive-2.2.1.tgz",
+      "integrity": "sha512-r7AMrscOky3zIjzOrbH+90P12WmFdQaIlJ26TXaUJrM3hGQ6lIQkWhy8eQs5xDI5ukEyrXp4962EIgO9DFdm+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.1",
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0",
+        "mirror-drive": "^1.2.0",
+        "mutexify": "^1.4.0",
+        "streamx": "^2.12.5",
+        "unix-path-resolve": "^1.0.2"
+      }
+    },
+    "node_modules/lunte": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lunte/-/lunte-1.8.0.tgz",
+      "integrity": "sha512-znc/elScelBYq/N6hUngr9rPdArBKhn4yR86ofnuj6qQ0MAHAo8KalAY2c/DBKw3dO4FjUZ9PR+YCFSbCgBcWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "paparam": "^1.8.6"
+      },
+      "bin": {
+        "lunte": "bin/lunte"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.8.1",
+        "bare-fs": "^4.7.0",
+        "bare-module": "^6.1.2",
+        "bare-os": "^3.6.2",
+        "bare-path": "^3.0.0",
+        "bare-process": "^4.2.2",
+        "bare-subprocess": "^5.1.4",
+        "bare-url": "^2.3.2",
+        "bare-utils": "^1.5.1"
+      }
+    },
+    "node_modules/mirror-drive": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/mirror-drive/-/mirror-drive-1.14.2.tgz",
+      "integrity": "sha512-1ZtS/TonGXWX0eDAGK90JapGyzOaz8IxX7mARZWPgUuZ9eEIvaoSY7bxv6/4FOW26wL8g/YcpqJpt8mMZ/QZCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.8.2",
+        "binary-stream-equals": "^1.0.0",
+        "rabin-stream": "^2.0.0",
+        "same-data": "^1.0.0",
+        "speedometer": "^1.1.0",
+        "streamx": "^2.22.1",
+        "unix-path-resolve": "^1.0.2"
+      }
+    },
+    "node_modules/msix-manager": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/msix-manager/-/msix-manager-0.2.5.tgz",
+      "integrity": "sha512-bfAqCBIIoxCsBCuDCr9wCfucmL0fy8jE4GBf9Yx24ZXDxQe4L7r/CJcNcGQxWx9RdHGCqCuNKrrNLfTYOue3fw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.8.2",
+        "bare-url": "^2.3.2",
+        "require-addon": "^1.2.0"
+      }
+    },
+    "node_modules/mutexify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/mutexify/-/mutexify-1.4.0.tgz",
+      "integrity": "sha512-pbYSsOrSB/AKN5h/WzzLRMFgZhClWccf2XIB4RSMC8JbquiB0e0/SH5AIfdQMdyHmYtv4seU7yV/TvAwPLJ1Yg==",
+      "license": "MIT",
+      "dependencies": {
+        "queue-tick": "^1.0.0"
+      }
+    },
+    "node_modules/nanoassert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
+      "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA==",
+      "license": "ISC"
+    },
+    "node_modules/nat-sampler": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nat-sampler/-/nat-sampler-1.0.1.tgz",
+      "integrity": "sha512-yQvyNN7xbqR8crTKk3U8gRgpcV1Az+vfCEijiHu9oHHsnIl8n3x+yXNHl42M6L3czGynAVoOT9TqBfS87gDdcw==",
+      "license": "MIT"
+    },
+    "node_modules/noise-curve-ed": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/noise-curve-ed/-/noise-curve-ed-2.1.0.tgz",
+      "integrity": "sha512-zAzJx+VwZM3w6EA1hTmDhJfvAnCeBQn/1FAeZ0LtGxCcCtlAK/uJXQVF/eDVUOaAZ286lHlx77WJ+qj9SmsRRg==",
+      "license": "ISC",
+      "dependencies": {
+        "b4a": "^1.1.0",
+        "nanoassert": "^2.0.0",
+        "sodium-universal": "^5.0.0"
+      }
+    },
+    "node_modules/noise-handshake": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/noise-handshake/-/noise-handshake-4.2.0.tgz",
+      "integrity": "sha512-9O/VTNX/E2/AToyMTTDU0J/4WhaXMTdqc2DHs9vf+snoZ0cenSBq0dNYTVV1snYYEkmo6QeRrYMxtqtoYnY+LA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.1.0",
+        "nanoassert": "^2.0.0",
+        "sodium-universal": "^5.0.0"
+      }
+    },
+    "node_modules/paparam": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/paparam/-/paparam-1.10.1.tgz",
+      "integrity": "sha512-viyQI64VIja0Za3njIzhoEP8ZVkgPowhZPuG0E96NwBfYJ6ZIyrrlhWGtFPkdN7eYLl2L8CTWL+wla0evm1KKQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/pear-aliases": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/pear-aliases/-/pear-aliases-1.0.7.tgz",
+      "integrity": "sha512-Z85C0naSKh3XMBKm1P1L2kYbIGE+Ph0HRSjTaQz5O99JvQq/wHylu9M2df1Ysfx7LG3UJrCCwZenrud18bZytw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "hypercore-id-encoding": "^1.3.0"
+      }
+    },
+    "node_modules/pear-errors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pear-errors/-/pear-errors-1.0.1.tgz",
+      "integrity": "sha512-KQyhym09QpLT4H/z3uLW0bqixgIZic2Eip2Q8Z72QmIpFzPtp6QmnzOUwB3kuHB4dqKNa+FQWHWH0NSK5lJjlw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/pear-link": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pear-link/-/pear-link-5.0.0.tgz",
+      "integrity": "sha512-Va2xz1vdm4akNonOXOQLsvsxIcT/SWai2R03l9JA5i7YTZa9F3y9AsxtUNBRNLkC4sA6Bk6+9XIa2FzvuoK/FA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0",
+        "hypercore-id-encoding": "^1.2.0",
+        "pear-aliases": "^1.0.0",
+        "pear-errors": "^1.0.0"
+      }
+    },
+    "node_modules/pear-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/pear-runtime/-/pear-runtime-1.1.4.tgz",
+      "integrity": "sha512-HfqoCYpVV6IBgyBbRXBjG8A8Ezm3JWW+pOtTQEoWh+DZ7e8x4xg+JkbdaOnAaQpVraXHdd77qd85fI4l/Rxlpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0",
+        "bare-sidecar": "^0.4.5",
+        "corestore": "^7.9.1",
+        "hyperswarm": "^4.17.0",
+        "pear-runtime-updater": "^3.0.0",
+        "ready-resource": "^1.2.0"
+      }
+    },
+    "node_modules/pear-runtime-updater": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pear-runtime-updater/-/pear-runtime-updater-3.2.0.tgz",
+      "integrity": "sha512-KLHefj2y0ehG3lE3iAgGSxSbl51ZIM9Arpzb/BW8LTjOmC3n9ydclMgvjlbuA12efQu4MnUvE7nNQ3leISxwLw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.5.3",
+        "bare-path": "^3.0.0",
+        "bare-semver": "^1.0.2",
+        "debounceify": "^1.1.0",
+        "fs-native-extensions": "^1.4.5",
+        "hypercore-id-encoding": "^1.3.0",
+        "hyperdrive": "^13.2.1",
+        "localdrive": "^2.2.0",
+        "msix-manager": "^0.2.4",
+        "pear-link": "^5.0.0",
+        "ready-resource": "^1.2.0",
+        "which-runtime": "^1.3.2"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-config-holepunch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-config-holepunch/-/prettier-config-holepunch-2.0.0.tgz",
+      "integrity": "sha512-yuskcdPRfQYLFPkOGvxS4TFmCb7QvAowjO+YaNLPLBWRev+qu6HXoKkPWH9lfNsL9gUThV7IeZ6t/B1QSu/jng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "prettier": "^3.6.2"
+      }
+    },
+    "node_modules/promaphore": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/promaphore/-/promaphore-1.0.0.tgz",
+      "integrity": "sha512-Eg8401+KJddVvDULkpy8bR964GMX8xMPegL6NdxTeBH2Wa3L86cZlEHizbkFJikr5u+E3wFoR5dLWJ+1OPyEfw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/protocol-buffers-encodings": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-encodings/-/protocol-buffers-encodings-1.2.0.tgz",
+      "integrity": "sha512-daeNPuKh1NlLD1uDfbLpD+xyUTc07nEtfHwmBZmt/vH0B7VOM+JOCOpDcx9ZRpqHjAiIkGqyTDi+wfGSl17R9w==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.0",
+        "signed-varint": "^2.0.1",
+        "varint": "5.0.0"
+      }
+    },
+    "node_modules/protomux": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/protomux/-/protomux-3.11.0.tgz",
+      "integrity": "sha512-Ze43XaNHbL6zQ/zJwVYvue7Aj8pDB1HNnISsrFhAur3291Y+Iu2fMhOpySD73J/32BoBIUYrhl07lJsBR/fUVA==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.3.1",
+        "compact-encoding": "^3.0.0",
+        "queue-tick": "^1.0.0",
+        "safety-catch": "^1.0.1",
+        "unslab": "^1.3.0"
+      }
+    },
+    "node_modules/queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
+      "license": "MIT"
+    },
+    "node_modules/quickbit-native": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/quickbit-native/-/quickbit-native-2.4.8.tgz",
+      "integrity": "sha512-FcCcqI+nIAWGknqhtrYT5TSD7t/N+Xd8ctM+2PrIIBuwOi5hx0SxAvuPtzLIEMfT/2h9+fhBakUe2uALOHX6yw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "require-addon": "^1.1.0"
+      }
+    },
+    "node_modules/quickbit-universal": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/quickbit-universal/-/quickbit-universal-2.2.0.tgz",
+      "integrity": "sha512-w02i1R8n7+6pEKTud8DfF8zbFY9o7RtPlUc3jWbtCkDKvhbx/AvV7oNnz4/TcmsPGpSJS+fq5Ud6RH6+YPvSGg==",
+      "license": "ISC",
+      "dependencies": {
+        "b4a": "^1.6.0",
+        "simdle-universal": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "quickbit-native": "^2.2.0"
+      }
+    },
+    "node_modules/rabin-native": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rabin-native/-/rabin-native-2.0.0.tgz",
+      "integrity": "sha512-x1BlYdIWh+nk9G0scvxyscrYiDPJ7vQZepqqPlVUSInIko1Zxooi8cm6lzBghEGI9aN3DXiunC8FXLgy6kke3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-addon": "^1.1.0"
+      }
+    },
+    "node_modules/rabin-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rabin-stream/-/rabin-stream-2.0.0.tgz",
+      "integrity": "sha512-EzS2Ig/qsMBSk1PahC0O0IPdRZe3bspHHLWChhqW1feKz+J46tlVL3g4wWr4lrQdXGzABIMsOhvdT6bjXYMuUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "rabin-native": "^2.0.0",
+        "streamx": "^2.23.0"
+      }
+    },
+    "node_modules/rache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rache/-/rache-1.0.0.tgz",
+      "integrity": "sha512-e0k0g0w/8jOCB+7YqCIlOa+OJ38k0wrYS4x18pMSmqOvLKoyhmMhmQyCcvfY6VaP8D75cqkEnlakXs+RYYLqNg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/random-array-iterator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-array-iterator/-/random-array-iterator-1.0.0.tgz",
+      "integrity": "sha512-u7xCM93XqKEvPTP6xZp2ehttcAemKnh73oKNf1FvzuVCfpt6dILDt1Kxl1LeBjm2iNIeR49VGFhy4Iz3yOun+Q==",
+      "license": "MIT"
+    },
+    "node_modules/ready-resource": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ready-resource/-/ready-resource-1.2.0.tgz",
+      "integrity": "sha512-nfcco/8iAFV0M+2PYnmIc+/xY0iRb35d42HFHQ7AfjulbGEAFa+XWpByfwSyeVeiBoMLLFVMv1HixxNCqzSQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "bare-events": "^2.2.0"
+      }
+    },
+    "node_modules/record-cache": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/record-cache/-/record-cache-1.2.0.tgz",
+      "integrity": "sha512-kyy3HWCez2WrotaL3O4fTn0rsIdfRKOdQQcEJ9KpvmKmbffKVvwsloX063EgRUlpJIXHiDQFhJcTbZequ2uTZw==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.3.1"
+      }
+    },
+    "node_modules/refcounter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/refcounter/-/refcounter-1.0.0.tgz",
+      "integrity": "sha512-1WosVzUy0kPUaPMEtlNDwm99UsteALIhXXR8rerELoa63WkYIXAl0hxgwPFrIYBRWZPGUyekQ04FRtPJ7dHk9w==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/require-addon": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/require-addon/-/require-addon-1.2.0.tgz",
+      "integrity": "sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-addon-resolve": "^1.3.0"
+      },
+      "engines": {
+        "bare": ">=1.10.0"
+      }
+    },
+    "node_modules/require-asset": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/require-asset/-/require-asset-1.2.2.tgz",
+      "integrity": "sha512-uc8nWKhqAxVD9Z4rST2b4yaemrC9Xb5vA1wlCz5AiCYnBYdwGRWNqFjneA5zRILzlo1MNrB63ry9+pc8wNR26w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-module-resolve": "^1.6.2"
+      },
+      "engines": {
+        "bare": ">=1.10.0",
+        "node": ">=18"
+      }
+    },
+    "node_modules/resolve-reject-promise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-reject-promise/-/resolve-reject-promise-1.1.0.tgz",
+      "integrity": "sha512-LWsTOA91AqzBTjSGgX79Tc130pwcBK6xjpJEO+qRT5IKZ6bGnHKcc8QL3upUBcWuU8OTIDzKK2VNSwmmlqvAVg==",
+      "license": "MIT"
+    },
+    "node_modules/resource-on-exit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resource-on-exit/-/resource-on-exit-1.0.0.tgz",
+      "integrity": "sha512-ViJwJAknCkLRJRPR+9SISQQ7R5eRgtdIHLJsM2hHx1MweAJbJxJ5XnMjjq0Lc7ZGv44ufzAqds1nKxiVkdy4ag==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/rocksdb-native": {
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/rocksdb-native/-/rocksdb-native-3.15.2.tgz",
+      "integrity": "sha512-8fXcL6yVfHd14NySHCNLcMKkbTO81aFog5aMrLU92vBMHpycSgqGVIevqeILGQ/jt0FAZy9lMqWO82f4eZVh/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "compact-encoding": "^3.0.0",
+        "ready-resource": "^1.0.0",
+        "refcounter": "^1.0.0",
+        "require-addon": "^1.0.2",
+        "resolve-reject-promise": "^1.1.0",
+        "signal-promise": "^1.0.3",
+        "streamx": "^2.16.1"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      }
+    },
+    "node_modules/safety-catch": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/safety-catch/-/safety-catch-1.0.3.tgz",
+      "integrity": "sha512-Zq+J1TefpoEq/HTUabo0YXX5MNvttjWYODGohgPBO2jfko8Wqx3JYMgE823szDFVamdH5PlpByvfiWScTdSYDA==",
+      "license": "MIT"
+    },
+    "node_modules/same-data": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/same-data/-/same-data-1.0.0.tgz",
+      "integrity": "sha512-Eqn7N2yV+aKMlUHTRqUwYG1Iv0cJqjlvLKj/GoP5PozJn361QaOYX14+v87r7NqQUZC22noP/LfLrSQiPwAygw==",
+      "license": "MIT"
+    },
+    "node_modules/same-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/same-object/-/same-object-1.0.2.tgz",
+      "integrity": "sha512-csHWhvUsLbIOHDM/nP+KHWM+BLPsIzWkFa8HbzaI0G7BqKXgx+7FJpKTGgLXyz5amfdY2OVBcmXTqYOMEk04og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/scope-lock": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/scope-lock/-/scope-lock-1.2.4.tgz",
+      "integrity": "sha512-BpSd8VCuCxW9ZitcdIC/vjs3gMaP9bRBL5nkHcyfX2VrS52n13/rHuBA2xJ/S/4DPuRdAO/Bk8pWd8eD/gHCIA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/shuffled-priority-queue": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/shuffled-priority-queue/-/shuffled-priority-queue-2.1.0.tgz",
+      "integrity": "sha512-xhdh7fHyMsr0m/w2kDfRJuBFRS96b9l8ZPNWGaQ+PMvnUnZ/Eh+gJJ9NsHBd7P9k0399WYlCLzsy18EaMfyadA==",
+      "license": "MIT",
+      "dependencies": {
+        "unordered-set": "^2.0.1"
+      }
+    },
+    "node_modules/signal-promise": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/signal-promise/-/signal-promise-1.0.3.tgz",
+      "integrity": "sha512-WBgv0UnIq2C+Aeh0/n+IRpP6967eIx9WpynTUoiW3isPpfe1zu2LJzyfXdo9Tgef8yR/sGjcMvoUXD7EYdiz+g==",
+      "license": "MIT"
+    },
+    "node_modules/signed-varint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
+      "integrity": "sha512-abgDPg1106vuZZOvw7cFwdCABddfJRz5akcCcchzTbhyhYnsG31y4AlZEgp315T7W3nQq5P4xeOm186ZiPVFzw==",
+      "license": "MIT",
+      "dependencies": {
+        "varint": "~5.0.0"
+      }
+    },
+    "node_modules/simdle-native": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/simdle-native/-/simdle-native-1.3.9.tgz",
+      "integrity": "sha512-Isc8sP4OiiIU0mpslD4GHEnR0VQWvR/54WN7YtwEDkNdTJVWtpmvsSvsgRlw5BNGxdYXlVRegdnrSu10H/PhvA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "b4a": "^1.6.0",
+        "require-addon": "^1.1.0"
+      }
+    },
+    "node_modules/simdle-universal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/simdle-universal/-/simdle-universal-1.1.2.tgz",
+      "integrity": "sha512-3n3w1bs+uwgHKQjt6arez83EywNlhZzYvNOhvAASTl/8KqNIcqr6aHyGt3JRlfuUC7iB0tomJRPlJ2cRGIpBzA==",
+      "license": "ISC",
+      "dependencies": {
+        "b4a": "^1.6.0"
+      },
+      "optionalDependencies": {
+        "simdle-native": "^1.1.1"
+      }
+    },
+    "node_modules/sodium-native": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-5.1.0.tgz",
+      "integrity": "sha512-3RxgyWyJlhTsABPnJVpCI5CoTDANZTqqFrEPqr+kjfnRaBihpVtMUE3yTF40ukdoB1APXeoBNKF3MzZAIHg39g==",
+      "license": "MIT",
+      "dependencies": {
+        "bare-assert": "^1.2.0",
+        "require-addon": "^1.1.0",
+        "which-runtime": "^1.2.1"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      }
+    },
+    "node_modules/sodium-secretstream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/sodium-secretstream/-/sodium-secretstream-1.2.0.tgz",
+      "integrity": "sha512-q/DbraNFXm1KfCiiZvapmz5UC3OlpirYFIvBK2MhGaOFSb3gRyk8OXTi17UI9SGfshQNCpsVvlopogbzZNyW6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.1.1",
+        "sodium-universal": "^5.0.0"
+      }
+    },
+    "node_modules/sodium-universal": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-5.0.1.tgz",
+      "integrity": "sha512-rv+aH+tnKB5H0MAc2UadHShLMslpJsc4wjdnHRtiSIEYpOetCgu8MS4ExQRia+GL/MK3uuCyZPeEsi+J3h+Q+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "sodium-native": "^5.0.1"
+      },
+      "peerDependencies": {
+        "sodium-javascript": "~0.8.0"
+      },
+      "peerDependenciesMeta": {
+        "sodium-javascript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/speedometer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.1.0.tgz",
+      "integrity": "sha512-z/wAiTESw2XVPssY2XRcme4niTc4S5FkkJ4gknudtVoc33Zil8TdTxHy5torRcgqMqksJV2Yz8HQcvtbsnw0mQ==",
+      "license": "MIT"
+    },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/streamx": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.27.0.tgz",
+      "integrity": "sha512-WZ189TKnHoAokYHvwzaAQMpd55cgUmFIcJFzBSgGcb886jau5DL+XdDhTWV4ps3FLvk+OORp0dLRTPsLZ21CSA==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/sub-encoder": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/sub-encoder/-/sub-encoder-2.1.3.tgz",
+      "integrity": "sha512-Xxx04ygZo/1J3yHvaSA6VhDmiSaBQkw/PmO3YnnYFXle+tfOGToC6FcDpIfMztWZXJzuKG14b/57HMkiL58C6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.0",
+        "codecs": "^3.1.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/test-tmp": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/test-tmp/-/test-tmp-1.4.0.tgz",
+      "integrity": "sha512-GVggxGg+jXqP2Wbju50JVLo+9E+nIOPPyWqgr63EbOnNItIKu1cEbJpTWAJeflnyGqXOtcMI7ijHRp88GUkfDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-os": "^3.3.0",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/time-ordered-set": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/time-ordered-set/-/time-ordered-set-2.0.1.tgz",
+      "integrity": "sha512-VJEKmgSN2UiOLB8BpN8Sh2b9LGMHTP5OPrQRpnKjvOheOyzk0mufbjzjKTIG2gO4A+Y+vDJ+0TcLbpUmMLsg8A==",
+      "license": "MIT"
+    },
+    "node_modules/timeout-refresh": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/timeout-refresh/-/timeout-refresh-2.0.1.tgz",
+      "integrity": "sha512-SVqEcMZBsZF9mA78rjzCrYrUs37LMJk3ShZ851ygZYW1cMeIjs9mL57KO6Iv5mmjSQnOe/29/VAfGXo+oRCiVw==",
+      "license": "MIT"
+    },
+    "node_modules/tmatch": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-5.0.0.tgz",
+      "integrity": "sha512-Ib9OtBkpHn07tXP04SlN1SYRxFgTk6wSM2EBmjjxug4u5RXPRVLkdFJSS1PmrQidaSB8Lru9nRtViQBsbxzE5Q==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/udx-native": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/udx-native/-/udx-native-1.20.6.tgz",
+      "integrity": "sha512-x2L/dPPEINPgURSPKCLahT3ooJ9p1qLXvj2YvIx30j95E0S6T+ghzroxmyedCbJqCFN2SQQ9QFrGKx96BJEn5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.5.0",
+        "bare-events": "^2.2.0",
+        "require-addon": "^1.1.0",
+        "streamx": "^2.22.0"
+      },
+      "engines": {
+        "bare": ">=1.17.4"
+      }
+    },
+    "node_modules/unix-path-resolve": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unix-path-resolve/-/unix-path-resolve-1.0.2.tgz",
+      "integrity": "sha512-kG4g5nobBBaMnH2XbrS4sLUXEpx4nY2J3C6KAlAUcnahG2HChxSPVKWYrqEq76iTo+cyMkLUjqxGaQR2tz097Q==",
+      "license": "MIT"
+    },
+    "node_modules/unordered-set": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unordered-set/-/unordered-set-2.0.1.tgz",
+      "integrity": "sha512-eUmNTPzdx+q/WvOHW0bgGYLWvWHNT3PTKEQLg0MAQhc0AHASHVHoP/9YytYd4RBVariqno/mEUhVZN98CmD7bg==",
+      "license": "MIT"
+    },
+    "node_modules/unslab": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/unslab/-/unslab-1.3.0.tgz",
+      "integrity": "sha512-YATkfKAFj47kTzmiQrWXMyRvaVrHsW6MEALa4bm+FhiA2YG4oira+Z3DXN6LrYOYn2Y8eO94Lwl9DOHjs1FpoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.6"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/varint": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
+      "integrity": "sha512-gC13b/bWrqQoKY2EmROCZ+AR0jitc6DnDGaQ6Ls9QpKmuSgJB1eQ7H3KETtQm7qSdMWMKCmsshyCmUwMLh3OAA==",
+      "license": "MIT"
+    },
+    "node_modules/which-runtime": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/which-runtime/-/which-runtime-1.4.0.tgz",
+      "integrity": "sha512-0ugbP4CJW4e2D20jvEcC4973dCgIaHI4Rw1PT+26U9zEve7FyYdWAIwUnoeOYvoCfn+wXHoHTKb1KhkYlb60Pw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/xache": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/xache/-/xache-1.2.1.tgz",
+      "integrity": "sha512-igRS6jPreJ54ABdzhh4mCDXcz+XMaWO2q1ABRV2yWYuk29jlp8VT7UBdCqNkX7rpYBbXsebVVKkwIuYZjyZNqA==",
+      "license": "MIT"
+    },
+    "node_modules/z32": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/z32/-/z32-1.1.0.tgz",
+      "integrity": "sha512-1WUHy+VS6d0HPNspDxvLssBbeQjXMjSnpv0vH82vRAUfg847NmX3OXozp/hRP5jPhxBbrVzrgvAt+UsGNzRFQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.5.3"
+      }
+    }
+  }
+}

--- a/examples/getting-started/hello-pear-bare-single-thread/package.json
+++ b/examples/getting-started/hello-pear-bare-single-thread/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "hello-pear-bare",
+  "version": "0.0.0-rc.0",
+  "description": "Pear Runtime CLI boilerplate using Bare with OTA updater support.",
+  "private": true,
+  "bin": "bin.mjs",
+  "upgrade": "pear://bwkbsetjgy5uhtkckppgn4dxq36ajnh1ugokxmiizubhiwqa59uy",
+  "scripts": {
+    "format": "prettier . --write",
+    "test": "brittle-bare test/index.js",
+    "lint": "prettier . --check && lunte",
+    "start": "bare bin.mjs --no-updates",
+    "make": "node scripts/make.js",
+    "make:darwin-arm64": "bare-build --name hello-pear-bare --standalone --host darwin-arm64 --out ./out/darwin-arm64 bin.mjs",
+    "make:darwin-x64": "bare-build --name hello-pear-bare --standalone --host darwin-x64 --out ./out/darwin-x64 bin.mjs",
+    "make:linux-arm64": "bare-build --name hello-pear-bare --standalone --host linux-arm64 --out ./out/linux-arm64 bin.mjs",
+    "make:linux-x64": "bare-build --name hello-pear-bare --standalone --host linux-x64 --out ./out/linux-x64 bin.mjs",
+    "make:win32-arm64": "bare-build --name hello-pear-bare --standalone --host win32-arm64 --out ./out/win32-arm64 bin.mjs",
+    "make:win32-x64": "bare-build --name hello-pear-bare --standalone --host win32-x64 --out ./out/win32-x64 bin.mjs"
+  },
+  "dependencies": {
+    "bare-os": "^3.9.0",
+    "bare-path": "^3.0.0",
+    "bare-process": "^4.5.0",
+    "bare-storage": "^1.1.0",
+    "corestore": "^7.9.2",
+    "hyperswarm": "^4.17.0",
+    "paparam": "^1.10.1",
+    "pear-runtime": "^1.1.4",
+    "ready-resource": "^1.2.0",
+    "which-runtime": "^1.4.0"
+  },
+  "devDependencies": {
+    "bare-build": "^1.0.1",
+    "bare-runtime": "^1.29.5",
+    "brittle": "^3.19.0",
+    "lunte": "^1.2.0",
+    "prettier": "^3.6.2",
+    "prettier-config-holepunch": "^2.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/holepunchto/hello-pear-bare.git"
+  },
+  "author": "Holepunch Inc",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/holepunchto/hello-pear-bare/issues"
+  }
+}

--- a/examples/getting-started/hello-pear-bare-single-thread/scripts/make.js
+++ b/examples/getting-started/hello-pear-bare-single-thread/scripts/make.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+'use strict'
+
+const os = require('os')
+const path = require('path')
+const { spawnSync } = require('child_process')
+
+const root = path.resolve(__dirname, '..')
+const host = `${os.platform()}-${os.arch()}`
+const script = `make:${host}`
+const supported = new Set([
+  'darwin-arm64',
+  'darwin-x64',
+  'linux-arm64',
+  'linux-x64',
+  'win32-arm64',
+  'win32-x64'
+])
+
+if (!supported.has(host)) {
+  console.error(`Unsupported platform/arch: ${host}`)
+  console.error(
+    'Supported targets: darwin-arm64, darwin-x64, linux-arm64, linux-x64, win32-arm64, win32-x64'
+  )
+  process.exit(1)
+}
+
+const isWindows = os.platform() === 'win32'
+const opts = {
+  cwd: root,
+  stdio: 'inherit'
+}
+const res = isWindows
+  ? spawnSync(`npm.cmd run ${script}`, { ...opts, shell: true })
+  : spawnSync('npm', ['run', script], opts)
+if (res.error) {
+  console.error(res.error.message)
+  process.exit(1)
+}
+if (res.status !== 0) process.exit(res.status || 1)

--- a/examples/getting-started/hello-pear-bare-single-thread/test/index.js
+++ b/examples/getting-started/hello-pear-bare-single-thread/test/index.js
@@ -1,0 +1,5 @@
+const { test } = require('brittle')
+
+test('REMOVE ME', (t) => {
+  t.pass()
+})

--- a/scripts/test-examples.ts
+++ b/scripts/test-examples.ts
@@ -111,6 +111,51 @@ const SCENARIOS: Scenario[] = [
     ],
   },
   {
+    // hello-pear-bare's `variant/single-thread` branch: same App ready-resource
+    // shape as `main`, but `_open()` constructs PearRuntime directly instead of
+    // spawning a Bare worker — no worker, no FramedStream IPC. There's no
+    // separate worker holding demo peer-to-peer code, so unlike `hello-pear-bare`
+    // there's no "Hello from worker" line; asserts the CLI's own ready log
+    // instead, then (like `main`) stays alive since Corestore/Hyperswarm/
+    // PearRuntime hold the event loop open.
+    id: 'hello-pear-bare-single-thread',
+    dir: `${GETTING}/hello-pear-bare-single-thread`,
+    installs: ['.'],
+    artifacts: [],
+    steps: [
+      {
+        kind: 'run',
+        process: 'app',
+        app: '.',
+        cmd: './node_modules/.bin/bare bin.mjs --no-updates',
+        expect: 'CLI ready. Press Ctrl+C to stop.',
+        expectAliveMs: 1500,
+        timeoutMs: 45_000,
+      },
+    ],
+  },
+  {
+    // hello-pear-bare's `variant/daemon` branch: `--no-updates` skips
+    // `App.spawnUpdater(...)` entirely (bin.mjs's `if (updates !== false)`
+    // guard), so no `App`/PearRuntime is ever constructed on this path and the
+    // foreground command exits on its own right after logging — unlike `main`
+    // and `single-thread`, this scenario must NOT assert `expectAliveMs`.
+    id: 'hello-pear-bare-daemon',
+    dir: `${GETTING}/hello-pear-bare-daemon`,
+    installs: ['.'],
+    artifacts: [],
+    steps: [
+      {
+        kind: 'run',
+        process: 'app',
+        app: '.',
+        cmd: './node_modules/.bin/bare bin.mjs --no-updates',
+        expect: 'CLI ready.',
+        timeoutMs: 45_000,
+      },
+    ],
+  },
+  {
     id: 'hyperdht-chat',
     dir: `${CONNECT}/connect-two-peers-by-key-with-hyperdht`,
     installs: ['server-app', 'client-app'],


### PR DESCRIPTION
## Summary
- Added a "Variants" section to [Start from the hello-pear-bare template](https://docs.pears.com/getting-started/from-a-template/start-from-hello-pear-bare/) covering the two other `holepunchto/hello-pear-bare` branches:
  - [`variant/single-thread`](https://github.com/holepunchto/hello-pear-bare/tree/variant/single-thread) — `pear-runtime` constructed directly in the main Bare process, no worker/IPC framing.
  - [`variant/daemon`](https://github.com/holepunchto/hello-pear-bare/tree/variant/daemon) — updater runs in a detached `bare-daemon` process so short-lived CLI invocations don't block on the update check.
- Includes a comparison table (branch / process shape / when to use it), short illustrative code excerpts for each variant pulled from their respective branches, and links out to the full files on GitHub.

## Test plan
- [x] `npm run check:internal-links` — passes
- [x] `npm run check:doctypes` — passes
- [x] Verified in dev server: new "Variants" section renders correctly (table, code blocks, all links resolve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)