### PR TITLE
Fix hello-pear-bare variant inaccuracies, wire snapshots into CI and drift watch, refresh stale pins

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,9 +1,15 @@
 name: Examples
 
-# Smoke-tests every example under examples/:
+# Smoke-tests most examples under examples/:
 #   - desktop-build:    the 9 Electron/Pear desktop apps (npm install + build).
-#   - terminal-examples: the 13 terminal Bare apps, grouped into 6 scenarios,
+#   - terminal-examples: the 16 terminal Bare apps, grouped into 9 scenarios,
 #                        run on the latest Bare runtime with output assertions.
+#
+# Both matrices are hardcoded, so a new example app or a new scenario in
+# scripts/test-examples.ts is NOT picked up automatically — add it below too, or
+# it silently never runs in CI. Of the 29 app dirs under examples/, four are
+# deliberately uncovered here: the hyperblobs writer/reader pair, keet-identity-key,
+# and publish-a-changelog have no scenario in scripts/test-examples.ts.
 
 on:
   push:
@@ -63,6 +69,11 @@ jobs:
       fail-fast: false
       matrix:
         scenario:
+          # The three vendored hello-pear-bare snapshots. These boot a real
+          # pear-runtime host with `--no-updates`, so they stay off the network.
+          - hello-pear-bare
+          - hello-pear-bare-single-thread
+          - hello-pear-bare-daemon
           - hyperdht-chat
           - hyperswarm-chat
           - hypercore-replicate

--- a/.github/workflows/watch-boilerplates.yml
+++ b/.github/workflows/watch-boilerplates.yml
@@ -4,12 +4,16 @@ name: Watch boilerplate upstreams
 # examples/getting-started/ and import code from them with remark-code-import
 # (```js file=<rootDir>/examples/getting-started/<name>/...). GitHub won't let
 # us subscribe to another org's repo events, so instead of a true webhook
-# "watcher" this job polls the upstream default branches on a schedule and opens
-# a tracking issue when a vendored snapshot falls behind upstream — the cue to
-# refresh the files and re-check the imported line ranges.
+# "watcher" this job polls each snapshot's upstream branch on a schedule (the
+# default branch, or `ref` where a snapshot tracks a non-default branch) and
+# opens a tracking issue when a vendored snapshot falls behind upstream — the
+# cue to refresh the files and re-check the imported line ranges.
 #
-# When you refresh a snapshot, bump the matching `pinned` SHA below (and the
-# snapshot's README); the next run sees no drift and auto-closes the issue.
+# When you refresh a snapshot, bump the matching `pinned` SHA below AND the
+# snapshot's provenance record — that is the bespoke README for snapshots whose
+# README this repo authors (hello-pear-bare, hello-pear-electron), or SNAPSHOT.md
+# for snapshots that vendor upstream's own README verbatim (the variants). The
+# next run sees no drift and auto-closes the issue.
 
 on:
   schedule:
@@ -38,6 +42,20 @@ jobs:
             repo: holepunchto/hello-pear-electron
             pinned: 9e8085a7ae0313150d05fd9d5ad6c0ba8b297243
             path: examples/getting-started/hello-pear-electron
+          # The two hello-pear-bare variants live on long-lived non-default
+          # branches, so they set `ref` explicitly. Without it the poll below
+          # would compare a variant snapshot against `main`'s HEAD and file a
+          # drift issue that could never close.
+          - name: hello-pear-bare-single-thread
+            repo: holepunchto/hello-pear-bare
+            ref: variant/single-thread
+            pinned: 31934aea35f3c0e32d357941218f95b325abbddb
+            path: examples/getting-started/hello-pear-bare-single-thread
+          - name: hello-pear-bare-daemon
+            repo: holepunchto/hello-pear-bare
+            ref: variant/daemon
+            pinned: 1f0cebf406f42dd1b3e90fc7e74e9831631e6441
+            path: examples/getting-started/hello-pear-bare-daemon
     steps:
       - name: Compare upstream HEAD to the vendored snapshot
         env:
@@ -46,10 +64,13 @@ jobs:
           NAME: ${{ matrix.name }}
           PINNED: ${{ matrix.pinned }}
           VENDOR_PATH: ${{ matrix.path }}
+          # Empty for snapshots vendored from the default branch; a branch name
+          # for snapshots vendored from elsewhere (e.g. `variant/daemon`).
+          REF: ${{ matrix.ref }}
         run: |
           set -euo pipefail
 
-          branch=$(gh api "repos/${REPO}" --jq '.default_branch')
+          branch="${REF:-$(gh api "repos/${REPO}" --jq '.default_branch')}"
           head_sha=$(gh api "repos/${REPO}/commits/${branch}" --jq '.sha')
           title="Refresh vendored snapshot: ${NAME}"
 
@@ -84,9 +105,10 @@ jobs:
             "" \
             "The docs import code from this snapshot via \`remark-code-import\`. To refresh:" \
             "" \
-            "1. Copy the imported upstream files into \`${VENDOR_PATH}\` at \`${head_sha}\`." \
-            "2. Re-check the \`#L…\` ranges in the importing \`.mdx\`." \
-            "3. Update the \`pinned\` SHA for \`${NAME}\` in \`.github/workflows/watch-boilerplates.yml\` and the snapshot README." \
+            "1. Copy the imported upstream files into \`${VENDOR_PATH}\` from \`${branch}\` at \`${head_sha}\`, keeping any deliberate local deviations (e.g. the placeholder \`upgrade\` link in \`package.json\`)." \
+            "2. Re-check the \`#L…\` ranges in the importing \`.mdx\` — a shifted range fails silently." \
+            "3. Update the \`pinned\` SHA for \`${NAME}\` in \`.github/workflows/watch-boilerplates.yml\` and the snapshot's provenance record (its bespoke \`README.md\`, or \`SNAPSHOT.md\` where the README is vendored from upstream)." \
+            "4. Re-run the snapshot's scenario: \`npm run test:examples -- --filter=${NAME}\` (if one exists)." \
             "" \
             "_Opened automatically by the Watch boilerplate upstreams workflow._")
 

--- a/.github/workflows/watch-boilerplates.yml
+++ b/.github/workflows/watch-boilerplates.yml
@@ -36,11 +36,11 @@ jobs:
         include:
           - name: hello-pear-bare
             repo: holepunchto/hello-pear-bare
-            pinned: c62e69bc47ec8b926587fd6979ab9b7e8a16d6fb
+            pinned: e391b8a8330e514df4fe37cd6dfc7572a4d0e21e
             path: examples/getting-started/hello-pear-bare
           - name: hello-pear-electron
             repo: holepunchto/hello-pear-electron
-            pinned: 9e8085a7ae0313150d05fd9d5ad6c0ba8b297243
+            pinned: ad23048ae2a02ee9a0961c280e795da66a08d77d
             path: examples/getting-started/hello-pear-electron
           # The two hello-pear-bare variants live on long-lived non-default
           # branches, so they set `ref` explicitly. Without it the poll below

--- a/content/getting-started/from-a-template/start-from-hello-pear-bare.mdx
+++ b/content/getting-started/from-a-template/start-from-hello-pear-bare.mdx
@@ -119,7 +119,7 @@ flowchart LR
 
 ## Variants
 
