### PR TITLE
docs: align module display names, nav labels, and doc-type metadata

### DIFF
--- a/content/explanation/dependencies-and-network.mdx
+++ b/content/explanation/dependencies-and-network.mdx
@@ -56,7 +56,7 @@ This means a peer you connect to can, in principle:
 - Log timing of your connections and disconnections.
 
 What they can't do without further ado:
-* Read your traffic (Pear connections are end-to-end encrypted via [Secretstream](/reference/helpers/secretstream))
+* Read your traffic (Pear connections are end-to-end encrypted via [NoiseSecretStream](/reference/helpers/secretstream))
 * Impersonate you (your peer key is a public key you control)
 * Identify you across IP changes (the IP changes; your peer key is what's stable)
 
@@ -66,7 +66,7 @@ If your IP is sensitive—you're a journalist, an activist, or just privacy-cons
 
 - [Connect to many peers by topic with Hyperswarm](/how-to/connect-to-peers/connect-to-many-peers-by-topic-with-hyperswarm)—joining a swarm in practice.
 - [Peer-to-peer, demystified](/explanation/peer-to-peer-demystified)—conceptual overview of HyperDHT and Hyperswarm.
-- [Secretstream](/reference/helpers/secretstream)—the encryption layer on every Pear peer connection.
+- [NoiseSecretStream](/reference/helpers/secretstream)—the encryption layer on every Pear peer connection.
 - [Storage and distribution](/explanation/storage-and-distribution)—what actually crosses the wire when peers replicate.
 - [Hyperswarm reference](/reference/building-blocks/hyperswarm)—topic-based peer discovery and connection management.
 - [HyperDHT reference](/reference/building-blocks/hyperdht)—the lower-level DHT layer handling hole punching and IP routing.

--- a/content/explanation/from-logs-to-files.mdx
+++ b/content/explanation/from-logs-to-files.mdx
@@ -82,7 +82,7 @@ Pear application bundles are Hyperdrives: code, assets, and dependencies staged 
 Helpers extend the model without changing the stack:
 
 - [Localdrive](/reference/helpers/localdrive)—mirror between a Hyperdrive and a local folder.
-- [Mirrordrive](/reference/helpers/mirrordrive)—copy or sync between two drives.
+- [MirrorDrive](/reference/helpers/mirrordrive)—copy or sync between two drives.
 
 ## Choosing a layer
 

--- a/content/explanation/peer-to-peer-demystified.mdx
+++ b/content/explanation/peer-to-peer-demystified.mdx
@@ -40,7 +40,7 @@ Most devices sit behind home routers or carrier-grade network address translatio
 
 ## HyperDHT: discovery and encrypted connections
 
-[HyperDHT](/reference/building-blocks/hyperdht) is a distributed hash table. It is the layer that finds peers and establishes **end-to-end encrypted** connections using Noise streams (via [Secretstream](/reference/helpers/secretstream)).
+[HyperDHT](/reference/building-blocks/hyperdht) is a distributed hash table. It is the layer that finds peers and establishes **end-to-end encrypted** connections using Noise streams (via [NoiseSecretStream](/reference/helpers/secretstream)).
 
 Core mechanisms:
 

--- a/content/explanation/workers.mdx
+++ b/content/explanation/workers.mdx
@@ -83,7 +83,7 @@ It points at a per-app directory the host has already prepared (see [Storage and
 
 ## Structured RPC over IPC
 
-Raw Inter-Process Communication (IPC) carries **bytes**, not typed messages. For a handful of one-off signals, length-preserving writes or newline-delimited JSON may be enough (see [Compact encoding](/reference/helpers/compact-encoding) for binary framing). As the host–worker protocol grows, manually pairing requests and responses becomes error-prone.
+Raw Inter-Process Communication (IPC) carries **bytes**, not typed messages. For a handful of one-off signals, length-preserving writes or newline-delimited JSON may be enough (see [compact-encoding](/reference/helpers/compact-encoding) for binary framing). As the host–worker protocol grows, manually pairing requests and responses becomes error-prone.
 
 **[bare-rpc](/reference/modules/bare-modules)** adds a thin Remote Procedure Call (RPC) layer on top of a duplex stream. Each message has a numeric command id and a payload; handlers dispatch on `req.command`:
 
@@ -176,5 +176,5 @@ Each worker is its own [Bare](/reference/modules/bare-modules) process, has its 
 - [Storage and distribution](/explanation/storage-and-distribution)—where `pear.storage` actually points on each operating system.
 - [Reshape into a production app](/getting-started/build-a-peer-to-peer-chat/reshape-into-a-production-app)—a tutorial that wires the hello-pear-electron-shaped `pear-chat` worker behind a `window.bridge` API.
 - [Corestore reference](/reference/helpers/corestore)—the storage factory typically opened on `Bare.argv[2]` inside a worker.
-- [Compact encoding reference](/reference/helpers/compact-encoding)—binary framing for IPC messages crossing the host/worker boundary.
+- [compact-encoding reference](/reference/helpers/compact-encoding)—binary framing for IPC messages crossing the host/worker boundary.
 - The upstream source: [`hello-pear-electron`'s Workers](https://github.com/holepunchto/hello-pear-electron#workers).

--- a/content/how-to/connect-to-peers/connect-two-peers-by-key-with-hyperdht.mdx
+++ b/content/how-to/connect-to-peers/connect-two-peers-by-key-with-hyperdht.mdx
@@ -107,5 +107,5 @@ Once it's connected, try typing in both terminals.
 - [Connect to many peers by topic with Hyperswarm](/how-to/connect-to-peers/connect-to-many-peers-by-topic-with-hyperswarm)—discover peers by a shared topic instead of a known public key.
 - [Peer-to-peer, demystified](/explanation/peer-to-peer-demystified)—hole punching, public-key identity, and when to use HyperDHT vs [Hyperswarm](/reference/building-blocks/hyperswarm).
 - [HyperDHT reference](/reference/building-blocks/hyperdht)—full API for the DHT node, servers, and connections used in this guide.
-- [Secretstream](/reference/helpers/secretstream)—the Noise-encrypted stream layer wrapping every HyperDHT connection.
+- [NoiseSecretStream](/reference/helpers/secretstream)—the Noise-encrypted stream layer wrapping every HyperDHT connection.
 - [Dependencies and network](/explanation/dependencies-and-network)—the IP-level information peers observe during a HyperDHT connection.

--- a/content/how-to/manage-identity/create-a-portable-identity-with-keet-identity-key.mdx
+++ b/content/how-to/manage-identity/create-a-portable-identity-with-keet-identity-key.mdx
@@ -71,5 +71,5 @@ Because verification only needs the public `identityPublicKey`, you can stamp ev
 
 - [Add Keet identity to a chat app](/how-to/manage-identity/add-keet-identity-to-a-chat-app)—this primitive wired into a full desktop chat, stamping every message with a verifiable identity.
 - [Connect two peers by key with HyperDHT](/how-to/connect-to-peers/connect-two-peers-by-key-with-hyperdht)—once you have a stable identity key, you can dial it directly.
-- [Secretstream](/reference/helpers/secretstream)—the noise-based encrypted transport that authenticates connections by public key.
+- [NoiseSecretStream](/reference/helpers/secretstream)—the noise-based encrypted transport that authenticates connections by public key.
 - [Workers](/explanation/workers)—why identity belongs in the worker, not the renderer.

--- a/content/how-to/manage-installed-applications.mdx
+++ b/content/how-to/manage-installed-applications.mdx
@@ -2,7 +2,7 @@
 title: "Manage installed applications"
 description: "Find the Pear applications installed on your machine and reset an app's local storage when you need a clean slate."
 docType: how-to
-schemaType: WebPage
+schemaType: TechArticle
 ---
 
 Since Pear v3, applications are installed with [`pear install`](/reference/pear/cli#pear-install) directly into your operating system's application folder, and each app keeps its peer-to-peer data in a local corestore (described in [Storage and distribution](/explanation/storage-and-distribution)). This guide covers finding what's installed and resetting an app's storage.

--- a/content/how-to/operate-an-app/build-and-package/distribute-as-binary.mdx
+++ b/content/how-to/operate-an-app/build-and-package/distribute-as-binary.mdx
@@ -2,7 +2,7 @@
 title: "Distribute as a binary"
 description: "Ship a Pear application as a small bootstrap binary that pulls the latest version from the swarm. One binary serves every future release."
 docType: how-to
-schemaType: WebPage
+schemaType: TechArticle
 ---
 
 The default Pear distribution model assumes users already have the `pear` runtime installed; they open `pear://<your-link>` to launch your application. For users who don't—or for app stores that want a self-contained download—Pear supports compiling a small bootstrap binary that pulls the platform and the application from the swarm at first launch. For why this stays small, see [Storage and distribution](/explanation/storage-and-distribution).

--- a/content/how-to/run-on-native/type-a-native-rpc-bridge.mdx
+++ b/content/how-to/run-on-native/type-a-native-rpc-bridge.mdx
@@ -128,5 +128,5 @@ for await (const chunk of updates) {
 
 - [One core, many platforms](/explanation/bare-on-native)—the architecture and the Swift/Android codegen story.
 - [`bare-kit` reference](/reference/bare/bare-kit)—the IPC channel this RPC rides on.
-- [Compact encoding](/reference/helpers/compact-encoding)—the codec `hyperschema` generates.
+- [compact-encoding](/reference/helpers/compact-encoding)—the codec `hyperschema` generates.
 - [Embed Bare in a React Native app](/how-to/run-on-native/embed-bare-in-react-native)—the worklet this seam connects to.

--- a/content/how-to/stream-and-share-media/create-a-full-peer-to-peer-filesystem-with-hyperdrive.mdx
+++ b/content/how-to/stream-and-share-media/create-a-full-peer-to-peer-filesystem-with-hyperdrive.mdx
@@ -185,4 +185,4 @@ bare drive-bee-reader-app <SUPPLY_KEY_HERE>
 - [Hyperdrive reference](/reference/building-blocks/hyperdrive)—full API for the distributed filesystem used in this guide.
 - [Corestore reference](/reference/helpers/corestore)—full API for the shared storage and replication manager passed to Hyperdrive.
 - [Localdrive reference](/reference/helpers/localdrive)—full API for the local filesystem adapter mirrored to and from Hyperdrive.
-- [Mirrordrive reference](/reference/helpers/mirrordrive)—full API for the diff-and-sync engine driving `drive.mirror(...)` and `local.mirror(...)` here.
+- [MirrorDrive reference](/reference/helpers/mirrordrive)—full API for the diff-and-sync engine driving `drive.mirror(...)` and `local.mirror(...)` here.

--- a/content/how-to/troubleshooting.mdx
+++ b/content/how-to/troubleshooting.mdx
@@ -29,17 +29,17 @@ Troubleshooting confusing scenarios while developing Pear applications.
 
 Troubleshooting confusing scenarios while developing with Bare. For background on why Bare is the runtime under Pear, see [Runtime and languages](/explanation/runtime-and-languages).
 
-### Missing builtin Modules when Running with Bare
+### Missing builtin modules when running with Bare
 
 Bare is minimal by design, so does not include all of the modules provided with Node.js. Instead modules such as `process` can be imported as a Bare specific module, for example `bare-process`. For a list of Node.js builtins and their Bare replacements, check out `bare-node`'s [`Modules table`](https://github.com/holepunchto/bare-node#modules), or browse the [Bare modules reference](/reference/modules/bare-modules).
 
-#### Writing a module with Support for Bare & Node.js
+#### Writing a module with support for Bare & Node.js
 
 If writing a library that can be run in both the Bare and Node.js runtimes, import maps should be used to support both the Bare version and the Node.js version of builtin modules. Import maps only apply to the `package.json`'s package so does not modify dependencies of the module.
 
 See `bare-node`'s [`Import maps`](https://github.com/holepunchto/bare-node#import-maps) for more details.
 
-#### Running Third-Party Modules Written for Node.js
+#### Running third-party modules written for Node.js
 
 To support dependencies that rely on Node.js builtins (eg. `fs`, `os`, etc), an alias can be used to point to a wrapper module to use the Bare version. For example to use `bare-net` where ever `net` is used in dependencies, install it as an alias:
 

--- a/content/reference/building-blocks/hypercore.mdx
+++ b/content/reference/building-blocks/hypercore.mdx
@@ -543,7 +543,7 @@ Register a custom protocol extension. This is a legacy implementation and is no 
 
 | Option | Description |
 | --- | --- |
-| `encoding` | Compact encoding to use for messages. Defaults to buffer |
+| `encoding` | compact-encoding codec to use for messages. Defaults to buffer |
 | `onmessage` | Callback for when a message for the extension is received |
 
 This extension API is documented as legacy. For new protocol work, the upstream README recommends creating a [`Protomux`](/reference/helpers/protomux) protocol instead.
@@ -1356,4 +1356,4 @@ Coded errors this module can throw — catch them via `err.code`.
 - [Corestore](/reference/helpers/corestore)—helper reference for creating, naming, and co-replicating groups of Hypercores.
 - [Hyperbee](/reference/building-blocks/hyperbee)—sorted key/value B-tree built directly on top of a Hypercore.
 - [Hyperdrive](/reference/building-blocks/hyperdrive)—filesystem abstraction whose metadata and blob stores are Hypercore-backed.
-- [Compact encoding](/reference/helpers/compact-encoding)—binary encoding toolkit used to structure Hypercore block payloads.
+- [compact-encoding](/reference/helpers/compact-encoding)—binary encoding toolkit used to structure Hypercore block payloads.

--- a/content/reference/building-blocks/hyperdht.mdx
+++ b/content/reference/building-blocks/hyperdht.mdx
@@ -435,7 +435,7 @@ Coded errors this module can throw — catch them via `err.code`.
 - [Connect two peers by key with HyperDHT](/how-to/connect-to-peers/connect-two-peers-by-key-with-hyperdht)—step-by-step direct peer connection flow.
 - [Connect to many peers by topic with Hyperswarm](/how-to/connect-to-peers/connect-to-many-peers-by-topic-with-hyperswarm)—higher-level topic discovery and connection management.
 - [Hyperswarm](/reference/building-blocks/hyperswarm)—higher-level swarm abstraction built on HyperDHT.
-- [Secretstream](/reference/helpers/secretstream)—the Noise-encrypted stream layer that wraps all HyperDHT connections.
+- [NoiseSecretStream](/reference/helpers/secretstream)—the Noise-encrypted stream layer that wraps all HyperDHT connections.
 - [Hyperbeam](/reference/tools/hyperbeam)—one-to-one encrypted pipe CLI built on HyperDHT.
 - [Hypershell](/reference/tools/hypershell)—encrypted remote shell and file-copy tools built on HyperDHT.
 - [Hypertele](/reference/tools/hypertele)—TCP proxy CLI built on HyperDHT.

--- a/content/reference/building-blocks/hyperdrive.mdx
+++ b/content/reference/building-blocks/hyperdrive.mdx
@@ -821,7 +821,7 @@ Coded errors this module can throw — catch them via `err.code`.
 - [Create a full peer-to-peer filesystem with Hyperdrive](/how-to/stream-and-share-media/create-a-full-peer-to-peer-filesystem-with-hyperdrive)—end-to-end filesystem replication walkthrough.
 - [Work with many Hypercores using Corestore](/how-to/store-and-replicate/work-with-many-hypercores-using-corestore)—recommended pattern when one app manages multiple drives or related cores.
 - [Localdrive](/reference/helpers/localdrive)—map a Hyperdrive-like API onto the local filesystem.
-- [Mirrordrive](/reference/helpers/mirrordrive)—sync between Hyperdrive and other drive-like destinations.
+- [MirrorDrive](/reference/helpers/mirrordrive)—sync between Hyperdrive and other drive-like destinations.
 - [Corestore](/reference/helpers/corestore)—shared storage and replication manager for drive metadata and content.
 - [Hyperbee](/reference/building-blocks/hyperbee)—Hyperdrive uses a Hyperbee internally for metadata indexing.
 - [Drives](/reference/tools/drives)—CLI tool for creating, mirroring, and seeding Hyperdrives.

--- a/content/reference/building-blocks/hyperswarm.mdx
+++ b/content/reference/building-blocks/hyperswarm.mdx
@@ -409,6 +409,6 @@ Banning prevents future reconnection attempts, but it does not close an already-
 - [Connect to many peers by topic with Hyperswarm](/how-to/connect-to-peers/connect-to-many-peers-by-topic-with-hyperswarm)—broader topic-based discovery walkthrough.
 - [Connect two peers by key with HyperDHT](/how-to/connect-to-peers/connect-two-peers-by-key-with-hyperdht)—direct one-to-one connections without topic discovery.
 - [HyperDHT](/reference/building-blocks/hyperdht)—lower-level DHT and hole-punching layer beneath Hyperswarm.
-- [Secretstream](/reference/helpers/secretstream)—the encrypted stream type that Hyperswarm connections expose.
+- [NoiseSecretStream](/reference/helpers/secretstream)—the encrypted stream type that Hyperswarm connections expose.
 - [Protomux](/reference/helpers/protomux)—multiplex multiple protocols across one Hyperswarm connection.
 - [Corestore](/reference/helpers/corestore)—pass swarm connections directly to `store.replicate()` to co-replicate all managed cores.

--- a/content/reference/helpers/localdrive.mdx
+++ b/content/reference/helpers/localdrive.mdx
@@ -9,7 +9,7 @@ schemaType: APIReference
 
 <Status level="stable" />
 
-`Localdrive` exposes a local directory through an API that closely matches [Hyperdrive](/reference/building-blocks/hyperdrive). It is the simplest way to mirror between on-disk files and distributed drives with [Mirrordrive](/reference/helpers/mirrordrive). For upstream implementation details, see the [Localdrive repository](https://github.com/holepunchto/localdrive).
+`Localdrive` exposes a local directory through an API that closely matches [Hyperdrive](/reference/building-blocks/hyperdrive). It is the simplest way to mirror between on-disk files and distributed drives with [MirrorDrive](/reference/helpers/mirrordrive). For upstream implementation details, see the [Localdrive repository](https://github.com/holepunchto/localdrive).
 
 ## Install
 
@@ -435,6 +435,6 @@ Options for `drive.mirror()`.
 
 - [Create a full peer-to-peer filesystem with Hyperdrive](/how-to/stream-and-share-media/create-a-full-peer-to-peer-filesystem-with-hyperdrive)—shows Localdrive mirroring in a full writer/reader flow.
 - [Hyperdrive](/reference/building-blocks/hyperdrive)—the distributed filesystem API Localdrive is designed to interoperate with.
-- [Mirrordrive](/reference/helpers/mirrordrive)—the sync engine that copies between Localdrive and Hyperdrive.
+- [MirrorDrive](/reference/helpers/mirrordrive)—the sync engine that copies between Localdrive and Hyperdrive.
 - [Drives](/reference/tools/drives)—CLI tool that mirrors between local directories and Hyperdrives using the same drive-like interface.
 - [Upstream Localdrive repository](https://github.com/holepunchto/localdrive)—source, releases, and implementation details.

--- a/content/reference/helpers/mirrordrive.mdx
+++ b/content/reference/helpers/mirrordrive.mdx
@@ -8,7 +8,7 @@ schemaType: APIReference
 
 <Status level="stable" />
 
-`Mirrordrive` computes diffs between two drive-like APIs and applies them efficiently. It is the helper that powers sync flows between [Hyperdrive](/reference/building-blocks/hyperdrive) and [Localdrive](/reference/helpers/localdrive), including the `drive.mirror(...)` shortcut on Hyperdrive. A `MirrorDrive` instance is itself an async iterable, so iterating it with `for await (const diff of mirror)` drives the diff/copy pass and yields one diff object per entry. For source and release notes, see the [mirror-drive repository](https://github.com/holepunchto/mirror-drive).
+`MirrorDrive` computes diffs between two drive-like APIs and applies them efficiently. It is the helper that powers sync flows between [Hyperdrive](/reference/building-blocks/hyperdrive) and [Localdrive](/reference/helpers/localdrive), including the `drive.mirror(...)` shortcut on Hyperdrive. A `MirrorDrive` instance is itself an async iterable, so iterating it with `for await (const diff of mirror)` drives the diff/copy pass and yields one diff object per entry. For source and release notes, see the [mirror-drive repository](https://github.com/holepunchto/mirror-drive).
 
 ## Async iteration
 
@@ -308,7 +308,7 @@ Options for the `monitor()` method.
 ## See also
 
 - [Create a full peer-to-peer filesystem with Hyperdrive](/how-to/stream-and-share-media/create-a-full-peer-to-peer-filesystem-with-hyperdrive)—end-to-end workflow that mirrors between Localdrive and Hyperdrive.
-- [Hyperdrive](/reference/building-blocks/hyperdrive)—exposes `drive.mirror(...)` and is the canonical distributed destination/source for Mirrordrive.
-- [Localdrive](/reference/helpers/localdrive)—the local filesystem companion API most often paired with Mirrordrive.
+- [Hyperdrive](/reference/building-blocks/hyperdrive)—exposes `drive.mirror(...)` and is the canonical distributed destination/source for MirrorDrive.
+- [Localdrive](/reference/helpers/localdrive)—the local filesystem companion API most often paired with MirrorDrive.
 - [Drives](/reference/tools/drives)—CLI tool whose `drives mirror` command is powered by the same sync logic.
 - [Upstream mirror-drive repository](https://github.com/holepunchto/mirror-drive)—source, releases, and implementation details.

--- a/content/reference/helpers/protomux.mdx
+++ b/content/reference/helpers/protomux.mdx
@@ -9,7 +9,7 @@ schemaType: APIReference
 
 <Status level="stable" />
 
-`Protomux` multiplexes multiple message-oriented subprotocols over one framed stream. It is typically layered on top of [Secretstream](/reference/helpers/secretstream) and uses [Compact encoding](/reference/helpers/compact-encoding) for message schemas. For source and releases, see the [Protomux repository](https://github.com/holepunchto/protomux).
+`Protomux` multiplexes multiple message-oriented subprotocols over one framed stream. It is typically layered on top of [NoiseSecretStream](/reference/helpers/secretstream) and uses [compact-encoding](/reference/helpers/compact-encoding) for message schemas. For source and releases, see the [Protomux repository](https://github.com/holepunchto/protomux).
 
 ## Install
 
@@ -467,7 +467,7 @@ Options for creating a protocol channel.
 | --- | --- | --- | --- |
 | `protocol` | `string` | — | Protocol name used to match channels between peers. |
 | `id` | [`Buffer\|null`](https://nodejs.org/api/buffer.html#class-buffer) | `null` | Optional binary identifier to distinguish multiple channels with the same protocol name. |
-| `handshake` | `*` | `null` | Compact-encoding codec for encoding/decoding the handshake value exchanged on open. |
+| `handshake` | `*` | `null` | compact-encoding codec for encoding/decoding the handshake value exchanged on open. |
 | `messages` | [`Array<AddMessageOptions>`](#addmessageoptions) | `[]` | Array of message descriptors registered when the channel is created. |
 | `unique` | `boolean` | `true` | When `true`, returns `null` if a channel with this protocol+id is already open. |
 | `aliases` | [`Array<string>`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) | `[]` | Alternative protocol names that also match this channel. |
@@ -498,7 +498,7 @@ Protocol + id selector used by pair/unpair/opened/getLastChannel.
 
 ## See also
 
-- [Secretstream](/reference/helpers/secretstream)—the encrypted framed stream most commonly used underneath Protomux.
-- [Compact encoding](/reference/helpers/compact-encoding)—the schema toolkit Protomux uses for handshakes and message payloads.
-- [Hyperswarm](/reference/building-blocks/hyperswarm)—common peer-transport entry point before you layer on Secretstream and Protomux.
+- [NoiseSecretStream](/reference/helpers/secretstream)—the encrypted framed stream most commonly used underneath Protomux.
+- [compact-encoding](/reference/helpers/compact-encoding)—the schema toolkit Protomux uses for handshakes and message payloads.
+- [Hyperswarm](/reference/building-blocks/hyperswarm)—common peer-transport entry point before you layer on NoiseSecretStream and Protomux.
 - [Upstream Protomux repository](https://github.com/holepunchto/protomux)—source, releases, and implementation details.

--- a/content/reference/helpers/secretstream.mdx
+++ b/content/reference/helpers/secretstream.mdx
@@ -8,7 +8,7 @@ schemaType: APIReference
 
 <Status level="stable" />
 
-`Secretstream` wraps a transport stream in a Noise handshake plus libsodium `secretstream` encryption. It is the encrypted stream layer used underneath [Hyperswarm](/reference/building-blocks/hyperswarm) and related peer transports. For the upstream package, source, and release notes, see the [@hyperswarm/secret-stream repository](https://github.com/holepunchto/hyperswarm-secret-stream).
+`NoiseSecretStream` wraps a transport stream in a Noise handshake plus libsodium `secretstream` encryption. It is the encrypted stream layer used underneath [Hyperswarm](/reference/building-blocks/hyperswarm) and related peer transports. For the upstream package, source, and release notes, see the [@hyperswarm/secret-stream repository](https://github.com/holepunchto/hyperswarm-secret-stream).
 
 ## Install
 
@@ -405,7 +405,7 @@ Options for creating a `SecretStream` (also accepted by `start()`).
 
 ## See also
 
-- [Hyperswarm](/reference/building-blocks/hyperswarm)—the peer-discovery and connection layer that typically hands sockets to Secretstream.
-- [HyperDHT](/reference/building-blocks/hyperdht)—lower-level DHT whose direct keyed connections are also wrapped in Secretstream.
+- [Hyperswarm](/reference/building-blocks/hyperswarm)—the peer-discovery and connection layer that typically hands sockets to NoiseSecretStream.
+- [HyperDHT](/reference/building-blocks/hyperdht)—lower-level DHT whose direct keyed connections are also wrapped in NoiseSecretStream.
 - [Protomux](/reference/helpers/protomux)—multiplex higher-level protocols across one framed encrypted stream.
 - [Upstream @hyperswarm/secret-stream repository](https://github.com/holepunchto/hyperswarm-secret-stream)—source, releases, and implementation details.

--- a/content/reference/index.mdx
+++ b/content/reference/index.mdx
@@ -40,7 +40,7 @@ Per-module API references (also linked from the [Bare modules catalog](/referenc
 
 ### Module catalog
 
-- [Modules](/reference/modules/pear-modules)—the `pear-*` libraries: application, UI, common, developer, integration.
+- [Pear modules](/reference/modules/pear-modules)—the `pear-*` libraries: application, UI, common, developer, integration.
 - [Bare modules](/reference/modules/bare-modules)—the `bare-*` runtime modules underpinning Pear.
 
 ### Building blocks
@@ -53,7 +53,7 @@ The core peer-to-peer primitives Pear is built on:
 
 Higher-level utilities that combine the building blocks:
 
-- [Corestore](/reference/helpers/corestore), [Localdrive](/reference/helpers/localdrive), [Mirrordrive](/reference/helpers/mirrordrive), [Secretstream](/reference/helpers/secretstream), [Compact-encoding](/reference/helpers/compact-encoding), [Protomux](/reference/helpers/protomux).
+- [Corestore](/reference/helpers/corestore), [Localdrive](/reference/helpers/localdrive), [MirrorDrive](/reference/helpers/mirrordrive), [NoiseSecretStream](/reference/helpers/secretstream), [compact-encoding](/reference/helpers/compact-encoding), [Protomux](/reference/helpers/protomux).
 
 ### Tools
 

--- a/content/reference/modules/bare-modules.mdx
+++ b/content/reference/modules/bare-modules.mdx
@@ -311,6 +311,6 @@ Extensions for [`bare-tui`](https://github.com/holepunchto/bare-tui), the termin
 - [Bare runtime API](/reference/bare/runtime)—the `Bare` global these modules build on.
 - [`bare` CLI](/reference/bare/cli)—run a script or REPL on Bare.
 - [Bare Kit](/reference/bare/bare-kit)—embed a Bare worklet in a native app.
-- [Modules](/reference/modules/pear-modules)—higher-level `pear-*` modules built on Bare.
+- [Pear modules](/reference/modules/pear-modules)—higher-level `pear-*` modules built on Bare.
 - [`pear-runtime` reference](/reference/pear/runtime)—JavaScript API exposed inside a running Pear app.
 - [Runtime and languages](/explanation/runtime-and-languages)—the language-and-runtime story behind both.

--- a/content/reference/modules/pear-modules.mdx
+++ b/content/reference/modules/pear-modules.mdx
@@ -1,12 +1,12 @@
 ---
-title: Modules
+title: Pear modules
 description: Catalog of installable Pear modules—application, UI, common, developer, and integration libraries shipped as `pear-*` packages.
-seoTitle: "Modules: Catalog of pear-* Packages"
+seoTitle: "Pear modules: Catalog of pear-* Packages"
 docType: reference
 schemaType: APIReference
 ---
 
-# Modules
+# Pear modules
 
 The `Pear` global API is minimal and not intended as a standard library. Application and integration libraries are supplied via installable modules prefixed with `pear-`.
 
@@ -105,9 +105,9 @@ Pear modules for runtime integrations. Such as [pear-electron](https://github.co
 - Helpers—utilities that complement the building blocks:
   - [Corestore](/reference/helpers/corestore)
   - [Localdrive](/reference/helpers/localdrive)
-  - [Mirrordrive](/reference/helpers/mirrordrive)
-  - [Secretstream](/reference/helpers/secretstream)
-  - [Compact encoding](/reference/helpers/compact-encoding)
+  - [MirrorDrive](/reference/helpers/mirrordrive)
+  - [NoiseSecretStream](/reference/helpers/secretstream)
+  - [compact-encoding](/reference/helpers/compact-encoding)
   - [Protomux](/reference/helpers/protomux)
 - Tools—standalone CLI utilities:
   - [Hypershell](/reference/tools/hypershell)

--- a/content/reference/pear/api.mdx
+++ b/content/reference/pear/api.mdx
@@ -9,7 +9,7 @@ schemaType: APIReference
 **Deprecated in Pear v2.6.5, removed as of Pear v3.** The `global.Pear` direct-access API documented here was injected by the removed `pear run` command and is superseded by **[Pear OTA](/reference/pear/runtime)** (the `pear-runtime` module)—instantiate `Pear` and use its API instead. This page is retained for reference and for the still-current [`global.Bare`](#globalbare) APIs.
 </Callout>
 
-Pear is built on [Bare](/reference/modules/bare-modules). Pear applications have a `global.Pear` object and a`global.Bare` object. For background on the runtime split, see [Runtime and languages](/explanation/runtime-and-languages); for the surrounding `pear-*` library catalog, see [Modules](/reference/modules/pear-modules).
+Pear is built on [Bare](/reference/modules/bare-modules). Pear applications have a `global.Pear` object and a`global.Bare` object. For background on the runtime split, see [Runtime and languages](/explanation/runtime-and-languages); for the surrounding `pear-*` library catalog, see [Pear modules](/reference/modules/pear-modules).
 
 * [global.Pear](#globalpear)
 * [global.Bare](#globalbare)
@@ -890,5 +890,5 @@ This is how [Pear OTA](/reference/pear/runtime) wires up worker communication: [
 - [`pear-runtime` reference](/reference/pear/runtime)—the supported, non-deprecated way to access these capabilities from a Pear app.
 - [Configuration](/reference/pear/configuration)—the `package.json` fields read at the values surfaced in `Pear.config` and `Pear.app.*`.
 - [Pear CLI](/reference/pear/cli)—commands that drive the lifecycle these APIs reflect (`pear stage`, `pear seed`, `pear build`).
-- [Modules](/reference/modules/pear-modules)—the `pear-*` libraries that supply most application capabilities.
+- [Pear modules](/reference/modules/pear-modules)—the `pear-*` libraries that supply most application capabilities.
 - [Bare modules](/reference/modules/bare-modules)—runtime primitives the API builds on.

--- a/content/reference/tools/drives.mdx
+++ b/content/reference/tools/drives.mdx
@@ -181,7 +181,7 @@ drives mirror ./site <drive-key>
 
 - [Hyperdrive](/reference/building-blocks/hyperdrive)
 - [Localdrive](/reference/helpers/localdrive)
-- [Mirrordrive](/reference/helpers/mirrordrive)—the sync engine powering `drives mirror`.
+- [MirrorDrive](/reference/helpers/mirrordrive)—the sync engine powering `drives mirror`.
 - [Hypershell—`hypershell-copy`](/reference/tools/hypershell#hypershell-copy)
 - [Hyperbeam—one-to-one pipe for ad-hoc transfers](/reference/tools/hyperbeam#hyperbeam)
 - [Pear CLI](/reference/pear/cli)

--- a/scripts/check-cross-links.ts
+++ b/scripts/check-cross-links.ts
@@ -105,10 +105,17 @@ function buildCanonicals(files: string[]): Canonical[] {
 }
 
 function prettifyModuleName(basename: string): string {
-  // hypercore → Hypercore, hyperdht → HyperDHT, compact-encoding → Compact-encoding.
+  // hypercore → Hypercore, hyperdht → HyperDHT, localdrive → Localdrive.
+  // Special-cased where the file basename doesn't titlecase into the name the
+  // docs actually use — usually mid-word capitals in the upstream class name
+  // (MirrorDrive, NoiseSecretStream) or a package name that stays lowercase
+  // (compact-encoding). Keep in sync with the page's frontmatter `title`.
   const specialCase: Record<string, string> = {
     hyperdht: 'HyperDHT',
     hyperssh: 'HyperSSH',
+    mirrordrive: 'MirrorDrive',
+    secretstream: 'NoiseSecretStream',
+    'compact-encoding': 'compact-encoding',
   };
   if (specialCase[basename]) return specialCase[basename];
   return basename

--- a/src/lib/custom-tree.ts
+++ b/src/lib/custom-tree.ts
@@ -133,7 +133,7 @@ export const customTree: Node[] = [
         children: [
           {
             type: 'page',
-            name: 'Pear desktop architecture',
+            name: 'Pear desktop application architecture',
             url: '/explanation/pear-desktop-architecture',
           },
           {
@@ -589,17 +589,17 @@ export const customTree: Node[] = [
           },
           {
             type: 'page',
-            name: 'Mirrordrive',
+            name: 'MirrorDrive',
             url: '/reference/helpers/mirrordrive',
           },
           {
             type: 'page',
-            name: 'Secretstream',
+            name: 'NoiseSecretStream',
             url: '/reference/helpers/secretstream',
           },
           {
             type: 'page',
-            name: 'Compact encoding',
+            name: 'compact-encoding',
             url: '/reference/helpers/compact-encoding',
           },
           {


### PR DESCRIPTION
A consistency pass over all 137 content pages. Everything here is naming and metadata — no prose was rewritten and no page changed URL.

## The core problem

Three sources disagreed about what some modules are called: the **page title**, the **sidebar label**, and the **canonical term** `check-cross-links` derives from the file basename. For two helpers, all three differed.

| | Page title | Sidebar | Checker | Prose links |
|---|---|---|---|---|
| `mirrordrive` | MirrorDrive | Mirrordrive | Mirrordrive | Mirrordrive ×11 |
| `secretstream` | NoiseSecretStream | Secretstream | Secretstream | Secretstream ×11 |
| `compact-encoding` | compact-encoding | Compact encoding | Compact-encoding | both spellings |

Resolved toward the **real upstream names** — `MirrorDrive` and `NoiseSecretStream` are the actual exported classes, and `compact-encoding` is a package name that stays lowercase.

`check-cross-links` learns all three as special cases alongside the existing `hyperdht`/`hyperssh` entries, so the term it derives from a basename now matches what the docs actually say.

### What was deliberately *not* renamed

`SecretStream` (mid-caps) is the imported binding from `@hyperswarm/secret-stream` — `import SecretStream from ...`, `new SecretStream(true)`, `SecretStreamOptions`. It's code, not a display name, and is untouched. libsodium's lowercase `secretstream` primitive is likewise left alone.

## Nav labels now track frontmatter titles

`custom-tree.ts` documents this rule ("`name` should track the MDX frontmatter `title`") but nothing enforces it. Fixed the four drifted entries, including `Pear desktop architecture` → `Pear desktop application architecture`.

## Doc-type metadata

- **`pear-modules` was titled just "Modules"** while its sibling is "Bare modules", and both nav and the checker already called it "Pear modules". Retitled; inbound link text updated to match.
- **Two how-to guides declared `schemaType: WebPage`.** Across the how-to quadrant the split is otherwise perfect — all 12 index landings are `WebPage`, all guides are `TechArticle`. `manage-installed-applications` and `distribute-as-binary` were the only exceptions, and both are plainly procedural ("This guide covers…", "## Steps"). This feeds JSON-LD structured data, so it isn't cosmetic.

## Headings

The Bare section of `troubleshooting.mdx` used Title Case ("Missing builtin Modules when Running with Bare") while every other heading in the same file used sentence case. **Anchors are unaffected** — `github-slugger` lowercases regardless — so no inbound link changes.

## Verification

`check:doctypes`, `check:internal-links`, `check:includes`, `check:docs-versions`, `types:check`, `gen-curated --check`, and `vale --minAlertLevel=error` (147 files) all pass.

`check:cross-links` passes with measured coverage for **Pear modules rising from 1/1 to 5/5**. One number moves the other way and is worth explaining: `compact-encoding` now reports 32%. The old canonical term `Compact-encoding` matched almost nothing in prose, so it reported "no prose mentions" — a dead rule. The new term matches real mentions and surfaces genuine link-coverage debt that was always there. CI does not gate on this metric.

## Not addressed here

Three findings from the same review that need a decision rather than a mechanical fix:

- **22 non-index pages have no `## See also` footer** (99/121 do). Mostly getting-started and chat-app guides.
- **11 page descriptions exceed 160 chars** and will truncate in search results; the longest is 299.
- **40 of 52 reference pages have no `upstreamVersion` pin**, so `check:upstream-pins` can't grade their drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)