### PR TITLE
fix: sync hello-pear-worker vendored copies, watch its upstream in CI

### DIFF
--- a/.github/workflows/watch-boilerplates.yml
+++ b/.github/workflows/watch-boilerplates.yml
@@ -4,10 +4,15 @@ name: Watch boilerplate upstreams
 # examples/getting-started/ and import code from them with remark-code-import
 # (```js file=<rootDir>/examples/getting-started/<name>/...). GitHub won't let
 # us subscribe to another org's repo events, so instead of a true webhook
-# "watcher" this job polls each snapshot's upstream branch on a schedule (the
-# default branch, or `ref` where a snapshot tracks a non-default branch) and
-# opens a tracking issue when a vendored snapshot falls behind upstream — the
-# cue to refresh the files and re-check the imported line ranges.
+# "watcher" this job polls each upstream's branch on a schedule (the default
+# branch, or `ref` where a snapshot tracks a non-default branch) and opens a
+# tracking issue when a vendored copy falls behind upstream — the cue to
+# refresh it and re-check the imported line ranges. Most entries below track
+# a whole vendored *directory* snapshot (`path`); the `hello-pear-worker`
+# entry instead tracks one deliberately-reshaped *file* — the inlined copy of
+# its `index.js` at `examples/getting-started/hello-pear-electron/workers/main.js`
+# (see that snapshot's README) — via `file` instead of `path`, which also
+# swaps in file-appropriate wording for the tracking issue it files.
 #
 # When you refresh a snapshot, bump the matching `pinned` SHA below AND the
 # snapshot's provenance record — that is the bespoke README for snapshots whose
@@ -56,6 +61,16 @@ jobs:
             ref: variant/daemon
             pinned: 1f0cebf406f42dd1b3e90fc7e74e9831631e6441
             path: examples/getting-started/hello-pear-bare-daemon
+          # holepunchto/hello-pear-worker is not vendored as a directory
+          # snapshot — only workers/main.js above is an inlined, deliberately
+          # reshaped copy of its index.js (see that README's "Deliberate
+          # deviations from upstream"). It sets `file` instead of `path`,
+          # which the shell step below uses to swap in file-appropriate
+          # wording for the tracking issue.
+          - name: hello-pear-worker
+            repo: holepunchto/hello-pear-worker
+            pinned: b906d27c98341b184a2907d9529585e4b876691c
+            file: examples/getting-started/hello-pear-electron/workers/main.js
     steps:
       - name: Compare upstream HEAD to the vendored snapshot
         env:
@@ -67,6 +82,10 @@ jobs:
           # Empty for snapshots vendored from the default branch; a branch name
           # for snapshots vendored from elsewhere (e.g. `variant/daemon`).
           REF: ${{ matrix.ref }}
+          # Set only for the single-file hello-pear-worker entry; empty (and
+          # unused) for the four directory-snapshot entries, which use
+          # VENDOR_PATH instead.
+          FILE: ${{ matrix.file }}
         run: |
           set -euo pipefail
 
@@ -96,20 +115,42 @@ jobs:
           fi
 
           compare="https://github.com/${REPO}/compare/${PINNED}...${head_sha}"