-The `main` branch above (a Bare worker thread) is one of three process shapes `holepunchto/hello-pear-bare` ships. All three keep the same `upgrade` link, build targets, and `pear install`/[`pear seed`](/explanation/availability-and-blind-peering#seeding-with-pear-seed) flow from [Clone and run](#clone-and-run) onward—only `app.js` and `bin.mjs` differ. Pick the branch that matches how your CLI runs:
+The `main` branch above (a Bare worker thread) is one of three process shapes `holepunchto/hello-pear-bare` ships. All three share the same `upgrade` link, the same per-platform build targets, and the same [`pear install`](/reference/pear/cli#pear-install)/[`pear seed`](/explanation/availability-and-blind-peering#seeding-with-pear-seed) release flow. What differs is `app.js`, `bin.mjs`, and their dependencies—and **neither variant has a `workers/` directory at all**, so the `workers/main.js` row in [Map the template](#map-the-template) applies to `main` only; on both variants the peer-to-peer code and the updater live in the same process tree as the CLI. Pick the branch that matches how your CLI runs:
 
 | Branch | Shape | Use it for |
 | --- | --- | --- |
@@ -135,7 +135,7 @@ git clone -b variant/single-thread https://github.com/holepunchto/hello-pear-bar
 
 ### `single-thread`
 
-Same `App` [`ready-resource`](https://github.com/holepunchto/ready-resource) shape and event surface (`updating`, `updating-delta`, `updated`, `update-applied`, `error`) as `main`, but `_open()` constructs `PearRuntime` directly instead of spawning a worker and wrapping its IPC in a `FramedStream`:
+Same `App` [`ready-resource`](https://github.com/holepunchto/ready-resource) shape as `main`, emitting the `updating`, `updated`, `update-applied`, and `error` events `bin.mjs` logs—plus `updating-delta`, which carries download progress and which `main`'s worker never actually forwards. (`main` also emits a generic `message` event for anything else the worker writes over the pipe; with no worker, single-thread has no equivalent.) The difference is in `_open()`, which constructs `PearRuntime` directly instead of spawning a worker and wrapping its IPC in a `FramedStream`:
 
 ```js file=<rootDir>/examples/getting-started/hello-pear-bare-single-thread/app.js#L23-L41 title="app.js"
 ```
@@ -154,13 +154,19 @@ See [`app.js`](https://github.com/holepunchto/hello-pear-bare/blob/variant/singl
 ```js file=<rootDir>/examples/getting-started/hello-pear-bare-daemon/app.js#L11-L18 title="app.js"
 ```
 
-The daemon acquires an `updater.lock` file in the storage directory—via [`fs-native-extensions`](https://github.com/holepunchto/fs-native-extensions)—so only one updater runs per storage directory at a time, waits up to `--update-window` (default 30 seconds) for an update to arrive, and logs to `<storage>/updates.log` instead of stdout since nothing is attached to read it. See [`app.js`](https://github.com/holepunchto/hello-pear-bare/blob/variant/daemon/app.js) and [`bin.mjs`](https://github.com/holepunchto/hello-pear-bare/blob/variant/daemon/bin.mjs) on the `variant/daemon` branch for the full files.
+The daemon acquires an `updater.lock` file in the storage directory—via [`fs-native-extensions`](https://github.com/holepunchto/fs-native-extensions)—so only one updater runs per storage directory at a time, and logs to `<storage>/updates.log` instead of stdout, since nothing is attached to read it.
 
-Tune how long a run waits for an update before giving up:
+`--update-window` (default `30000`, in milliseconds) bounds only how long the daemon waits for a download to **start**. Once one starts, it stays alive until the update is applied or errors out, however long that takes. See [`app.js`](https://github.com/holepunchto/hello-pear-bare/blob/variant/daemon/app.js) and [`bin.mjs`](https://github.com/holepunchto/hello-pear-bare/blob/variant/daemon/bin.mjs) on the `variant/daemon` branch for the full files.
+
+Give a run longer to pick up a download before the daemon gives up:
 
 ```bash
 npm start -- --updates --update-window 60000
 ```
+
+<Callout type="warn">
+Two steps from [Clone and run](#clone-and-run) behave differently on this branch. `npm start` **returns immediately** rather than staying up, so there is no `Ctrl+C` to press. And because the foreground process never constructs [`pear-runtime`](/reference/pear/runtime), an unreplaced placeholder `upgrade` link does **not** fail with `INVALID_URL` in your terminal—the detached updater writes that error to `<storage>/updates.log`. Check that file first whenever updates appear not to run.
+</Callout>
 
 ## Build a standalone binary
 

--- a/examples/getting-started/hello-pear-bare-daemon/SNAPSHOT.md
+++ b/examples/getting-started/hello-pear-bare-daemon/SNAPSHOT.md
@@ -1,0 +1,50 @@
+# hello-pear-bare `variant/daemon` (documentation snapshot)
+
+Vendored from [`holepunchto/hello-pear-bare`](https://github.com/holepunchto/hello-pear-bare),
+branch **`variant/daemon`**, at commit `1f0cebf`
+([tree](https://github.com/holepunchto/hello-pear-bare/tree/1f0cebf406f42dd1b3e90fc7e74e9831631e6441)).
+
+This is the detached-updater variant: the foreground command spawns a `bare-daemon` updater and
+returns immediately, so a short-lived CLI invocation never blocks on an update check. There is no
+`workers/` directory.
+
+## Why this directory exists
+
+`bin.mjs` and `app.js` back the code imports in
+`content/getting-started/from-a-template/start-from-hello-pear-bare.mdx` (the `### daemon` part of
+the "Variants" section), via
+`file=<rootDir>/examples/getting-started/hello-pear-bare-daemon/…#L…`. Keeping a real copy of the
+branch here means the documented code is the code that actually runs, rather than hand-transcribed
+excerpts that drift silently.
+
+It is also exercised by the `hello-pear-bare-daemon` scenario in `scripts/test-examples.ts`:
+
+```sh
+npm run test:examples -- --filter=hello-pear-bare-daemon
+```
+
+Note what that scenario does **not** cover: it runs with `--no-updates`, which short-circuits the
+`if (updates !== false)` guard in `bin.mjs`, so `App.spawnUpdater` is never called and no
+`bare-daemon` process is ever spawned. The scenario asserts the foreground CLI boots and exits; the
+daemon machinery itself is not under test, because exercising it needs a live `pear://` link and a
+seeding peer.
+
+## Deliberate deviations from upstream
+
+Every file is byte-identical to upstream at the commit above, with one exception:
+
+- `package.json` → `upgrade` is set to a syntactically valid placeholder key
+  (`pear://bwkbsetjgy5uhtkckppgn4dxq36ajnh1ugokxmiizubhiwqa59uy`) instead of upstream's
+  `pear://<YOUR_KEY_HERE>`. On this branch an invalid link does not fail in the foreground — the
+  detached updater reports `INVALID_URL` to `<storage>/updates.log` — but the placeholder keeps the
+  snapshot consistent with its siblings. The link is inert; nothing seeds it.
+
+Preserve that deviation when refreshing. `test/index.js` is upstream's `REMOVE ME` placeholder;
+that is upstream's content and is intentionally kept as-is.
+
+## Refreshing
+
+Drift is polled weekly by `.github/workflows/watch-boilerplates.yml`, which opens a tracking issue
+when `variant/daemon` moves past the pinned commit. Follow the steps in that issue: re-copy the
+files, re-check the `#L…` ranges in the MDX (a shifted range fails silently), then bump both the
+`pinned` SHA in that workflow and the commit recorded above.

--- a/examples/getting-started/hello-pear-bare-single-thread/SNAPSHOT.md
+++ b/examples/getting-started/hello-pear-bare-single-thread/SNAPSHOT.md
@@ -1,0 +1,43 @@
+# hello-pear-bare `variant/single-thread` (documentation snapshot)
+
+Vendored from [`holepunchto/hello-pear-bare`](https://github.com/holepunchto/hello-pear-bare),
+branch **`variant/single-thread`**, at commit `31934ae`
+([tree](https://github.com/holepunchto/hello-pear-bare/tree/31934aea35f3c0e32d357941218f95b325abbddb)).
+
+This is the workerless variant: `app.js` constructs `pear-runtime` directly in the main Bare
+process instead of spawning a Bare worker, so there is no `workers/` directory and no
+`framed-stream` IPC.
+
+## Why this directory exists
+
+`app.js` backs the code imports in
+`content/getting-started/from-a-template/start-from-hello-pear-bare.mdx` (the `### single-thread`
+part of the "Variants" section), via
+`file=<rootDir>/examples/getting-started/hello-pear-bare-single-thread/app.js#L…`. Keeping a real
+copy of the branch here means the documented code is the code that actually runs, rather than
+hand-transcribed excerpts that drift silently.
+
+It is also exercised by the `hello-pear-bare-single-thread` scenario in `scripts/test-examples.ts`:
+
+```sh
+npm run test:examples -- --filter=hello-pear-bare-single-thread
+```
+
+## Deliberate deviations from upstream
+
+Every file is byte-identical to upstream at the commit above, with one exception:
+
+- `package.json` → `upgrade` is set to a syntactically valid placeholder key
+  (`pear://bwkbsetjgy5uhtkckppgn4dxq36ajnh1ugokxmiizubhiwqa59uy`) instead of upstream's
+  `pear://<YOUR_KEY_HERE>`, which fails URL validation at startup with `INVALID_URL` and would
+  break the test scenario. The link is inert — nothing seeds it.
+
+Preserve that deviation when refreshing. `test/index.js` is upstream's `REMOVE ME` placeholder;
+that is upstream's content and is intentionally kept as-is.
+
+## Refreshing
+
+Drift is polled weekly by `.github/workflows/watch-boilerplates.yml`, which opens a tracking issue
+when `variant/single-thread` moves past the pinned commit. Follow the steps in that issue: re-copy
+the files, re-check the `#L…` ranges in the MDX (a shifted range fails silently), then bump both the
+`pinned` SHA in that workflow and the commit recorded above.

--- a/examples/getting-started/hello-pear-bare/README.md
+++ b/examples/getting-started/hello-pear-bare/README.md
@@ -1,9 +1,46 @@
 # hello-pear-bare (documentation snapshot)
 
-Vendored from [holepunchto/hello-pear-bare](https://github.com/holepunchto/hello-pear-bare) at commit `c62e69b`.
+Vendored from [holepunchto/hello-pear-bare](https://github.com/holepunchto/hello-pear-bare),
+branch **`main`**, at commit `e391b8a`
+([tree](https://github.com/holepunchto/hello-pear-bare/tree/e391b8a8330e514df4fe37cd6dfc7572a4d0e21e)).
 
-`bin.js` backs the code imports in `content/getting-started/from-a-template/start-from-hello-pear-bare.mdx`
-(via `file=<rootDir>/examples/getting-started/hello-pear-bare/bin.js#L…`).
+`bin.mjs` and `app.js` back the code imports in
+`content/getting-started/from-a-template/start-from-hello-pear-bare.mdx` (via
+`file=<rootDir>/examples/getting-started/hello-pear-bare/…#L…`).
 
-This is a partial, documentation-only snapshot — not a runnable app. To refresh, copy the
-upstream file for the new commit and re-check the imported line ranges in the MDX.
+Unlike the `hello-pear-electron` snapshot, this is a **complete, runnable app**. It is booted by the
+`hello-pear-bare` scenario in `scripts/test-examples.ts`:
+
+```sh
+npm run test:examples -- --filter=hello-pear-bare
+```
+
+See also the two variant snapshots alongside it — `../hello-pear-bare-single-thread` and
+`../hello-pear-bare-daemon` — which track long-lived non-default upstream branches and record their
+own provenance in `SNAPSHOT.md`.
+
+## Deliberate deviations from upstream
+
+Preserve these when refreshing; they are intentional, not drift:
+
+- **`package.json` → `upgrade`** is a syntactically valid placeholder key
+  (`pear://bwkbsetjgy5uhtkckppgn4dxq36ajnh1ugokxmiizubhiwqa59uy`) instead of upstream's
+  `pear://<YOUR_KEY_HERE>`, which fails URL validation at startup with `INVALID_URL` and would break
+  the scenario. The link is inert — nothing seeds it. Everything else in `package.json` matches
+  upstream byte-for-byte.
+- **`workers/main.js` is an inlined copy of the `hello-pear-worker` package**, not upstream's
+  two-line `require('hello-pear-worker')`. The docs show readers the actual worker source, so the
+  real upstream for this file is
+  [holepunchto/hello-pear-worker](https://github.com/holepunchto/hello-pear-worker) — do **not**
+  overwrite it from this repo's `main`. `scripts/check-workers-in-sync.ts` enforces that every
+  `examples/**/workers/main.js` stays byte-identical to the canonical copy in
+  `../hello-pear-electron/workers/main.js`, so this file can only change in lockstep with all ten.
+- **`test/index.js` is a docs-authored test** asserting the `App` constructor's config handling.
+  Upstream ships a `test('REMOVE ME')` placeholder; this replaces it with something meaningful.
+
+## Refreshing
+
+Drift is polled weekly by `.github/workflows/watch-boilerplates.yml`, which opens a tracking issue
+when `main` moves past the pinned commit. Copy the upstream files for the new commit, keeping the
+deviations above, re-check the `#L…` ranges in the MDX (a shifted range fails silently), then bump
+both the `pinned` SHA in that workflow and the commit recorded here.

--- a/examples/getting-started/hello-pear-bare/bin.mjs
+++ b/examples/getting-started/hello-pear-bare/bin.mjs
@@ -8,7 +8,7 @@ import pkg from './package.json'
 import App from './app.js'
 
 const appName = pkg.productName || pkg.name
-const isDev = path.basename(Bare.argv[0]) === 'bare'
+const isDev = path.basename(Bare.argv[0]) === (isWindows ? 'bare.exe' : 'bare')
 
 const cmd = command(
   appName,

--- a/examples/getting-started/hello-pear-bare/package-lock.json
+++ b/examples/getting-started/hello-pear-bare/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "hello-pear-bare",
-  "version": "1.0.0",
+  "version": "0.0.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hello-pear-bare",
-      "version": "1.0.0",
+      "version": "0.0.0-rc.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "bare-os": "^3.9.0",
         "bare-path": "^3.0.0",
@@ -15,6 +16,7 @@
         "corestore": "^7.9.2",
         "framed-stream": "^1.0.1",
         "graceful-goodbye": "^1.3.3",
+        "hello-pear-worker": "^1.0.0",
         "hyperswarm": "^4.17.0",
         "paparam": "^1.10.1",
         "pear-runtime": "^1.2.0",
@@ -26,8 +28,11 @@
       },
       "devDependencies": {
         "bare-build": "^1.0.2",
-        "bare-runtime": "^1.29.4",
-        "brittle": "^3.19.0"
+        "bare-runtime": "1.29.4",
+        "brittle": "^3.19.0",
+        "lunte": "^1.2.0",
+        "prettier": "^3.6.2",
+        "prettier-config-holepunch": "^2.0.0"
       }
     },
     "node_modules/@hyperswarm/secret-stream": {
@@ -112,9 +117,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/bare-addon-resolve": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.10.1.tgz",
-      "integrity": "sha512-F/SD2du8keuYSb4xipnGz5j2E6yhNdHA8ZVxtHae6h2uOrpBIjjbhXvjzKZbr5XUOzqBzh/i8GVFycj2DlFQIA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.10.0.tgz",
+      "integrity": "sha512-sSd0jieRJlDaODOzj0oe0RjFVC1QI0ZIjGIdPkbrTXsdVVtENg14c+lHHAhHwmWCZ2nQlMhy8jA3Y5LYPc/isA==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-module-resolve": "^1.10.0",
@@ -147,9 +152,9 @@
       }
     },
     "node_modules/bare-apk": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/bare-apk/-/bare-apk-0.1.4.tgz",
-      "integrity": "sha512-y8gcCU4GSkCCHAnXskAos9hMT5lU80oOVwqYekmi/po1o+oNGQ6LnUklj8jrUwOs3EkxRoZrUpZmX3/iGxvrTA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/bare-apk/-/bare-apk-0.1.3.tgz",
+      "integrity": "sha512-LakK8fcKDQaMDZvfaMAH7vB1tkDrKGi8rffSG4QkagM+Db8kn6pOEr02Iacix0cG3G83HlKqJ7xmIl4uZHkIhQ==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -158,42 +163,14 @@
         "bare-fs": "^4.5.2",
         "bare-os": "^3.6.2",
         "bare-path": "^3.0.0",
-        "bare-subprocess": "^6.1.0",
+        "bare-subprocess": "^5.2.1",
         "require-asset": "^1.2.1"
       }
     },
-    "node_modules/bare-apk/node_modules/bare-subprocess": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/bare-subprocess/-/bare-subprocess-6.1.0.tgz",
-      "integrity": "sha512-8L6KtbmreDy4Fc1BdDqaDo9fg0nbedUmTSFQxYPV0uHIM2BBAX8+E0LyMDKgkk0I+mlKto80WYzOnIhT8VDdOg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-env": "^3.0.0",
-        "bare-events": "^2.5.4",
-        "bare-os": "^3.0.1",
-        "bare-pipe": "^4.2.0",
-        "bare-structured-clone": "^1.5.2",
-        "bare-tcp": "^2.4.1",
-        "bare-url": "^2.2.2"
-      },
-      "engines": {
-        "bare": ">=1.7.0"
-      },
-      "peerDependencies": {
-        "bare-buffer": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-buffer": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/bare-app-image": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/bare-app-image/-/bare-app-image-0.1.2.tgz",
-      "integrity": "sha512-Bg7R28sc7i96dZdPfUvGBbg5IPZ7u6fu0gFOhhRwJzNfiHjOl4a3wDEiex4TR4Lx6hJE/UkWAfhArkol0eWeGA==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/bare-app-image/-/bare-app-image-0.1.1.tgz",
+      "integrity": "sha512-FOmSjy+0bx6Qkztl+n7PHhrqxSnu4ccsokjHPwQUFnDNcAetYlxsLQHquq7B/vJeZiowBVJV+ulrTdwuVBfXpA==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -203,36 +180,8 @@
       "dependencies": {
         "bare-fs": "^4.5.1",
         "bare-path": "^3.0.0",
-        "bare-subprocess": "^6.1.0",
+        "bare-subprocess": "^5.1.5",
         "require-asset": "^1.1.0"
-      }
-    },
-    "node_modules/bare-app-image/node_modules/bare-subprocess": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/bare-subprocess/-/bare-subprocess-6.1.0.tgz",
-      "integrity": "sha512-8L6KtbmreDy4Fc1BdDqaDo9fg0nbedUmTSFQxYPV0uHIM2BBAX8+E0LyMDKgkk0I+mlKto80WYzOnIhT8VDdOg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-env": "^3.0.0",
-        "bare-events": "^2.5.4",
-        "bare-os": "^3.0.1",
-        "bare-pipe": "^4.2.0",
-        "bare-structured-clone": "^1.5.2",
-        "bare-tcp": "^2.4.1",
-        "bare-url": "^2.2.2"
-      },
-      "engines": {
-        "bare": ">=1.7.0"
-      },
-      "peerDependencies": {
-        "bare-buffer": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-buffer": {
-          "optional": true
-        }
       }
     },
     "node_modules/bare-assert": {
@@ -256,9 +205,9 @@
       }
     },
     "node_modules/bare-buffer": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/bare-buffer/-/bare-buffer-3.6.2.tgz",
-      "integrity": "sha512-WT9xx12FJvWbBCkgfjuAeWfY40RW6BKVr2fK9UGrTEYKbvqhcaW0J9AMkA3Sj36Wgi+DUuGXYkZPxn5jVH61LA==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/bare-buffer/-/bare-buffer-3.6.1.tgz",
+      "integrity": "sha512-8mzp60t6jdSD3cEGmyxAV1YrAN2+mnxiUvBPQHJJ4WNk0hSVLJGSIEolRj09ZP8yt/+oSj2N2f5kDVW8297n4A==",
       "license": "Apache-2.0",
       "peer": true,
       "engines": {
@@ -567,9 +516,9 @@
       }
     },
     "node_modules/bare-env": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bare-env/-/bare-env-3.0.1.tgz",
-      "integrity": "sha512-BdoLvnzaWR0YyyJreEx4zG2Od0AC/s9JSZ+EXyMZKunpn8zEgR/dGv37hdFUaY1bjDkcRKvcKkFyJIwlJ0CaYA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-env/-/bare-env-3.0.0.tgz",
+      "integrity": "sha512-0u964P5ZLAxTi+lW4Kjp7YRJQ5gZr9ycYOtjLxsSrupgMz3sn5Z9n4SH/JIifHwvadsf1brA2JAjP+9IOWwTiw==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-os": "^3.0.1"
@@ -600,9 +549,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
-      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.5.4",
@@ -687,9 +636,9 @@
       }
     },
     "node_modules/bare-inspector": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/bare-inspector/-/bare-inspector-6.1.0.tgz",
-      "integrity": "sha512-PRxmZ4gF+K3TLzGubgRFvzdECybTCSKackgNsAdd4e7SdvICxMkGj+p5iX7bSKYSmgDnxgCR+2Z6UXmWykKhvw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/bare-inspector/-/bare-inspector-6.0.1.tgz",
+      "integrity": "sha512-rL+aKJ74FhF+6iJS2cV3C8js8nGF37H05ldiyMojgFP/N5eYShZ/mhSbTcDh1yriW5jndYd6xWQU0E/CE14Tiw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -700,7 +649,7 @@
         "bare-ws": "^3.0.0"
       },
       "engines": {
-        "bare": ">=1.29.0"
+        "bare": ">=1.25.0"
       },
       "peerDependencies": {
         "bare-tcp": "*"
@@ -722,9 +671,9 @@
       }
     },
     "node_modules/bare-link": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/bare-link/-/bare-link-3.3.0.tgz",
-      "integrity": "sha512-gAa3PJ+kZnL7vT5MGCgqXDfBKDu62turjBaZBRp0ZqnGT3BFeox9jWYrW1zo/8sQqmSpMEcWGWCyJpPt8huYRA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/bare-link/-/bare-link-3.2.2.tgz",
+      "integrity": "sha512-8URo/GQp1tQloDmCbM2fw3vUaSWs6aNbq3yyy6ioVy4z2zatWHzfeSncI6FXRn7MBcuXgMyBCCdg/NM3sAPUiw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -733,7 +682,6 @@
         "bare-module-resolve": "^1.12.0",
         "bare-os": "^3.2.0",
         "bare-path": "^3.0.0",
-        "bare-semver": "^1.0.3",
         "bare-subprocess": "^6.0.0",
         "bare-url": "^2.0.9",
         "paparam": "^1.5.0"
@@ -743,9 +691,9 @@
       }
     },
     "node_modules/bare-link/node_modules/bare-lief": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/bare-lief/-/bare-lief-0.2.6.tgz",
-      "integrity": "sha512-sq1DmnANQ/EYR0gFnt6UnrWGc+QCz1fVXfiqp+Of8WYptoxMXnvUyKw7hIBXxcsrLzhbzQuO8gESlIvPcRZQRA==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/bare-lief/-/bare-lief-0.2.4.tgz",
+      "integrity": "sha512-h9urnxzacY8z2BKc4ABdbyGXBivfern5IPXzbtU94KyXD8r0nGBKtjQTU0BNHq0POxE6qe8zLGfuQSd9IoqpQw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -780,12 +728,6 @@
         }
       }
     },
-    "node_modules/bare-mime": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/bare-mime/-/bare-mime-1.0.0.tgz",
-      "integrity": "sha512-lUOswzBkfqham4zjLDueKOd4Qj3gS56BiZ3q2f0g0adoFhF+HFNupvTUfZBWoicl7fWJ7Hp2RUZjmkY47dxxOQ==",
-      "license": "Apache-2.0"
-    },
     "node_modules/bare-module": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/bare-module/-/bare-module-6.4.0.tgz",
