### PR TITLE
Changelog: curate draft entries for new upstream releases

### DIFF
--- a/content/release-overview/index.mdx
+++ b/content/release-overview/index.mdx
@@ -9,6 +9,17 @@ A curated record of changes across Pear and its modules, newest first. Entries a
 
 {/* changelog:insert — automation inserts draft entries below this marker; keep it directly above the newest entry. */}
 
+## 2026-08-10 — Upstream releases (draft)
+
+### Bare — v1.31.0
+
+{/* TODO(curate): draft from the 2026-08-04 upstream release — reword for readers, flag Breaking items, add migration links. Source: https://github.com/holepunchto/bare/releases/tag/v1.31.0 */}
+
+- Update dependencies by @kasperisager in https://github.com/holepunchto/bare/pull/169
+- Surface structured errors for addon and module loading by @kasperisager in https://github.com/holepunchto/bare/pull/171
+- Add `new Addon(url)` and deprecate existing addon APIs by @kasperisager in https://github.com/holepunchto/bare/pull/172
+- Update dependencies by @kasperisager in https://github.com/holepunchto/bare/pull/175
+
 ## 2026-07-30 — Pear 3.1.0 and module updates
 
 Pear 3.1.0 is the first feature release on top of Pear v3 (below). Nothing in it is breaking: it adds core inspection, speeds up vanity key generation, and fills in reporting gaps left by the v3 restructure.

--- a/scripts/upstream-releases-state.json
+++ b/scripts/upstream-releases-state.json
@@ -5,7 +5,7 @@
   "holepunchto/pear-electron": "v1.9.0-rc.0",
   "holepunchto/pear-build": "v1.1.1",
   "holepunchto/pear-install": "v1.2.2",
-  "holepunchto/bare": "v1.30.3",
+  "holepunchto/bare": "v1.31.0",
   "holepunchto/hypercore": "v11.35.1",
   "holepunchto/hyperbee": "v2.27.3",
   "holepunchto/hyperdrive": "v13.3.3",
@@ -17,5 +17,6 @@
   "holepunchto/mirror-drive": "v1.14.2",
   "holepunchto/hyperswarm-secret-stream": "v6.9.1",
   "holepunchto/compact-encoding": "v3.3.0",
-  "holepunchto/protomux": "v3.11.0"
+  "holepunchto/protomux": "v3.11.0",
+  "holepunchto/react-native-bare-kit": "v0.15.0"
 }


### PR DESCRIPTION
New upstream releases were detected and inserted as **draft** changelog entries:

- Bare — v1.31.0



**Review checklist** (see the `TODO(curate)` comments in the diff):

- [ ] Reword upstream notes for docs readers (what it means for their app)
- [ ] Flag breaking items with `**Breaking:**` and link migration guidance
- [ ] Fold entries into the right dated section; remove the `(draft)` heading suffix
- [ ] Delete the `TODO(curate)` comments

_Opened automatically by the Watch upstream releases workflow. Scheduled reruns stack new drafts on this branch without touching curation commits._