### PR TITLE
docs: retire "Pear stack" as a named term per branding decision

### DIFF
--- a/content/_snippets/_p2p-intro-callout.mdx
+++ b/content/_snippets/_p2p-intro-callout.mdx
@@ -5,5 +5,5 @@
 */}
 
 <Callout type="info">
-New to peer-to-peer? [Peer-to-peer, demystified](/explanation/peer-to-peer-demystified) explains how peers find each other and connect directly—no servers—and [The Pear stack](/explanation/the-pear-stack) maps the pieces you'll wire together.
+New to peer-to-peer? [Peer-to-peer, demystified](/explanation/peer-to-peer-demystified) explains how peers find each other and connect directly—no servers—and [How Pear and Bare fit together](/explanation/pear-and-bare) maps the pieces you'll wire together.
 </Callout>

--- a/content/explanation/bare-on-native.mdx
+++ b/content/explanation/bare-on-native.mdx
@@ -9,7 +9,7 @@ A peer-to-peer app has two very different halves.
 1. One is the **core**: swarm identity, storage, replication, and the protocol logic—code that should be identical on every device.
 2. The other is the **UI**: windows, views, and gestures—code that is necessarily different on a desktop, a phone, and a terminal.
 
-Bare's answer is to keep the core in one place and let only the UI change. This page explains that pattern and the machinery that connects the two halves. For the runtime itself, see [Inside Bare](/explanation/bare-runtime); for where this sits in the wider picture, see [The Pear stack](/explanation/the-pear-stack).
+Bare's answer is to keep the core in one place and let only the UI change. This page explains that pattern and the machinery that connects the two halves. For the runtime itself, see [Inside Bare](/explanation/bare-runtime); for where this sits in the wider picture, see [How Pear and Bare fit together](/explanation/pear-and-bare).
 
 ## The shape: shell, seam, core
 

--- a/content/explanation/bare-runtime.mdx
+++ b/content/explanation/bare-runtime.mdx
@@ -9,7 +9,7 @@ schemaType: WebPage
 
 <Callout type="info">
 - For the exact API, see the [`Bare` runtime reference](/reference/bare/runtime).
-- For where Bare sits relative to Pear, see [The Pear stack](/explanation/the-pear-stack).
+- For where Bare sits relative to Pear, see [How Pear and Bare fit together](/explanation/pear-and-bare).
 </Callout>
 
 ## What Bare adds, and what it leaves out
@@ -82,4 +82,4 @@ It depends on the build. Bare talks to the engine through the `libjs` ABI, so it
 - [One core, many platforms](/explanation/bare-on-native)—embedding the runtime in native and mobile apps.
 - [Handle app suspension](/how-to/run-on-native/handle-app-suspension)—stop all I/O on `suspend` or the OS will force-terminate the app.
 - [Runtime and languages](/explanation/runtime-and-languages)—why Pear is JavaScript and how other languages plug in.
-- [The Pear stack](/explanation/the-pear-stack)—where the runtime sits relative to Pear.
+- [How Pear and Bare fit together](/explanation/pear-and-bare)—where the runtime sits relative to Pear.

--- a/content/explanation/index.mdx
+++ b/content/explanation/index.mdx
@@ -16,7 +16,7 @@ Pages are grouped by topic and ordered roughly from foundational concepts to app
 
 ### Platform foundations
 
-- [The Pear stack](/explanation/the-pear-stack)—how Pear and Bare layer together, from the native C foundations up to the apps you run.
+- [How Pear and Bare fit together](/explanation/pear-and-bare)—how Pear and Bare layer together, from the native C foundations up to the apps you run.
 - [Peer-to-peer, demystified](/explanation/peer-to-peer-demystified)—hole punching, public-key identity, and the roles of [HyperDHT](/reference/building-blocks/hyperdht) and [Hyperswarm](/reference/building-blocks/hyperswarm).
 - [Runtime and languages](/explanation/runtime-and-languages)—JavaScript on Bare, native addons for other languages, and the Pear-end pattern for cross-platform apps.
 - [Using Bare on its own](/explanation/use-bare-standalone)—the entry point for adopting Bare as a standalone runtime, without Pear's peer-to-peer platform.

--- a/content/explanation/pear-and-bare.mdx
+++ b/content/explanation/pear-and-bare.mdx
@@ -1,15 +1,15 @@
 ---
-title: "The Pear stack"
+title: "How Pear and Bare fit together"
 description: "How Pear and Bare fit together—from the native C foundations up through the Bare runtime, the peer-to-peer building blocks, and the Pear platform to the apps people run."
 docType: explanation
 schemaType: WebPage
 ---
 
-Pear is the platform people see: a runtime, a CLI, and over-the-air updates for peer-to-peer apps. [Bare](/explanation/bare-runtime) is the engine underneath it. They're often named together—"the Pear stack"—but they sit at different layers, and knowing which layer you're working at makes the rest of these docs easier to navigate.
+Pear is the platform people see: a runtime, a CLI, and over-the-air updates for peer-to-peer apps. [Bare](/explanation/bare-runtime) is the engine underneath it. They sit at different layers, and knowing which layer you're working at makes the rest of these docs easier to navigate.
 