@@ -812,9 +754,9 @@
       }
     },
     "node_modules/bare-module-lexer": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/bare-module-lexer/-/bare-module-lexer-1.6.3.tgz",
-      "integrity": "sha512-NQY7cnPV3GZlHJphX4nXmPdNPER/Tp17pVi9/he2ODw/GNZ7FXzrZlrS7WMF8zbtWigqW/NMc9aQc2BH8UJXqA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bare-module-lexer/-/bare-module-lexer-1.5.0.tgz",
+      "integrity": "sha512-FXjqDdVrR9zizyHcZvJtkUNe9CanFo9eOmo33O8CGEL45xYMiZDUvAqoQhsHb/RK2QKsryAyKiNv0W5kiALzmw==",
       "license": "Apache-2.0",
       "dependencies": {
         "require-addon": "^1.0.2"
@@ -829,9 +771,9 @@
       }
     },
     "node_modules/bare-module-resolve": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.4.tgz",
-      "integrity": "sha512-xcfgg2u7HqgJiBmah71O9vvdFAgHCvkqC/WSC2O7Bbgosoc1eC/BWe/6IDJ4OsfKlkxuvC/TDWXC+oH5yeW8mA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.2.tgz",
+      "integrity": "sha512-j+hiD5k99qec4KjJvYsI67q5AOBifmy9JG3oeMVxTmvrhn2sIdp8StrUvZu4YNgwTpO+NhniQG16N1ETDe1k5w==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-semver": "^1.0.0"
@@ -846,14 +788,13 @@
       }
     },
     "node_modules/bare-module-traverse": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/bare-module-traverse/-/bare-module-traverse-2.4.4.tgz",
