### PR TITLE
chore: fill remaining agent-readiness gaps (skills coverage, llms.txt sections)

### DIFF
--- a/public/.well-known/agent-skills/autobase/SKILL.md
+++ b/public/.well-known/agent-skills/autobase/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: autobase
+description: Use when building a deterministic multi-writer view over many Hypercores with Autobase — linearizing causal writes from several peers through an apply handler, often materialized into a Hyperbee view.
+---
+
+# Autobase
+
+Autobase is a multi-writer linearization layer over Hypercore. Writers
+append causal nodes to local cores; Autobase linearizes that graph into an
+eventually consistent order, and an `apply` handler materializes a
+deterministic view — often into a Hyperbee.
+
+Reference: https://docs.pears.com/reference/building-blocks/autobase/

--- a/public/.well-known/agent-skills/hyperbee/SKILL.md
+++ b/public/.well-known/agent-skills/hyperbee/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: hyperbee
+description: Use when storing sorted key/value data on top of Hypercore with Hyperbee — range scans, atomic batches, namespaces, point-in-time snapshots, and replicating a Hyperbee between a writer and reader peer.
+---
+
+# Hyperbee
+
+Hyperbee is an append-only B-tree built on Hypercore, for ordered key/value
+storage with range scans, atomic batches, namespaces, and point-in-time
+snapshots over one replicated log.
+
+Reference: https://docs.pears.com/reference/building-blocks/hyperbee/
+How-to (writer/reader peers sharing a Hyperbee):
+https://docs.pears.com/how-to/store-and-replicate/share-append-only-databases-with-hyperbee/

--- a/public/.well-known/ai-catalog.json
+++ b/public/.well-known/ai-catalog.json
@@ -62,6 +62,19 @@
         "find the canonical URL list for docs.pears.com"
       ],
       "metadata": { "resourceClass": "documentation", "format": "sitemap" }
+    },
+    {
+      "identifier": "urn:air:docs.pears.com:docs:agent-skills",
+      "displayName": "Pear documentation — Agent Skills index",
+      "type": "application/json",
+      "url": "https://docs.pears.com/.well-known/agent-skills/index.json",
+      "description": "An index, per the Agent Skills Discovery RFC v0.2.0, of task-oriented SKILL.md files covering the Pear CLI, scaffolding a Pear app, the Bare runtime, migrating Node.js to Bare, and the Hypercore/Hyperbee/Hyperswarm/Hyperdrive/Autobase building blocks.",
+      "tags": ["documentation", "agent-skills", "pear"],
+      "representativeQueries": [
+        "what agent skills does the Pear documentation provide",
+        "give me a SKILL.md for building a Pear app"
+      ],
+      "metadata": { "resourceClass": "documentation", "format": "agent-skills-index" }
     }
   ]
 }

--- a/public/_headers
+++ b/public/_headers
@@ -18,5 +18,9 @@
 # (also registered, RFC 8631/9727) are deliberately NOT used here — they
 # assert an HTTP API exists, and this is a static docs site with none;
 # using them would misrepresent what's actually being served.
+#
+# Two `describedby` targets: the ARD manifest (site-level metadata) and the
+# Agent Skills index (task-oriented SKILL.md catalog) — RFC 8288 allows a
+# link-value's relation type to repeat, each pointing at a different resource.
 /*
-  Link: </sitemap.xml>; rel="sitemap"; type="text/xml", </llms.txt>; rel="llms-txt"; type="text/plain", </llms-full.txt>; rel="llms-txt-full"; type="text/plain", </.well-known/ai-catalog.json>; rel="describedby"; type="application/json"
+  Link: </sitemap.xml>; rel="sitemap"; type="text/xml", </llms.txt>; rel="llms-txt"; type="text/plain", </llms-full.txt>; rel="llms-txt-full"; type="text/plain", </.well-known/ai-catalog.json>; rel="describedby"; type="application/json", </.well-known/agent-skills/index.json>; rel="describedby"; type="application/json"

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -3,12 +3,33 @@ import { source } from '@/lib/source';
 export const dynamic = 'force-static';
 export const revalidate = false;
 
+// Maps a page's top-level URL segment to its llms.txt section heading, in
+// display order. A page whose first segment isn't one of these keys (just
+// the root index today) falls into 'Overview'.
+const SECTIONS: [key: string, title: string][] = [
+  ['', 'Overview'],
+  ['getting-started', 'Getting Started'],
+  ['how-to', 'How-to Guides'],
+  ['reference', 'Reference'],
+  ['explanation', 'Explanation'],
+  ['release-overview', 'Release Overview'],
+];
+
 export async function GET() {
-  const lines: string[] = [];
-  lines.push('# Documentation');
-  lines.push('');
+  const bySection = new Map<string, string[]>();
   for (const page of source.getPages()) {
-    lines.push(`- [${page.data.title}](${page.url}): ${page.data.description}`);
+    const key = page.url.split('/')[1] ?? '';
+    const line = `- [${page.data.title}](${page.url}): ${page.data.description}`;
+    const entries = bySection.get(key);
+    if (entries) entries.push(line);
+    else bySection.set(key, [line]);
+  }
+
+  const lines: string[] = ['# Documentation', ''];
+  for (const [key, title] of SECTIONS) {
+    const entries = bySection.get(key);
+    if (!entries?.length) continue;
+    lines.push(`## ${title}`, '', ...entries, '');
   }
   return new Response(lines.join('\n'));
 }


### PR DESCRIPTION
## Summary
Follow-up to #358. Four gaps found while reviewing that work:

- **Hyperbee/Autobase skill coverage** — `ai-catalog.json` already described the docs site as covering "Hypercore, Hyperswarm, Hyperdrive, Hyperbee, and Autobase," but the Agent Skills index only shipped `hypercore`/`hyperdrive`/`hyperswarm`. Added `hyperbee` and `autobase` SKILL.md so the claim matches what's served.
- **Agent Skills index wasn't itself discoverable** — added an `ai-catalog.json` entry and a second `describedby` Link header value pointing at `/.well-known/agent-skills/index.json`, matching how the other machine-readable surfaces (sitemap, llms.txt, llms-full.txt) are already advertised.
- **llms.txt was one flat list** — restructured into llmstxt.org-style H2 sections (Getting Started / How-to Guides / Reference / Explanation / Release Overview) instead of ~190 ungrouped links, for easier agent routing at this page count.

## Test plan
- [x] `npx tsx scripts/check-agent-ready-metadata.ts` passes (9 skills, digests verified against source bytes)
- [x] `npx tsc --noEmit` clean on the changed route
- [ ] CI: `agent-ready` and other `docs-lint` jobs green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)