-          body=$(printf '%s\n' \
-            "[\`${REPO}\`](https://github.com/${REPO}) has new commits since the snapshot vendored at \`${VENDOR_PATH}\`." \
-            "" \
-            "- Pinned: \`${PINNED}\`" \
-            "- Upstream \`${branch}\`: \`${head_sha}\`" \
-            "- Changes: ${compare}" \
-            "" \
-            "The docs import code from this snapshot via \`remark-code-import\`. To refresh:" \
-            "" \
-            "1. Copy the imported upstream files into \`${VENDOR_PATH}\` from \`${branch}\` at \`${head_sha}\`, keeping any deliberate local deviations (e.g. the placeholder \`upgrade\` link in \`package.json\`)." \
-            "2. Re-check the \`#L…\` ranges in the importing \`.mdx\` — a shifted range fails silently." \
-            "3. Update the \`pinned\` SHA for \`${NAME}\` in \`.github/workflows/watch-boilerplates.yml\` and the snapshot's provenance record (its bespoke \`README.md\`, or \`SNAPSHOT.md\` where the README is vendored from upstream)." \
-            "4. Re-run the snapshot's scenario: \`npm run test:examples -- --filter=${NAME}\` (if one exists)." \
-            "" \
-            "_Opened automatically by the Watch boilerplate upstreams workflow._")
+
+          if [ -n "${FILE:-}" ]; then
+            # Single-file entry (hello-pear-worker): no vendored directory,
+            # and the refresh is a deliberate re-inline, not a plain copy —
+            # word the issue accordingly instead of the directory phrasing.
+            body=$(printf '%s\n' \
+              "[\`${REPO}\`](https://github.com/${REPO}) has new commits since \`${FILE}\` was last synced to it." \
+              "" \
+              "- Pinned: \`${PINNED}\`" \
+              "- Upstream \`${branch}\`: \`${head_sha}\`" \
+              "- Changes: ${compare}" \
+              "" \
+              "\`${FILE}\` is an inlined copy of \`${REPO}\`'s \`index.js\`, deliberately reshaped rather than left as upstream's two-line \`require('hello-pear-worker')\` — see that file's snapshot README, \"Deliberate deviations from upstream\". To refresh:" \
+              "" \
+              "1. Re-inline \`${branch}\`'s \`index.js\` at \`${head_sha}\` into \`${FILE}\`, preserving the deliberate deviations described in the README (do not replace it with a plain \`require('hello-pear-worker')\`)." \
+              "2. Re-check the \`#L…\` ranges in the \`.mdx\` that imports from \`${FILE}\` — a shifted range fails silently." \
+              "3. Run \`npm run check:workers-in-sync\`, and copy \`${FILE}\` byte-for-byte over any of the other nine \`examples/**/workers/main.js\` copies it reports as drifted." \
+              "4. Update the \`pinned\` SHA for \`${NAME}\` in \`.github/workflows/watch-boilerplates.yml\`." \
+              "" \
+              "_Opened automatically by the Watch boilerplate upstreams workflow._")
+          else
+            body=$(printf '%s\n' \
+              "[\`${REPO}\`](https://github.com/${REPO}) has new commits since the snapshot vendored at \`${VENDOR_PATH}\`." \
+              "" \
+              "- Pinned: \`${PINNED}\`" \
+              "- Upstream \`${branch}\`: \`${head_sha}\`" \
+              "- Changes: ${compare}" \
+              "" \
+              "The docs import code from this snapshot via \`remark-code-import\`. To refresh:" \
+              "" \
+              "1. Copy the imported upstream files into \`${VENDOR_PATH}\` from \`${branch}\` at \`${head_sha}\`, keeping any deliberate local deviations (e.g. the placeholder \`upgrade\` link in \`package.json\`)." \
+              "2. Re-check the \`#L…\` ranges in the importing \`.mdx\` — a shifted range fails silently." \
+              "3. Update the \`pinned\` SHA for \`${NAME}\` in \`.github/workflows/watch-boilerplates.yml\` and the snapshot's provenance record (its bespoke \`README.md\`, or \`SNAPSHOT.md\` where the README is vendored from upstream)." \
+              "4. Re-run the snapshot's scenario: \`npm run test:examples -- --filter=${NAME}\` (if one exists)." \
+              "" \
+              "_Opened automatically by the Watch boilerplate upstreams workflow._")
+          fi
 
           gh issue create --repo "${GITHUB_REPOSITORY}" --title "${title}" --body "${body}"

--- a/examples/getting-started/hello-pear-bare/workers/main.js
+++ b/examples/getting-started/hello-pear-bare/workers/main.js
@@ -39,6 +39,7 @@ console.log('Application storage:', pear.storage)
 
 pear.updater.on('updating', () => pipe.write('updating'))
 pear.updater.on('updated', () => pipe.write('updated'))