-      "integrity": "sha512-zK4bDxqeD15Tvu/C5B1Mi/epl9PavjIhU3SVh5RhDb4Hpet6applPVX8Q9rinu7nT80yzgSSlBn0exzJaNXv0A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bare-module-traverse/-/bare-module-traverse-2.1.1.tgz",
+      "integrity": "sha512-+gNplZqErqrFwgAEqkGBz25sOaqkUMJV+2ZCM8qtAyg/WU+6jX2n6k5eJEe6QIqpWqTHpuSkXYQSVC0S+GtOAw==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-addon-resolve": "^1.5.0",
-        "bare-mime": "^1.0.0",
-        "bare-module-lexer": "^1.6.0",
+        "bare-module-lexer": "^1.4.0",
         "bare-module-resolve": "^1.7.0"
       },
       "peerDependencies": {
@@ -883,25 +824,25 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.3.tgz",
-      "integrity": "sha512-fF4Q7QsyKVF5Rj0qvI8BgUNjqzC2JvQlpTaPLjVJVxYVUX5Zr9un+y3w1HmA4nNKdFmRBT8z/WmrjvXzXVerKQ==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
       "license": "Apache-2.0",
       "engines": {
         "bare": ">=1.14.0"
       }
     },
     "node_modules/bare-pack": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bare-pack/-/bare-pack-2.2.1.tgz",
-      "integrity": "sha512-7w9tcotjBxT31Azwqr/gq5acO//8cMxiNwtNccLvIhu0ZmlEXvqrBsZfUJ9P3i+Nd13/7DOY1bLcq+4lCcqzqQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bare-pack/-/bare-pack-2.1.0.tgz",
+      "integrity": "sha512-0iJ/2NRWYbB8iL8bWfQrKbtQzJHUyt3pdgyjDCNKhM3SeRNVi7rzrW6e6a/albzmwDm+x0frxiV2mNgAO0VdKg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-bundle": "^1.8.3",
         "bare-bundle-id": "^1.0.0",
         "bare-fs": "^4.2.1",
-        "bare-module-traverse": "~2.4.0",
+        "bare-module-traverse": "~2.1.1",
         "bare-path": "^3.0.0",
         "paparam": "^1.5.0",
         "promaphore": "^1.0.0"
@@ -923,15 +864,18 @@
       }
     },
     "node_modules/bare-path": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
-      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
-      "license": "Apache-2.0"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
     },
     "node_modules/bare-pipe": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/bare-pipe/-/bare-pipe-4.2.3.tgz",
-      "integrity": "sha512-MJYji+Vy8cNMAB2fwg1WQAm1hFIOe5ojw5V9EhEa/wEEYpKT8c36WjHBDwgkgAZfUSX6wQcEFX+Q7wN09SgRow==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/bare-pipe/-/bare-pipe-4.2.1.tgz",
+      "integrity": "sha512-il5ssf8MGPHtuaHnqjAiJHUzNQ3dahjkIMAo1k+7+zxdqscZZf8gLyptjFGQHVNHb24z8zwmAXpMBeNcFjwMBA==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.0.0",
@@ -948,9 +892,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/bare-process": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/bare-process/-/bare-process-4.5.1.tgz",
-      "integrity": "sha512-CaAvy1trputD49mtwfJ6G75vydhnirLrW/F3Sznp4H556e1uZn8YMo9ELicBTrGYy7RBNUgPl9bpB/ERzRCiDw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/bare-process/-/bare-process-4.5.0.tgz",
+      "integrity": "sha512-NTtYDiwleJjWWNg4+yzS6B/RovL/LLPHVvoOM+18W+dYAXCmky0zFfN66hqqBbrlGAlb52/QgKrdzPR3x1QyHA==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-abort": "^2.0.13",
@@ -959,7 +903,7 @@
         "bare-hrtime": "^2.0.0",
         "bare-os": "^3.7.1",
         "bare-posix": "^1.0.1",
