### PR TITLE
Fix Docs lint failures blocking the main sync PR

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -70,13 +70,13 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 22
-      # Only tsx: check-docs-versions.ts imports nothing but src/lib/docs-versions.ts,
-      # which is self-contained. Same throwaway-prefix dance as internal-links,
-      # because a plain `npm install` here would need the token-gated
-      # @tetherto/* packages. See that job for the full explanation.
+      # tsx + github-slugger: check-docs-versions.ts imports scripts/helpers.ts
+      # for fileToSlug, which needs github-slugger. Same throwaway-prefix dance
+      # as internal-links, because a plain `npm install` here would need the
+      # token-gated @tetherto/* packages. See that job for the full explanation.
       - name: Install tsx
         run: |
-          npm install --no-save --prefix "$RUNNER_TEMP/checker" tsx
+          npm install --no-save --prefix "$RUNNER_TEMP/checker" tsx github-slugger
           mkdir -p node_modules
           cp -R "$RUNNER_TEMP/checker/node_modules/." node_modules/
       # Catches a gate whose version is well-formed but not a real doc-state —

--- a/content/reference/bare/runtime.mdx
+++ b/content/reference/bare/runtime.mdx
@@ -16,7 +16,7 @@ changed:
   <VersionGate since="x.y.z">…</…>     gates a block that is not a whole section, for example a single <Callout>.
   --flag  Description  [!version since=x.y.z]    gates one row inside a fenced help block.
 This axis is independent of `bare-cli` and `bare-kit` — each Bare page tracks its own
-surface, not one shared "Bare version".
+surface, not one shared "Bare version."
 
 As of 2026-08-06, across the tracked window (1.23.5 -> 1.31.0):
 
@@ -30,7 +30,7 @@ IS a real, marker-worthy change and is now reflected in the `## Bare.Addon` / `#
 sections below with `<Since v="1.31.0" />`. First pass at this delta wrongly lumped the whole
 block in with the cosmetic rename because most of it (host/url/exports/etc.) genuinely was
 just the rename — the giveaway missed on first read was that `Addon.constructor` had no `-`
-counterpart, i.e. it wasn't a rename at all. `scripts/bare-model-surface.ts`'s fingerprint was
+counterpart, that is it wasn't a rename at all. `scripts/bare-model-surface.ts`'s fingerprint was
 also blind to `deprecated` status at the time (fixed since — it's now a first-class fingerprinted
 field, and deprecated members surface explicitly in the printed delta, including across a
 rename boundary). `Bare.simulator` was ALSO marked `@deprecated` back in 1.27.0, per the


### PR DESCRIPTION
# Description of Changes

The "Release published docs to main" sync PR (#306) has had a failing Docs lint check since 2026-08-06, on two independent, pre-existing bugs — both confirmed failing on `published` at `8175a12` directly, unrelated to any content change.

## Fixes

* `vale prose lint`: two Google style errors in `content/reference/bare/runtime.mdx` (inside a maintainer-note comment, but vale lints it anyway) — a period outside a closing quote, and "i.e." instead of "that is."
* `version gates`: the job's throwaway dependency install only had `tsx`, but `check-docs-versions.ts` imports `scripts/helpers.ts` for `fileToSlug`, which needs `github-slugger` — every run failed with `ERR_MODULE_NOT_FOUND`.

Verified locally: `vale --minAlertLevel=error content` (0 errors, 186 files), and `check-docs-versions.ts` run against an isolated `tsx` + `github-slugger`-only install, matching the CI job exactly.