+pear.on('minver-required', () => pipe.write('minver-required')) // for mobile store update notification
 
 goodbye(async () => {
   await swarm.destroy()

--- a/examples/getting-started/hello-pear-electron/workers/main.js
+++ b/examples/getting-started/hello-pear-electron/workers/main.js
@@ -39,6 +39,7 @@ console.log('Application storage:', pear.storage)
 
 pear.updater.on('updating', () => pipe.write('updating'))
 pear.updater.on('updated', () => pipe.write('updated'))
+pear.on('minver-required', () => pipe.write('minver-required')) // for mobile store update notification
 
 goodbye(async () => {
   await swarm.destroy()

--- a/examples/getting-started/pear-chat/workers/main.js
+++ b/examples/getting-started/pear-chat/workers/main.js
@@ -39,6 +39,7 @@ console.log('Application storage:', pear.storage)
 
 pear.updater.on('updating', () => pipe.write('updating'))
 pear.updater.on('updated', () => pipe.write('updated'))
+pear.on('minver-required', () => pipe.write('minver-required')) // for mobile store update notification
 
 goodbye(async () => {
   await swarm.destroy()

--- a/examples/how-to/blind-peering/add-blind-peering-to-a-chat-app/workers/main.js
+++ b/examples/how-to/blind-peering/add-blind-peering-to-a-chat-app/workers/main.js
@@ -39,6 +39,7 @@ console.log('Application storage:', pear.storage)
 
 pear.updater.on('updating', () => pipe.write('updating'))
 pear.updater.on('updated', () => pipe.write('updated'))
+pear.on('minver-required', () => pipe.write('minver-required')) // for mobile store update notification
 
 goodbye(async () => {
   await swarm.destroy()

--- a/examples/how-to/connect-to-peers/multi-rooms/workers/main.js
+++ b/examples/how-to/connect-to-peers/multi-rooms/workers/main.js
@@ -39,6 +39,7 @@ console.log('Application storage:', pear.storage)
 
 pear.updater.on('updating', () => pipe.write('updating'))
 pear.updater.on('updated', () => pipe.write('updated'))
+pear.on('minver-required', () => pipe.write('minver-required')) // for mobile store update notification
 
 goodbye(async () => {
   await swarm.destroy()

--- a/examples/how-to/manage-identity/keet-identity/workers/main.js
+++ b/examples/how-to/manage-identity/keet-identity/workers/main.js
@@ -39,6 +39,7 @@ console.log('Application storage:', pear.storage)
 
 pear.updater.on('updating', () => pipe.write('updating'))
 pear.updater.on('updated', () => pipe.write('updated'))
+pear.on('minver-required', () => pipe.write('minver-required')) // for mobile store update notification
 
 goodbye(async () => {
   await swarm.destroy()

--- a/examples/how-to/stream-and-share-media/file-sharing/workers/main.js
+++ b/examples/how-to/stream-and-share-media/file-sharing/workers/main.js
@@ -39,6 +39,7 @@ console.log('Application storage:', pear.storage)
 
 pear.updater.on('updating', () => pipe.write('updating'))
 pear.updater.on('updated', () => pipe.write('updated'))
+pear.on('minver-required', () => pipe.write('minver-required')) // for mobile store update notification
 
 goodbye(async () => {
   await swarm.destroy()

--- a/examples/how-to/stream-and-share-media/live-cam/workers/main.js
+++ b/examples/how-to/stream-and-share-media/live-cam/workers/main.js
@@ -39,6 +39,7 @@ console.log('Application storage:', pear.storage)
 
 pear.updater.on('updating', () => pipe.write('updating'))
 pear.updater.on('updated', () => pipe.write('updated'))
+pear.on('minver-required', () => pipe.write('minver-required')) // for mobile store update notification
 
 goodbye(async () => {
   await swarm.destroy()

--- a/examples/how-to/stream-and-share-media/photo-backup/workers/main.js
+++ b/examples/how-to/stream-and-share-media/photo-backup/workers/main.js
@@ -39,6 +39,7 @@ console.log('Application storage:', pear.storage)
 
 pear.updater.on('updating', () => pipe.write('updating'))
 pear.updater.on('updated', () => pipe.write('updated'))
+pear.on('minver-required', () => pipe.write('minver-required')) // for mobile store update notification
 
 goodbye(async () => {
   await swarm.destroy()

--- a/examples/how-to/stream-and-share-media/video-stream/workers/main.js
+++ b/examples/how-to/stream-and-share-media/video-stream/workers/main.js
@@ -39,6 +39,7 @@ console.log('Application storage:', pear.storage)
 
 pear.updater.on('updating', () => pipe.write('updating'))
 pear.updater.on('updated', () => pipe.write('updated'))
+pear.on('minver-required', () => pipe.write('minver-required')) // for mobile store update notification
 
 goodbye(async () => {
   await swarm.destroy()


### PR DESCRIPTION
## What

The canonical vendored worker source at `examples/getting-started/hello-pear-electron/workers/main.js` had drifted from its real upstream, [holepunchto/hello-pear-worker](https://github.com/holepunchto/hello-pear-worker)'s `index.js` (`main`, now `b906d27`): it was missing

```js
pear.on('minver-required', () => pipe.write('minver-required')) // for mobile store update notification
```

This adds that line to the canonical copy and all nine other `examples/**/workers/main.js` copies that `scripts/check-workers-in-sync.ts` enforces byte-identity against (10 total). The single MDX import of this file (`start-from-hello-pear-electron.mdx`, `#L15-L27`) falls entirely before the inserted line, so its rendered range is unaffected — verified by re-checking it after the edit.

Separately, `.github/workflows/watch-boilerplates.yml`'s matrix only polled `holepunchto/hello-pear-electron`'s HEAD for this file, not `hello-pear-worker` itself — its actual documented upstream (per that snapshot's `README.md`) — so this exact kind of drift would never have been auto-flagged. This adds a fifth matrix entry that polls `holepunchto/hello-pear-worker` directly, pinned to its current HEAD (`b906d27c98341b184a2907d9529585e4b876691c`). Since that repo isn't vendored as a directory snapshot (just one deliberately-reshaped file), the entry uses a new `file` field instead of `path`, which branches the tracking-issue body to correct re-inline/re-sync wording rather than the directory-copy wording the other four entries use. The four existing entries are untouched.

## Verification

- `npm run check:workers-in-sync` passes (all 10 copies in sync).
- The new workflow YAML parses cleanly (`yaml.safe_load`).
- Grepped `content/**/*.mdx` for `workers/main.js#L` — confirmed the only import range is unaffected by the line insertion.
- Reviewed the workflow diff to confirm the four pre-existing matrix entries' behavior is byte-for-byte unchanged (the `else` branch of the new body-wording split is identical to the original `printf` call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)