-        "bare-signals": "^5.0.0",
+        "bare-signals": "^4.0.0",
         "bare-stdio": "^1.0.1"
       }
     },
@@ -1286,19 +1230,20 @@
       }
     },
     "node_modules/bare-semver": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.1.0.tgz",
-      "integrity": "sha512-1Hw5qJ7hXdVt3uPUqjeFTuxyvBUJauvz5A1I2jk8gzjZMHp04n//6nV9MDbG9CMw78JHY2lGV0w6s//LrASm2w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.0.3.tgz",
+      "integrity": "sha512-HS/A30bi2+PiRJfU6R4+Kp+6KeLSCSByjYM2iiobOKzLAvtu1CT+S8xWfiU7wz0erknjkUoC+yXy108tzIuP5Q==",
       "license": "Apache-2.0"
     },
     "node_modules/bare-sidecar": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/bare-sidecar/-/bare-sidecar-0.5.3.tgz",
-      "integrity": "sha512-TO/FHNUWgNEfDGiqrvmYT7+1ZxRpa4J0fWQsdVIjh5FY5xC+PocdMQPw/LiTp7iyhTUatZEeTDWr4l8DQ3jaeA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/bare-sidecar/-/bare-sidecar-0.5.2.tgz",
+      "integrity": "sha512-7v8m3P39/QtgVWiHvK94xp36CBcju65raQTYF3aPSjwfj2I8hlgxCAFRt4q8/n4HMRVEgarcSv51cihEpQqEcQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-fs": "^4.5.1",
         "bare-module": "^6.1.3",
+        "bare-os": "^3.6.2",
         "bare-path": "^3.0.0",
         "bare-pipe": "^4.1.3",
         "bare-stream": "^2.7.0",
@@ -1334,21 +1279,22 @@
       }
     },
     "node_modules/bare-signals": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bare-signals/-/bare-signals-5.0.0.tgz",
-      "integrity": "sha512-8Gn8bBFUh2AUCJ9wWWFjSGWIo1HIUSIQnXRJGSm/f7GCDMqsuJhRmR1dT+HtDaDBkeu2l8Koxt2JLurfJ5yHVw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/bare-signals/-/bare-signals-4.2.0.tgz",
+      "integrity": "sha512-fNHMOdQIlYuTvMB3Oh9Apk99hLKn351+Ir8vz+khiPTcOqIyGG4uWWjdLTzxWdYGsA0eT+We3y0K74hjj2nq7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "bare-events": "^2.5.3"
+        "bare-events": "^2.5.3",
+        "bare-os": "^3.3.1"
       },
       "engines": {
         "bare": ">=1.7.0"
       }
     },
     "node_modules/bare-stdio": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bare-stdio/-/bare-stdio-1.0.3.tgz",
-      "integrity": "sha512-8BRMx7RWMWCbBmKhyHgBco62J+Pgss7+EPI21L3R9+w0UpwDYWUUcbE0YTOesGyt7M6N7VtoshYbzwrP0pI52Q==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bare-stdio/-/bare-stdio-1.0.2.tgz",
+      "integrity": "sha512-3WJDqtvVGP4f+j68kyEC05umOYNwKJ1xG+YAXL8yZ605WgNqiRhVaFq+mVIhBt2eKNp7pa5vCQdhOt1pNh79SA==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-fs": "^4.5.2",
@@ -1398,9 +1344,9 @@
       }
     },
     "node_modules/bare-structured-clone": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/bare-structured-clone/-/bare-structured-clone-1.6.0.tgz",
-      "integrity": "sha512-AZjEERyqF7kAuudlmgrweT2KwwWM0LsGG4Gx/bWyFwJrKU7E3wNG8c09z2DIrdw93p3vDtfOX8fyHOcXfy5m+g==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/bare-structured-clone/-/bare-structured-clone-1.5.5.tgz",
+      "integrity": "sha512-b1x++7qt6x7T0Rm8NAg/EnU13+rn3Gfglv8N5PGtFcfdi4yAfLJs/mLbrVfc+C66DFrO+CxdIsl1NcnE6Ra+xQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-buffer": "^3.6.0",
@@ -1449,9 +1395,9 @@
       }
     },
     "node_modules/bare-tcp": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/bare-tcp/-/bare-tcp-2.5.3.tgz",
-      "integrity": "sha512-TsioekALDulWi0mglooIVG4ML7doxyANKfvuXUU6NS5tFMUnWVuvDht9wQplg07ZS6PQ3jfowzKxNeWdj2e02Q==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/bare-tcp/-/bare-tcp-2.5.0.tgz",
+      "integrity": "sha512-lwUy3jSVoloVBbCCyPFmmqT1KaeBk/XEkpLMHU+BCap8WNXc48iQfiWEQYgJkCRYuP6vnkZ0XHCLY222TJ29Wg==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-dns": "^2.0.4",
@@ -1504,13 +1450,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/bare-tty": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/bare-tty/-/bare-tty-5.1.2.tgz",
-      "integrity": "sha512-wDHPU/yVQtrDCUrKVdIVOLmfIw7dFPETz30UayuFlROvgz8Juv2SmISSMhqxYQVO+fVnG/1ZoLcbGh/35eAjDA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bare-tty/-/bare-tty-5.1.0.tgz",
+      "integrity": "sha512-EZLvW4A+XiJgI3TW+e1pMME9PIJsfEXe/DA/WSKzIkq/v7Yarpv/rvG6Z5pGnpo4V/Bd+qopwnCLSR71hMMBYA==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.2.0",
-        "bare-signals": "^5.0.0",
+        "bare-signals": "^4.0.0",
         "bare-stream": "^2.0.0"
       },
       "engines": {
@@ -1527,9 +1473,9 @@
       }
     },
     "node_modules/bare-type-stripper": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/bare-type-stripper/-/bare-type-stripper-0.1.4.tgz",
-      "integrity": "sha512-FdZhp9XEnQpj8AWFmIft/sVUyKS9XSmB6PhcxBHhuEDxxZM5Kkt8+kFS7eEpLXR7TkaRkNpSENoGH/8lpAmtkA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/bare-type-stripper/-/bare-type-stripper-0.1.2.tgz",
+      "integrity": "sha512-ArhqyRF9PramHfuSkZHp6DeMg8UdXWN2vjH0dvJ8PNJW15UDM6X/cSeT40R1IsKbyFgpM6+lZd2ZBlAKmKaGyg==",
       "license": "Apache-2.0",
       "dependencies": {
         "require-addon": "^1.0.2"
@@ -1561,9 +1507,9 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.6.tgz",
-      "integrity": "sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-path": "^3.0.0"
@@ -1732,9 +1678,9 @@
       }
     },
     "node_modules/compact-encoding": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/compact-encoding/-/compact-encoding-3.3.0.tgz",
-      "integrity": "sha512-e64XyzlBvTRJ3iScuU/U2w25Dglkm7fhrRbrGaHIwuTlNnzjRKMaQBCVl7mJRvZg7wI5a9wX1IVTXCuaAANNkw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/compact-encoding/-/compact-encoding-3.2.0.tgz",
+      "integrity": "sha512-cCe/FM8f/WuXkEVpsYEoSX3ht2tec7NSNOC8rZBv/sbdFzO3h2Z/JUmZwJQBhghKJNimJSkWM40YURhgU640jw==",
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.3.0"
@@ -1766,9 +1712,9 @@
       "license": "MIT"
     },
     "node_modules/corestore": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/corestore/-/corestore-7.11.1.tgz",
-      "integrity": "sha512-X6UsGFyHeAcqffTqgoDV7WDZjhfvolWabwzws6GbdqeXQY0CTM6gNpNMGEi6RGvAdZDPnFaboF5jFBy1lw1rDA==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/corestore/-/corestore-7.11.0.tgz",
+      "integrity": "sha512-zGlF6dBZ9bvyRliz6g+NW0tGRwGYmmc84o1TARbXOJ+fPRXeKTkVzVV95eWIJEU3+6WBUbcvIBQKmKiNmiTAdg==",
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.7",
@@ -1849,9 +1795,9 @@
       "license": "MIT"
     },
     "node_modules/fd-lock": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/fd-lock/-/fd-lock-2.2.0.tgz",