-This page lays out the whole stack, bottom to top, and shows where each library you'll meet elsewhere belongs.
+This page lays out the layers, bottom to top, and shows where each library you'll meet elsewhere belongs.
 
-## The stack at a glance
+## The layers at a glance
 
 ```mermaid
 flowchart TB

--- a/content/explanation/runtime-and-languages.mdx
+++ b/content/explanation/runtime-and-languages.mdx
@@ -8,7 +8,7 @@ schemaType: WebPage
 Pear applications are JavaScript programs. The runtime under them is **[Bare](/explanation/bare-runtime)**, a small embeddable JavaScript runtime that strips the assumptions Node.js carries about being a server. This page explains why the language story looks the way it does, how non-JavaScript code joins in, and what the recommended app shape is when you want one codebase to run on desktop, mobile, and terminal. 
 
 <Callout type="info">
-For where Bare sits relative to Pear, see [The Pear stack](/explanation/the-pear-stack).
+For where Bare sits relative to Pear, see [How Pear and Bare fit together](/explanation/pear-and-bare).
 </Callout>
 
 ## Why JavaScript
@@ -50,7 +50,7 @@ See [Workers](/explanation/workers) for the pattern in full—what crosses the I
 
 ## See also
 
-- [The Pear stack](/explanation/the-pear-stack)—the full layering, from native C foundations up to apps.
+- [How Pear and Bare fit together](/explanation/pear-and-bare)—the full layering, from native C foundations up to apps.
 - [Inside Bare](/explanation/bare-runtime)—what the runtime adds, its lifecycle, and why it's minimal.
 - [One core, many platforms](/explanation/bare-on-native)—running the Pear-end in a worklet behind a typed RPC seam.
 - [Workers](/explanation/workers)—the host-and-worker split this page calls the "Pear-end."

--- a/content/explanation/use-bare-standalone.mdx
+++ b/content/explanation/use-bare-standalone.mdx
@@ -15,7 +15,7 @@ Use standalone Bare when you want:
 - **A modular Node.js alternative.** Bare is mobile-first and ships almost no standard library; you opt into only the [`bare-*` modules](/reference/modules/bare-modules) you actually use, keeping bundles small.
 - **A single standalone executable.** Compile a CLI, service, or daemon into one binary with no Node.js, Bare, or Pear install required on the user's machine.
 
-If instead you're building a peer-to-peer app—storage, replication, swarms, over-the-air updates—start with Pear rather than Bare directly: [Getting started](/getting-started) and [The Pear stack](/explanation/the-pear-stack) show how Bare fits underneath it.
+If instead you're building a peer-to-peer app—storage, replication, swarms, over-the-air updates—start with Pear rather than Bare directly: [Getting started](/getting-started) and [How Pear and Bare fit together](/explanation/pear-and-bare) show how Bare fits underneath it.
 
 ## The runtime-only path
 
@@ -39,4 +39,4 @@ If instead you're building a peer-to-peer app—storage, replication, swarms, ov
 
 ## Where Bare and Pear meet
 
-Even used on its own, Bare shares an ecosystem with Pear. The peer-to-peer [building blocks](/reference/building-blocks/hypercore) are ordinary JavaScript modules that run on Bare, and tools like [`compact-encoding`](/reference/helpers/compact-encoding) and `hyperschema` are used on both sides. So if a standalone Bare app later grows peer-to-peer features, the same core moves onto Pear unchanged—see [The Pear stack](/explanation/the-pear-stack).
+Even used on its own, Bare shares an ecosystem with Pear. The peer-to-peer [building blocks](/reference/building-blocks/hypercore) are ordinary JavaScript modules that run on Bare, and tools like [`compact-encoding`](/reference/helpers/compact-encoding) and `hyperschema` are used on both sides. So if a standalone Bare app later grows peer-to-peer features, the same core moves onto Pear unchanged—see [How Pear and Bare fit together](/explanation/pear-and-bare).

--- a/content/getting-started/build-a-peer-to-peer-chat/build-a-peer-to-peer-chat.mdx
+++ b/content/getting-started/build-a-peer-to-peer-chat/build-a-peer-to-peer-chat.mdx
@@ -232,7 +232,7 @@ A peer-to-peer desktop chat that runs without a server. Each piece maps to one c
 
 | File | What it does | Pear concept |
 | --- | --- | --- |
-| `package.json` | Declares Electron, [Hyperswarm](/reference/building-blocks/hyperswarm), and `pear-runtime` as deps | The Pear stack you embed into a JS host |
+| `package.json` | Declares Electron, [Hyperswarm](/reference/building-blocks/hyperswarm), and `pear-runtime` as deps | What you embed into a JS host |
 | `workers/main.mjs` | Hyperswarm + topic + connection handlers | Peer-to-peer code lives in a [Bare worker](/explanation/runtime-and-languages) |
 | `electron/main.js` | `PearRuntime.run()` spawns the worker | The worker is your local backend |
 | `electron/preload.js` | `contextBridge.exposeInMainWorld('chat', { ... })` | The single door from renderer to worker |

--- a/content/getting-started/from-a-template/start-from-hello-pear-bare.mdx
+++ b/content/getting-started/from-a-template/start-from-hello-pear-bare.mdx
@@ -246,7 +246,7 @@ Before you ship, set your identity in `package.json`:
 - [Start from a template](/getting-started/from-a-template)—both boilerplates, side by side.
 - [Start from the hello-pear-electron template](/getting-started/from-a-template/start-from-hello-pear-electron)—the desktop counterpart, with a renderer, preload bridge, and Bare worker.
 - [Inside Bare](/explanation/bare-runtime)—what the runtime this template builds on actually is, and its lifecycle.
-- [The Pear stack](/explanation/the-pear-stack)—where Bare and Pear sit relative to each other.
+- [How Pear and Bare fit together](/explanation/pear-and-bare)—where Bare and Pear sit relative to each other.
 - [Runtime and languages](/explanation/runtime-and-languages)—where Bare fits among Pear's runtimes.
 - [Bundle a Bare app](/how-to/run-on-native/bundle-a-bare-app)—the `bare-pack` and `bare-build` paths behind `npm run make`.
 - [Bare modules](/reference/modules/bare-modules)—the Bare standard library this template builds on.

--- a/scripts/redirects.ts
+++ b/scripts/redirects.ts
@@ -255,7 +255,12 @@ export function buildRedirects(contentRoot = 'content'): Redirect[] {
 
   // "The Pears stack" was renamed "The Pear stack" to drop the pluralised
   // brand term; the slug moved with it.
-  out.push({ from: '/explanation/the-pears-stack/', to: '/explanation/the-pear-stack/' });
+  out.push({ from: '/explanation/the-pears-stack/', to: '/explanation/pear-and-bare/' });
+
+  // "The Pear stack" was retired as a named concept—the branding decision
+  // says there is no "Pear Stack" or "Pears Stack"—and reframed as a plain
+  // explainer of how the layers fit together; the slug moved with it.
+  out.push({ from: '/explanation/the-pear-stack/', to: '/explanation/pear-and-bare/' });
 
   out.sort((a, b) => a.from.localeCompare(b.from));
   return out;

--- a/scripts/redirects.ts
+++ b/scripts/redirects.ts
@@ -257,9 +257,7 @@ export function buildRedirects(contentRoot = 'content'): Redirect[] {
   // brand term; the slug moved with it.
   out.push({ from: '/explanation/the-pears-stack/', to: '/explanation/pear-and-bare/' });
 
-  // "The Pear stack" was retired as a named concept—the branding decision
-  // says there is no "Pear Stack" or "Pears Stack"—and reframed as a plain
-  // explainer of how the layers fit together; the slug moved with it.
+  // "the-pear-stack" retired as a named term; slug moved.
   out.push({ from: '/explanation/the-pear-stack/', to: '/explanation/pear-and-bare/' });
 
   out.sort((a, b) => a.from.localeCompare(b.from));

--- a/src/lib/custom-tree.ts
+++ b/src/lib/custom-tree.ts
@@ -71,8 +71,8 @@ export const customTree: Node[] = [
         children: [
           {
             type: 'page',
-            name: 'The Pear stack',
-            url: '/explanation/the-pear-stack',
+            name: 'How Pear and Bare fit together',
+            url: '/explanation/pear-and-bare',
           },
           {
             type: 'page',


### PR DESCRIPTION
## Summary

Applies the branding decision (Option 1a, "Pears Means Many Pears"):

- Plural **"Pears"** is reserved for the domain (`pears.com`), the logo, and "the Internet of Peers".
- Singular **"Pear"** covers individual libraries, the Pear Platform, and individual Pear apps.
- There is no "Pear Stack" / "Pears Stack".

An audit of the whole site found the docs already followed the singular/plural rule everywhere except one place: the named concept **"the Pear stack"**. Everything else matching `pears` was a legitimate domain reference (`install.pears.com`, `pears.com/news`, `pass.pears.com`) or a substring false-positive ("appears"/"disappears").

- Renamed `content/explanation/the-pear-stack.mdx` → `content/explanation/pear-and-bare.mdx`, retitled **"How Pear and Bare fit together"**, and reworded the intro so it no longer introduces "the Pear stack" as a named term (generic uses of "stack"/"layer" are untouched).
- Updated the sidebar nav entry in `src/lib/custom-tree.ts`.
- Added redirects in `scripts/redirects.ts` from both `/explanation/the-pear-stack/` and the older `/explanation/the-pears-stack/` to the new slug.
- Fixed all 9 backlinks/mentions across other explanation and getting-started pages.

## Test plan

- [x] `npm run check:internal-links` — pass
- [x] `npm run check:cross-links` — pass
- [x] `npm run check:doctypes` — pass
- [x] `npm run types:check` — pass
- [x] Manually verified the renamed page in a local preview (title, nav highlighting, mermaid diagram all render correctly)
- [ ] `npm run check:redirects` will show the new stub as missing until the next full `next build` regenerates `out/` — expected, not a regression (a pre-existing unrelated rename shows the same pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)