-      "integrity": "sha512-Il4jWBhjjgvUg+z8d0bC7ncXqB42caqKTUpnZ9jpcqiPmw8bkIixt7Kic1czbZPMxAQD/9kEqfZ5Dq77nSll0w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fd-lock/-/fd-lock-2.1.1.tgz",
+      "integrity": "sha512-H3VkcWFl39Rk0xBokDcUyBcVs6VrYTUo/DhDWMzJOF99wXWDAvmvq/GlLTS2NTehsznZhp3fXVyrtB2ldDXhwg==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-fs": "^4.5.0",
@@ -1902,16 +1848,16 @@
       "license": "MIT"
     },
     "node_modules/globbie": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/globbie/-/globbie-1.0.5.tgz",
-      "integrity": "sha512-P/NGQsM5Qxg5UEsqB3GmrVIwugvF5U0nDn6+F8Yn9kV2WOGpT8i38NEHB9mkHhU9Iz2P2hzAhzlVVOX2rSVI2g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globbie/-/globbie-1.0.3.tgz",
+      "integrity": "sha512-hcryJmKcftf82xfBWTWxuUITWIIoYO3ec104V17SMHGFl6VLbm1d1Ju9LX9L+jyJTwICpemX/dmPI/HGYoKr1A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "bare-fs": "^4.7.4",
-        "bare-path": "^3.1.1",
-        "bare-process": "^4.5.1",
-        "picomatch": "^4.0.5"
+        "bare-fs": "^4.1.2",
+        "bare-path": "^3.0.0",
+        "bare-process": "^4.2.1",
+        "picomatch": "^4.0.2"
       }
     },
     "node_modules/graceful-goodbye": {
@@ -1922,6 +1868,23 @@
       "dependencies": {
         "bare-process": "^4.0.0",
         "safety-catch": "^1.0.2"
+      }
+    },
+    "node_modules/hello-pear-worker": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hello-pear-worker/-/hello-pear-worker-1.0.0.tgz",
+      "integrity": "sha512-y9Iakp8fQnZj+ypdhCPT13AKFgQu3i1m4ZBXtWSnJ6v61PSbGcS7e3RP4imFmXYWW2pOzo8ZoQFj9yp04knr/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.1",
+        "bare-storage": "^1.1.0",
+        "corestore": "^7.11.0",
+        "framed-stream": "^1.0.1",
+        "graceful-goodbye": "^1.3.3",
+        "hyperswarm": "^4.17.0",
+        "pear-mobile": "^4.2.2",
+        "pear-runtime": "^1.3.1",
+        "which-runtime": "^1.4.0"
       }
     },
     "node_modules/hyperbee": {
@@ -1961,9 +1924,9 @@
       }
     },
     "node_modules/hypercore": {
-      "version": "11.34.1",
-      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-11.34.1.tgz",
-      "integrity": "sha512-nlrbXjI4x59akT8AwVEFLN54OicB53JDnH1xYP4j9zKDksHUVgqJFXnFwOkRr4Nr3kwCU0b9Rh3eIsU0JX5HEA==",
+      "version": "11.33.1",
+      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-11.33.1.tgz",
+      "integrity": "sha512-fpAWVOM4CclWAPChmsh1nAfJy5pJlFOLUOiegRws2HYzUsj5bP/VwanZYv9ruhRXRLY1qJeddXLTEz4DJf1GQw==",
       "license": "MIT",
       "dependencies": {
         "@hyperswarm/secret-stream": "^6.0.0",
@@ -1976,7 +1939,7 @@
         "hypercore-crypto": "^3.2.1",
         "hypercore-errors": "^1.5.0",
         "hypercore-id-encoding": "^1.2.0",
-        "hypercore-storage": "^3.2.0",
+        "hypercore-storage": "^3.0.0",
         "is-options": "^1.0.1",
         "nanoassert": "^2.0.0",
         "protomux": "^3.5.0",
@@ -2020,9 +1983,9 @@
       }
     },
     "node_modules/hypercore-storage": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/hypercore-storage/-/hypercore-storage-3.2.0.tgz",
-      "integrity": "sha512-i5O5ZMkdZaNAWGuNRXUZjuzv7B41OIhDHUwLCZPjucgVmywY0ZE5PDafu6e5oPuhtghjl6S8q6Jn+POVKN2BvQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/hypercore-storage/-/hypercore-storage-3.1.1.tgz",
+      "integrity": "sha512-UEOtZDT2ftGSrGEfwUTzOprhwICxNHfSYgl6BxgdJZDpV18hllbUQIBdjkH+IfRNBg5c85ehSY8VZJ6bIPwPEQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.7",
@@ -2036,14 +1999,13 @@
         "resolve-reject-promise": "^1.0.0",
         "rocksdb-native": "^3.11.0",
         "scope-lock": "^1.2.4",
-        "streamx": "^2.21.1",
-        "xache": "^1.2.1"
+        "streamx": "^2.21.1"
       }
     },
     "node_modules/hyperdht": {
-      "version": "6.33.0",
-      "resolved": "https://registry.npmjs.org/hyperdht/-/hyperdht-6.33.0.tgz",
-      "integrity": "sha512-veSvVKptjPTu2di3q5IWI62ZDFzEmTj1QSTAkiXW/cg0+lgMUlwfVWB4dX+WI14xNb54vogVIjA/Ph3KiVuRJQ==",
+      "version": "6.32.0",
+      "resolved": "https://registry.npmjs.org/hyperdht/-/hyperdht-6.32.0.tgz",
+      "integrity": "sha512-Y/SibEN7wue0E8ydh8lx9IX7SOE9o00b6tufPA7hRxAafXsisWUBrW36fIHdyxg148T4Z3olrooOGZDZ89LYag==",
       "license": "MIT",
       "dependencies": {
         "@hyperswarm/secret-stream": "^6.6.2",
@@ -2081,9 +2043,9 @@
       }
     },
     "node_modules/hyperdrive": {
-      "version": "13.3.3",
-      "resolved": "https://registry.npmjs.org/hyperdrive/-/hyperdrive-13.3.3.tgz",
-      "integrity": "sha512-nLqBbBUg1OPsjl8vn5T3wxhtLbzQz+JxUK1i1YOKTX4tdDFET8H4HxdA17knv5P4lC9v9eVC0mlPKdFlYxzDfw==",
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/hyperdrive/-/hyperdrive-13.3.2.tgz",
+      "integrity": "sha512-YgM/be3hppRTLN7plGGot30w58imhCBhzy+bfSToyDH0Gf4ykwplOxsW3YnDIIH5Oa/tNU2ZdZHQ6IhrTZ9aLQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "hyperbee": "^2.11.1",
@@ -2173,6 +2135,30 @@
         "mutexify": "^1.4.0",
         "streamx": "^2.12.5",
         "unix-path-resolve": "^1.0.2"
+      }
+    },
+    "node_modules/lunte": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lunte/-/lunte-1.8.0.tgz",
+      "integrity": "sha512-znc/elScelBYq/N6hUngr9rPdArBKhn4yR86ofnuj6qQ0MAHAo8KalAY2c/DBKw3dO4FjUZ9PR+YCFSbCgBcWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "paparam": "^1.8.6"
+      },
+      "bin": {
+        "lunte": "bin/lunte"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.8.1",
+        "bare-fs": "^4.7.0",
+        "bare-module": "^6.1.2",
+        "bare-os": "^3.6.2",
+        "bare-path": "^3.0.0",
+        "bare-process": "^4.2.2",
+        "bare-subprocess": "^5.1.4",
+        "bare-url": "^2.3.2",
+        "bare-utils": "^1.5.1"
       }
     },
     "node_modules/mirror-drive": {
@@ -2277,6 +2263,21 @@
         "pear-errors": "^1.0.0"
       }
     },
+    "node_modules/pear-mobile": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/pear-mobile/-/pear-mobile-4.2.2.tgz",
+      "integrity": "sha512-le8sCauiEUQNTWtz6YRYzRcbn75YKlT+tqTAKisV2jJr78VmyBqbUfyaNInLN074L/bTc8APpStEG5PHP7d+kg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.5.5",
+        "bare-path": "^3.0.0",
+        "bare-storage": "^1.1.0",
+        "corestore": "^7.9.1",
+        "hyperswarm": "^4.17.0",
+        "pear-runtime-updater": "^3.0.0",
+        "ready-resource": "^1.2.0"
+      }
+    },
     "node_modules/pear-runtime": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/pear-runtime/-/pear-runtime-1.3.1.tgz",
@@ -2313,9 +2314,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2323,6 +2324,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-config-holepunch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-config-holepunch/-/prettier-config-holepunch-2.0.0.tgz",
+      "integrity": "sha512-yuskcdPRfQYLFPkOGvxS4TFmCb7QvAowjO+YaNLPLBWRev+qu6HXoKkPWH9lfNsL9gUThV7IeZ6t/B1QSu/jng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "prettier": "^3.6.2"
       }
     },
     "node_modules/promaphore": {
@@ -2478,9 +2506,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/rocksdb-native": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/rocksdb-native/-/rocksdb-native-3.17.2.tgz",
-      "integrity": "sha512-6kijLkb7NrUFCyWQsIxKIU/iQASxdqLDWrteAeXVEq1MJWrJUcXP6MDPRh8Ux7im2sBereDiI/D4vxYV2ia90A==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/rocksdb-native/-/rocksdb-native-3.15.2.tgz",
+      "integrity": "sha512-8fXcL6yVfHd14NySHCNLcMKkbTO81aFog5aMrLU92vBMHpycSgqGVIevqeILGQ/jt0FAZy9lMqWO82f4eZVh/A==",
       "license": "Apache-2.0",
       "dependencies": {
         "compact-encoding": "^3.0.0",
@@ -2622,9 +2650,9 @@
       "license": "MIT"
     },
     "node_modules/streamx": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
-      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.27.0.tgz",
+      "integrity": "sha512-WZ189TKnHoAokYHvwzaAQMpd55cgUmFIcJFzBSgGcb886jau5DL+XdDhTWV4ps3FLvk+OORp0dLRTPsLZ21CSA==",
       "license": "MIT",
       "dependencies": {
         "events-universal": "^1.0.0",
@@ -2695,9 +2723,9 @@
       }
     },
     "node_modules/udx-native": {
-      "version": "1.20.7",
-      "resolved": "https://registry.npmjs.org/udx-native/-/udx-native-1.20.7.tgz",
-      "integrity": "sha512-FNG0QpnSt0us2xbLP5mmG5Q0UKdLYjKHuh2eR9VrJSFmoZMzeszYLLhK12+iq5x3eq/rgoGG/lLwPn7IDAr6pg==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/udx-native/-/udx-native-1.20.6.tgz",
+      "integrity": "sha512-x2L/dPPEINPgURSPKCLahT3ooJ9p1qLXvj2YvIx30j95E0S6T+ghzroxmyedCbJqCFN2SQQ9QFrGKx96BJEn5g==",
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.5.0",
@@ -2758,9 +2786,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/xache": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/xache/-/xache-1.3.0.tgz",
-      "integrity": "sha512-ekAknjLTiyXJcuezqwa/cOMfFenVVY2toL4J7D3AfTn7UEDYb8JSgRnv3CK8khF7u38XZ4NjS1MXEw4RwqJ4oA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/xache/-/xache-1.2.1.tgz",
+      "integrity": "sha512-igRS6jPreJ54ABdzhh4mCDXcz+XMaWO2q1ABRV2yWYuk29jlp8VT7UBdCqNkX7rpYBbXsebVVKkwIuYZjyZNqA==",
       "license": "MIT"
     },
     "node_modules/z32": {

--- a/examples/getting-started/hello-pear-bare/package.json
+++ b/examples/getting-started/hello-pear-bare/package.json
@@ -1,14 +1,15 @@
 {
   "name": "hello-pear-bare",
-  "productName": "hello-pear-bare",
-  "version": "1.0.0",
+  "version": "0.0.0-rc.0",
   "description": "Pear Runtime CLI boilerplate using Bare with OTA updater support.",
   "private": true,
   "bin": "bin.mjs",
   "upgrade": "pear://bwkbsetjgy5uhtkckppgn4dxq36ajnh1ugokxmiizubhiwqa59uy",
   "scripts": {
-    "start": "bare bin.mjs --no-updates",
+    "format": "prettier . --write",
     "test": "brittle-bare test/index.js",
+    "lint": "prettier . --check && lunte",
+    "start": "bare bin.mjs --no-updates",
     "make": "node scripts/make.js",
     "make:darwin-arm64": "bare-build --name hello-pear-bare --standalone --host darwin-arm64 --out ./out/darwin-arm64 bin.mjs",
     "make:darwin-x64": "bare-build --name hello-pear-bare --standalone --host darwin-x64 --out ./out/darwin-x64 bin.mjs",
@@ -25,6 +26,7 @@
     "corestore": "^7.9.2",
     "framed-stream": "^1.0.1",
     "graceful-goodbye": "^1.3.3",
+    "hello-pear-worker": "^1.0.0",
     "hyperswarm": "^4.17.0",
     "paparam": "^1.10.1",
     "pear-runtime": "^1.2.0",
@@ -33,7 +35,19 @@
   },
   "devDependencies": {
     "bare-build": "^1.0.2",
-    "bare-runtime": "^1.29.4",
-    "brittle": "^3.19.0"
+    "bare-runtime": "1.29.4",
+    "brittle": "^3.19.0",
+    "lunte": "^1.2.0",
+    "prettier": "^3.6.2",
+    "prettier-config-holepunch": "^2.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/holepunchto/hello-pear-bare.git"
+  },
+  "author": "Holepunch Inc",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/holepunchto/hello-pear-bare/issues"
   }
 }

--- a/examples/getting-started/hello-pear-electron/README.md
+++ b/examples/getting-started/hello-pear-electron/README.md
@@ -1,10 +1,36 @@
 # hello-pear-electron (documentation snapshot)
 
-Vendored from [holepunchto/hello-pear-electron](https://github.com/holepunchto/hello-pear-electron) at commit `9e8085a`.
+Vendored from [holepunchto/hello-pear-electron](https://github.com/holepunchto/hello-pear-electron),
+branch **`main`**, at commit `ad23048`
+([tree](https://github.com/holepunchto/hello-pear-electron/tree/ad23048ae2a02ee9a0961c280e795da66a08d77d)).
 
 `renderer/app.js` and `workers/main.js` back the code imports in
 `content/getting-started/from-a-template/start-from-hello-pear-electron.mdx`
 (via `file=<rootDir>/examples/getting-started/hello-pear-electron/…#L…`).
 
-This is a partial, documentation-only snapshot — not a runnable app. To refresh, copy the
-upstream files for the new commit and re-check the imported line ranges in the MDX.
+This is a partial, documentation-only snapshot — only the two imported files are vendored, so it is
+not a runnable app. (The `hello-pear-bare` snapshot beside it *is* complete and runnable.)
+
+## Deliberate deviations from upstream
+
+Preserve these when refreshing; they are intentional, not drift:
+
+- **`workers/main.js` is an inlined copy of the `hello-pear-worker` package**, not upstream's
+  two-line `require('hello-pear-worker')`. The docs show readers the actual worker source, so the
+  real upstream for this file is
+  [holepunchto/hello-pear-worker](https://github.com/holepunchto/hello-pear-worker) — do **not**
+  overwrite it from this repo's `main`.
+
+  This copy is the **canonical** one: `scripts/check-workers-in-sync.ts` asserts that all ten
+  `examples/**/workers/main.js` files are byte-identical to it, because the worker's positional
+  `argv` parsing is a contract with every host that spawns it. Changing it means re-syncing all ten
+  copies and re-checking each host's `PearRuntime.run` spawn array.
+
+`renderer/app.js` matches upstream byte-for-byte.
+
+## Refreshing
+
+Drift is polled weekly by `.github/workflows/watch-boilerplates.yml`, which opens a tracking issue
+when `main` moves past the pinned commit. Copy the upstream files for the new commit, keeping the
+deviations above, re-check the `#L…` ranges in the MDX (a shifted range fails silently), then bump
+both the `pinned` SHA in that workflow and the commit recorded here.

--- a/scripts/test-examples.ts
+++ b/scripts/test-examples.ts
@@ -89,11 +89,17 @@ const GETTING = 'getting-started';
 const SCENARIOS: Scenario[] = [
   {
     // hello-pear-bare: the three-layer template (bin.mjs entry -> app.js host
-    // -> Bare worker). Runs with the pinned `bare-runtime` devDep via
-    // ./node_modules/.bin/bare so the boot is independent of the host's PATH
-    // `bare` version, then asserts the worker's "Hello from worker" reaches the
+    // -> Bare worker). Asserts the worker's "Hello from worker" reaches the
     // host over IPC — i.e. the full PearRuntime.run spawn + argv + FramedStream
     // round-trip works. `--no-updates` keeps it off the network.
+    //
+    // Uses the PATH `bare` (preflight requires it) rather than the local
+    // `bare-runtime` devDep: `./node_modules/.bin/bare` cannot be relied on.
+    // `bare-runtime` and its per-platform package (e.g. bare-runtime-linux-x64)
+    // both declare the same `bin` name, so npm skips the conflicting shim on
+    // Linux, and the platform binary lands without the executable bit — the
+    // local path fails with either ENOENT or EACCES there while working on
+    // macOS. All the other scenarios below already invoke `bare` from PATH.
     id: 'hello-pear-bare',
     dir: `${GETTING}/hello-pear-bare`,
     installs: ['.'],
@@ -103,7 +109,7 @@ const SCENARIOS: Scenario[] = [
         kind: 'run',
         process: 'app',
         app: '.',
-        cmd: './node_modules/.bin/bare bin.mjs --no-updates',
+        cmd: 'bare bin.mjs --no-updates',
         expect: 'Hello from worker',
         expectAliveMs: 1500,
         timeoutMs: 45_000,
@@ -127,7 +133,7 @@ const SCENARIOS: Scenario[] = [
         kind: 'run',
         process: 'app',
         app: '.',
-        cmd: './node_modules/.bin/bare bin.mjs --no-updates',
+        cmd: 'bare bin.mjs --no-updates',
         expect: 'CLI ready. Press Ctrl+C to stop.',
         expectAliveMs: 1500,
         timeoutMs: 45_000,
@@ -149,7 +155,7 @@ const SCENARIOS: Scenario[] = [
         kind: 'run',
         process: 'app',
         app: '.',
-        cmd: './node_modules/.bin/bare bin.mjs --no-updates',
+        cmd: 'bare bin.mjs --no-updates',
         expect: 'CLI ready.',
         timeoutMs: 45_000,
       },
@@ -653,6 +659,43 @@ function preflight(): string[] {
   return missing;
 }
 
+/**
+ * The `hello-pear-*` scenarios boot `pear-runtime`, whose native addon needs a
+ * reasonably current Bare. An older PATH `bare` (e.g. the standalone `bare`
+ * package at 1.28.0) dies with an opaque V8 abort — "Cannot construct
+ * SharedArrayBuffer with BackingStore of ArrayBuffer" — rather than anything
+ * naming a version. Warn instead of failing: the other scenarios run fine on
+ * older runtimes, so this must not block them.
+ */
+const MIN_BARE_FOR_PEAR_RUNTIME = [1, 29, 0];
+
+function warnOnOldBare(): void {
+  const r = spawnSync('bare', ['--version'], { encoding: 'utf-8', env: childEnv() });
+  const raw = `${r.stdout ?? ''}${r.stderr ?? ''}`;
+  const m = raw.match(/v?(\d+)\.(\d+)\.(\d+)/);
+  if (!m) return;
+
+  const found = [Number(m[1]), Number(m[2]), Number(m[3])];
+
+  if (compareVersion(found, MIN_BARE_FOR_PEAR_RUNTIME) < 0) {
+    console.error(
+      `[test-examples] warning: PATH bare is v${found.join('.')}, older than ` +
+        `v${MIN_BARE_FOR_PEAR_RUNTIME.join('.')}.\n` +
+        `  The hello-pear-* scenarios boot pear-runtime and will abort inside V8 on this version.\n` +
+        `  Fix: npm i -g bare-runtime (uninstall a conflicting global \`bare\` package first —\n` +
+        `  both provide a \`bare\` bin, and npm silently keeps the existing one).\n`
+    );
+  }
+}
+
+function compareVersion(a: number[], b: number[]): number {
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const d = (a[i] ?? 0) - (b[i] ?? 0);
+    if (d !== 0) return d < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
 interface Args {
   filter?: string;
 }
@@ -694,6 +737,7 @@ async function main(): Promise<void> {
     );
     process.exit(1);
   }
+  warnOnOldBare();
 
   const selected = args.filter
     ? SCENARIOS.filter((s) => s.id === args.filter)


### PR DESCRIPTION
Follow-up to #336, addressing the review of that PR — plus refreshing the two pre-existing snapshots whose pins were stale.

## Docs corrections

All four were wrong in the merged page:

- **`workers/` doesn't exist on either variant.** "only `app.js` and `bin.mjs` differ" was false — dependencies differ too, and more importantly the page's own *Map the template* table told readers `workers/main.js` is "your backend", sending anyone who cloned a variant branch after a file that isn't there.
- **The "same event surface" claim was wrong in both directions.** `main` never forwards `updating-delta` (its worker only writes `updating`/`updated`, so main's own listener is dead code upstream), and `main` emits a generic `message` event that single-thread has no equivalent for. The list given was actually single-thread's.
- **`--update-window` was mis-described.** It bounds only how long the daemon waits for a download to **start**; once one starts it runs to completion with no limit. Now also states the unit (ms).
- **Two Clone-and-run steps don't hold on `variant/daemon`.** `npm start` returns immediately (no `Ctrl+C`), and an unreplaced `upgrade` link does *not* surface `INVALID_URL` in the terminal — the detached updater writes it to `<storage>/updates.log`. Added as a callout.

## Infrastructure

- **`watch-boilerplates.yml` gains an optional per-entry `ref`.** The variants *could not* have been registered without this: the poll resolved `.default_branch`, so a variant row would have compared against `main`'s HEAD and filed drift that could never auto-close. Both variants are registered at the commits they were actually vendored from — verified byte-for-byte before pinning.
- **`SNAPSHOT.md` per variant**, recording repo, branch, commit, the importing MDX, and the deliberate deviation. The existing snapshots keep provenance in a bespoke README, but these vendor upstream's README verbatim, so the record goes in a sibling file rather than breaking byte-fidelity.
- **All three `hello-pear-bare` scenarios added to the `examples.yml` terminal matrix.** They were dead manifest entries — the matrix is hardcoded, so #336's tests never ran in CI, and neither did the pre-existing `hello-pear-bare` scenario. Also documented that the matrix is hardcoded and which four app dirs remain uncovered.

## Stale pins refreshed

Both pre-existing pins were behind upstream, so the watcher would have filed a tracking issue on its first run.

- **`hello-pear-bare` `c62e69b` → `e391b8a`.** `bin.mjs` takes the upstream `isWindows` fix (dev-mode detection now also matches `bare.exe`) — a 1-for-1 line change outside every imported range; all four `#L…` ranges re-verified. `package.json`/`package-lock.json` refreshed; dropping the docs-added `productName` is behaviour-preserving (`productName || name` both resolve to `hello-pear-bare`), which leaves the placeholder `upgrade` link as the single remaining deviation, matching the variants.
- **`hello-pear-electron` `9e8085a` → `ad23048`.** `renderer/app.js` was already identical; the bump just records correspondence.

**Not refreshed, deliberately:** `workers/main.js` in either snapshot. Upstream has moved both to a two-line `require('hello-pear-worker')`, but the docs inline the real worker source so readers can see it, and `check-workers-in-sync.ts` holds all ten copies byte-identical to the canonical electron copy. Its real upstream is `holepunchto/hello-pear-worker`, not these repos. Also kept: the docs-authored `test/index.js`, which replaces upstream's `test('REMOVE ME')` placeholder.

Both snapshot READMEs now record branch + commit and enumerate every deviation. Two pre-existing errors in them are also fixed: the bare README referred to `bin.js` (the file is `bin.mjs`) and described a complete, CI-exercised app as a "partial, documentation-only snapshot — not a runnable app".

## Deliberately not changed

The review flagged a leaked-process defect in `test-examples.ts` teardown. **That was a misdiagnosis** — the orphans came from ad-hoc verification commands that killed the `node` wrapper PID instead of the process group. Re-running every scenario through the harness leaves nothing behind, so working code was left alone.

I also skipped generating the CI matrix from a `--list` flag (the structural fix for the recurrence). It's the better long-term answer but adds CI moving parts; a comment warning about the hardcoded matrix seemed the right trade for now.

## Test plan

- [x] `check:internal-links`, `check:doctypes`, `check:includes`, `check:workers-in-sync` — all pass (all 10 workers still in sync)
- [x] `vale --minAlertLevel=error` on the edited page — 0 errors
- [x] All three scenarios pass, including `hello-pear-bare` from a **deleted `node_modules`** so the refreshed `package.json`/lock install cleanly, as CI will
- [x] No orphaned processes after any run
- [x] Both workflow YAMLs parse; matrix structure asserted
- [x] Simulated the drift job for all four entries: **all report in sync** (variants resolve their non-default branches; pre-existing entries still resolve `main`)
- [x] `${REF:-…}` fallback verified under `set -euo pipefail` (default substitution correctly does not run when `ref` is set)
- [x] Every imported `#L…` range re-verified against the intended construct after the refresh; both template pages render with no empty code blocks and no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up: fixing the CI failure this PR exposed

Adding the three scenarios to CI immediately failed all three with exit 127 — `./node_modules/.bin/bare: No such file or directory` — while passing on macOS. Reproduced on `linux/amd64` in Docker; the local devDep path is unusable there for two independent reasons:

1. **`bare-runtime` and its per-platform package (`bare-runtime-linux-x64`) both declare the same `bin` name, `bare`.** npm resolves the collision by skipping the shim, so `node_modules/.bin/bare` is simply absent on Linux — even though both packages installed successfully.
2. Invoking the real launcher directly gets further and then fails **`EACCES`**: the platform binary lands without the executable bit, because the chmod rides along with the bin link that was skipped.

So the original "pin the local devDep so the boot doesn't depend on the host's `bare`" rationale, while well-intentioned, cannot work on Linux. All three now use `bare bin.mjs --no-updates`, matching the other six scenarios and the contract `preflight()` already enforces. Verified in a `linux/amd64` container running the exact CI steps (`npm i -g bare-runtime tsx`, fresh `npm install`): all three pass. **CI is now 22/22 green.**

Losing the pinned devDep does mean these scenarios depend on the host's `bare`, so there's also a **non-blocking version warning**. An older PATH `bare` — e.g. the standalone `bare` package at 1.28.0 — aborts inside V8 with `Cannot construct SharedArrayBuffer with BackingStore of ArrayBuffer`, naming neither `bare` nor a version. It's advisory rather than fatal so the six non-`pear-runtime` scenarios still run on older runtimes, and it flags that a pre-existing global `bare` package silently wins over `npm i -g bare-runtime` — the same bin-name collision, in the global prefix.
