### PR TITLE
docs: add custom P2P logic how-to using snake-mobile as the worked example

### DIFF
--- a/.github/workflows/watch-boilerplates.yml
+++ b/.github/workflows/watch-boilerplates.yml
@@ -1,8 +1,8 @@
 name: Watch boilerplate upstreams
 
-# The docs vendor read-only snapshots of the hello-pear-* boilerplates under
-# examples/getting-started/ and import code from them with remark-code-import
-# (```js file=<rootDir>/examples/getting-started/<name>/...). GitHub won't let
+# The docs vendor read-only snapshots of the upstream example apps under
+# examples/ and import code from them with remark-code-import
+# (```js file=<rootDir>/examples/<path>/...). GitHub won't let
 # us subscribe to another org's repo events, so instead of a true webhook
 # "watcher" this job polls each upstream's branch on a schedule (the default
 # branch, or `ref` where a snapshot tracks a non-default branch) and opens a
@@ -16,9 +16,14 @@ name: Watch boilerplate upstreams
 #
 # When you refresh a snapshot, bump the matching `pinned` SHA below AND the
 # snapshot's provenance record — that is the bespoke README for snapshots whose
-# README this repo authors (hello-pear-bare, hello-pear-electron), or SNAPSHOT.md
-# for snapshots that vendor upstream's own README verbatim (the variants). The
-# next run sees no drift and auto-closes the issue.
+# README this repo authors, or SNAPSHOT.md for snapshots that vendor upstream's
+# own README verbatim (the hello-pear-bare variants). The next run sees no drift
+# and auto-closes the issue.
+#
+# NOTE: this workflow's `schedule` trigger only fires from the repository's
+# DEFAULT branch. While the default branch is `main` (which carries no
+# .github/workflows), the weekly poll never runs and drift must be checked by
+# hand or via workflow_dispatch from this branch.
 
 on:
   schedule:

--- a/.github/workflows/watch-boilerplates.yml
+++ b/.github/workflows/watch-boilerplates.yml
@@ -47,6 +47,10 @@ jobs:
             repo: holepunchto/hello-pear-electron
             pinned: 5da5c1b46f34baeae0e16d0c5c6c743b51c56ced
             path: examples/getting-started/hello-pear-electron
+          - name: hello-pear-react-native
+            repo: holepunchto/hello-pear-react-native
+            pinned: 5c79f39dc9d65ac44c80a9ebab54f0d3f1ae1696
+            path: examples/getting-started/hello-pear-react-native
           # The two hello-pear-bare variants live on long-lived non-default
           # branches, so they set `ref` explicitly. Without it the poll below
           # would compare a variant snapshot against `main`'s HEAD and file a

--- a/.github/workflows/watch-boilerplates.yml
+++ b/.github/workflows/watch-boilerplates.yml
@@ -1,8 +1,8 @@
 name: Watch boilerplate upstreams
 
-# The docs vendor read-only snapshots of the upstream example apps under
-# examples/ and import code from them with remark-code-import
-# (```js file=<rootDir>/examples/<path>/...). GitHub won't let
+# The docs vendor read-only snapshots of the hello-pear-* boilerplates under
+# examples/getting-started/ and import code from them with remark-code-import
+# (```js file=<rootDir>/examples/getting-started/<name>/...). GitHub won't let
 # us subscribe to another org's repo events, so instead of a true webhook
 # "watcher" this job polls each upstream's branch on a schedule (the default
 # branch, or `ref` where a snapshot tracks a non-default branch) and opens a
@@ -16,14 +16,9 @@ name: Watch boilerplate upstreams
 #
 # When you refresh a snapshot, bump the matching `pinned` SHA below AND the
 # snapshot's provenance record — that is the bespoke README for snapshots whose
-# README this repo authors, or SNAPSHOT.md for snapshots that vendor upstream's
-# own README verbatim (the hello-pear-bare variants). The next run sees no drift
-# and auto-closes the issue.
-#
-# NOTE: this workflow's `schedule` trigger only fires from the repository's
-# DEFAULT branch. While the default branch is `main` (which carries no
-# .github/workflows), the weekly poll never runs and drift must be checked by
-# hand or via workflow_dispatch from this branch.
+# README this repo authors (hello-pear-bare, hello-pear-electron), or SNAPSHOT.md
+# for snapshots that vendor upstream's own README verbatim (the variants). The
+# next run sees no drift and auto-closes the issue.
 
 on:
   schedule:

--- a/.github/workflows/watch-boilerplates.yml
+++ b/.github/workflows/watch-boilerplates.yml
@@ -51,6 +51,10 @@ jobs:
             repo: holepunchto/hello-pear-react-native
             pinned: 5c79f39dc9d65ac44c80a9ebab54f0d3f1ae1696
             path: examples/getting-started/hello-pear-react-native
+          - name: snake-mobile
+            repo: holepunchto/snake-mobile
+            pinned: 87694ee010d4916f6d06800fa8b409082a67d6ad
+            path: examples/how-to/run-on-native/snake-mobile
           # The two hello-pear-bare variants live on long-lived non-default
           # branches, so they set `ref` explicitly. Without it the poll below
           # would compare a variant snapshot against `main`'s HEAD and file a

--- a/content/_snippets/_hello-pear-worker-source-callout.mdx
+++ b/content/_snippets/_hello-pear-worker-source-callout.mdx
@@ -1,0 +1,27 @@
+{/*
+  Shared snippet (content/_snippets/) included via Fumadocs <include> by every
+  "Start from a template" page under a page-authored "## Where the app logic
+  goes" heading. Inlines the hello-pear-worker source (via remark-code-import,
+  pointed at the canonical copy vendored for hello-pear-electron) and explains
+  it once—every hello-pear-* template's workers/main.js is the same
+  require('hello-pear-worker'), so the explanation is template-agnostic.
+  Do NOT vendor a second copy of workers/main.js for another template just to
+  reuse this text; point this snippet's file= import at the existing canonical
+  copy under examples/getting-started/hello-pear-electron/workers/main.js
+  instead. Note for editors: scripts/check-workers-in-sync.ts keeps every
+  vendored workers/main.js copy across the examples tree byte-identical to
+  that one (avoid writing the two-character close-comment sequence when
+  describing that glob—it prematurely ends this very comment block).
+  See: https://www.fumadocs.dev/docs/markdown#include
+*/}
+
+Everything peer-to-peer lives in `workers/main.js`, which runs in Bare (not Node). The host passes the runtime configuration as positional arguments; the worker reads them (with an `argv` helper for cross-platform compatibility) and constructs the [`pear-runtime`](/reference/pear/runtime) instance:
+
+```js file=<rootDir>/examples/getting-started/hello-pear-electron/workers/main.js#L15-L27 title="workers/main.js"
+```
+
+This is where you add your [Corestore](/reference/helpers/corestore) cores, join [Hyperswarm](/reference/building-blocks/hyperswarm) topics, and run your protocols. Use `pear.storage` as the storage root so your data lands in the same per-app directory Pear manages—see [Storage and distribution](/explanation/storage-and-distribution). For why the logic belongs in a worker rather than the UI, see [Workers](/explanation/workers).
+
+<Callout type="info">
+Upstream now ships this worker as the [`hello-pear-worker`](https://github.com/holepunchto/hello-pear-worker) package—the template's `workers/main.js` is just `require('hello-pear-worker')`. The code above is that worker inlined so you can see what it does; write your own peer-to-peer logic in `workers/main.js` the same way.
+</Callout>

--- a/content/_snippets/_hello-pear-worker-source-callout.mdx
+++ b/content/_snippets/_hello-pear-worker-source-callout.mdx
@@ -1,6 +1,8 @@
 {/*
-  Shared snippet included via <include> by every "Start from a template" page,
-  under a page-authored "## Where the app logic goes" heading—every
+  Shared snippet included via <include> by the hello-pear-electron and
+  hello-pear-react-native template pages, under a page-authored
+  "## Where the app logic goes" heading. (The hello-pear-bare page carries
+  its own shorter Callout instead and has no such section.) Every
   hello-pear-* template's workers/main.js is the same require('hello-pear-worker'),
   so this explanation is template-agnostic. Don't vendor a second copy of
   workers/main.js elsewhere for this; the file= import below points at the

--- a/content/_snippets/_hello-pear-worker-source-callout.mdx
+++ b/content/_snippets/_hello-pear-worker-source-callout.mdx
@@ -1,18 +1,11 @@
 {/*
-  Shared snippet (content/_snippets/) included via Fumadocs <include> by every
-  "Start from a template" page under a page-authored "## Where the app logic
-  goes" heading. Inlines the hello-pear-worker source (via remark-code-import,
-  pointed at the canonical copy vendored for hello-pear-electron) and explains
-  it once—every hello-pear-* template's workers/main.js is the same
-  require('hello-pear-worker'), so the explanation is template-agnostic.
-  Do NOT vendor a second copy of workers/main.js for another template just to
-  reuse this text; point this snippet's file= import at the existing canonical
-  copy under examples/getting-started/hello-pear-electron/workers/main.js
-  instead. Note for editors: scripts/check-workers-in-sync.ts keeps every
-  vendored workers/main.js copy across the examples tree byte-identical to
-  that one (avoid writing the two-character close-comment sequence when
-  describing that glob—it prematurely ends this very comment block).
-  See: https://www.fumadocs.dev/docs/markdown#include
+  Shared snippet included via <include> by every "Start from a template" page,
+  under a page-authored "## Where the app logic goes" heading—every
+  hello-pear-* template's workers/main.js is the same require('hello-pear-worker'),
+  so this explanation is template-agnostic. Don't vendor a second copy of
+  workers/main.js elsewhere for this; the file= import below points at the
+  one canonical copy under hello-pear-electron, kept in sync across the
+  examples tree by scripts/check-workers-in-sync.ts.
 */}
 
 Everything peer-to-peer lives in `workers/main.js`, which runs in Bare (not Node). The host passes the runtime configuration as positional arguments; the worker reads them (with an `argv` helper for cross-platform compatibility) and constructs the [`pear-runtime`](/reference/pear/runtime) instance:

--- a/content/getting-started/from-a-template/index.mdx
+++ b/content/getting-started/from-a-template/index.mdx
@@ -1,16 +1,17 @@
 ---
 title: "Start from a template"
 description: >-
-  Two official Pear boilerplates to start from—hello-pear-electron for desktop
-  GUI apps and hello-pear-bare for standalone terminal binaries, both with
-  peer-to-peer over-the-air updates. Pick the one that matches what you're shipping.
+  Three official Pear boilerplates to start from—hello-pear-electron for desktop
+  GUI apps, hello-pear-bare for standalone terminal binaries, and
+  hello-pear-react-native for mobile apps—all with peer-to-peer over-the-air
+  updates. Pick the one that matches what you're shipping.
 docType: getting-started
 schemaType: TechArticle
 ---
 
 import { Cards, Card } from 'fumadocs-ui/components/card'
 
-The fastest way to a production-shaped app is to clone an official boilerplate and learn where each piece lives. Both embed [`pear-runtime`](/reference/pear/runtime) for peer-to-peer over-the-air updates—pick the one that matches what you're shipping.
+The fastest way to a production-shaped app is to clone an official boilerplate and learn where each piece lives. All three embed a `pear-runtime`-family module for peer-to-peer over-the-air updates—pick the one that matches what you're shipping.
 
 <include>../../_snippets/_interactive-menu-callout.mdx</include>
 
@@ -25,17 +26,23 @@ The fastest way to a production-shaped app is to clone an official boilerplate a
     title="hello-pear-bare (terminal)"
     description="A standalone Bare executable: CLIs, daemons, and tools with no GUI and no peer dependencies."
   />
+  <Card
+    href="/getting-started/from-a-template/start-from-hello-pear-react-native"
+    title="hello-pear-react-native (mobile)"
+    description="An Expo/React Native app: a Bare worklet embedded via pear-mobile, with the same over-the-air updates. The mobile counterpart to hello-pear-electron."
+  />
 </Cards>
 
 ## Which one?
 
 - **Building a desktop GUI?** Start from [hello-pear-electron](/getting-started/from-a-template/start-from-hello-pear-electron)—it ships a renderer and the preload bridge that connects your UI to peer-to-peer logic in a Bare worker.
 - **Building a CLI, daemon, or other headless tool?** Start from [hello-pear-bare](/getting-started/from-a-template/start-from-hello-pear-bare)—it compiles to a single standalone binary per OS and architecture.
+- **Building a mobile app?** Start from [hello-pear-react-native](/getting-started/from-a-template/start-from-hello-pear-react-native)—it embeds a Bare worklet in an Expo/React Native app via [`pear-mobile`](/reference/pear/mobile).
 
-Both share the same peer-to-peer core: the [Bare](/reference/modules/bare-modules) runtime, [`pear-runtime`](/reference/pear/runtime) for updates, and the [Hyperswarm](/reference/building-blocks/hyperswarm) + [Corestore](/reference/helpers/corestore) stack. Your peer-to-peer logic is portable between them—only the shell (GUI versus terminal) changes. See [Runtime and languages](/explanation/runtime-and-languages).
+All three share the same peer-to-peer core: the [Bare](/reference/modules/bare-modules) runtime, a `pear-runtime`-family module for updates ([`pear-runtime`](/reference/pear/runtime) on desktop, [`pear-mobile`](/reference/pear/mobile) on mobile), and the [Hyperswarm](/reference/building-blocks/hyperswarm) + [Corestore](/reference/helpers/corestore) stack. Your peer-to-peer logic is portable between them—only the shell (GUI, terminal, or mobile) changes. See [Runtime and languages](/explanation/runtime-and-languages).
 
 <Callout type="info">
-Once you've cloned a template and made it yours, ship it over the air: [Deploy your application](/how-to/operate-an-app/manual-deployment/deployment) is the step-by-step release flow, and [Release pipeline](/explanation/deployment-releasing-apps-p2p) explains the stage → provision → multisig model behind it.
+Once you've cloned a template and made it yours, ship it over the air. For desktop and terminal, [Deploy your application](/how-to/operate-an-app/manual-deployment/deployment) is the step-by-step release flow, and [Release pipeline](/explanation/deployment-releasing-apps-p2p) explains the stage → provision → multisig model behind it. Mobile shares that stage/provision/multisig model but builds a different payload—see [Pear Mobile OTA](/reference/pear/mobile#the-minver-gate) and the [hello-pear-react-native README](https://github.com/holepunchto/hello-pear-react-native#deployments).
 </Callout>
 
 ## Where to go next

--- a/content/getting-started/from-a-template/start-from-hello-pear-bare.mdx
+++ b/content/getting-started/from-a-template/start-from-hello-pear-bare.mdx
@@ -245,7 +245,7 @@ Before you ship, set your identity in `package.json`:
 
 ## Where to go next
 
-- [Start from a template](/getting-started/from-a-template)—both boilerplates, side by side.
+- [Start from a template](/getting-started/from-a-template)—all three boilerplates, side by side.
 - [Start from the hello-pear-electron template](/getting-started/from-a-template/start-from-hello-pear-electron)—the desktop counterpart, with a renderer, preload bridge, and Bare worker.
 - [Inside Bare](/explanation/bare-runtime)—what the runtime this template builds on actually is, and its lifecycle.
 - [How Pear and Bare fit together](/explanation/pear-and-bare)—where Bare and Pear sit relative to each other.

--- a/content/getting-started/from-a-template/start-from-hello-pear-electron.mdx
+++ b/content/getting-started/from-a-template/start-from-hello-pear-electron.mdx
@@ -111,16 +111,7 @@ The full production bridge—including how `window.bridge` is assembled—is wal
 
 ## Where the app logic goes
 
-Everything peer-to-peer lives in `workers/main.js`, which runs in Bare (not Node). The host passes the runtime configuration as positional arguments; the worker reads them (with an `argv` helper for cross-platform compatibility) and constructs the [`pear-runtime`](/reference/pear/runtime) instance:
-
-```js file=<rootDir>/examples/getting-started/hello-pear-electron/workers/main.js#L15-L27 title="workers/main.js"
-```
-
-This is where you add your [Corestore](/reference/helpers/corestore) cores, join [Hyperswarm](/reference/building-blocks/hyperswarm) topics, and run your protocols. Use `pear.storage` as the storage root so your data lands in the same per-app directory Pear manages—see [Storage and distribution](/explanation/storage-and-distribution). For why the logic belongs here rather than in the renderer, see [Workers](/explanation/workers).
-
-<Callout type="info">
-Upstream now ships this worker as the [`hello-pear-worker`](https://github.com/holepunchto/hello-pear-worker) package—the template's `workers/main.js` is just `require('hello-pear-worker')`. The code above is that worker inlined so you can see what it does; write your own peer-to-peer logic in `workers/main.js` the same way.
-</Callout>
+<include>../../_snippets/_hello-pear-worker-source-callout.mdx</include>
 
 ## How to connect them
 
@@ -233,7 +224,7 @@ Then build and release with [Build desktop distributables](/how-to/operate-an-ap
 - [Pear desktop application architecture](/explanation/pear-desktop-architecture)—the conceptual model behind the renderer/main/worker split.
 - [Workers](/explanation/workers)—why peer-to-peer logic lives in a Bare worker and where the boundary should sit.
 - [Reshape into a production app](/getting-started/build-a-peer-to-peer-chat/reshape-into-a-production-app)—the hello-pear-electron-shaped scaffold with an [Autobase](/reference/building-blocks/autobase)-backed room, blind-pairing invites, and a vanilla HTML renderer.
-- [Start from a template](/getting-started/from-a-template)—both boilerplates, side by side.
+- [Start from a template](/getting-started/from-a-template)—all three boilerplates, side by side.
 - [Start from the hello-pear-bare template](/getting-started/from-a-template/start-from-hello-pear-bare)—the terminal counterpart: a standalone Bare CLI with OTA updates and no GUI.
 - [Publish with GitHub Actions](/how-to/operate-an-app/github-actions/publish-with-github-actions)—stage a stable `pear://` link on every push with the `pear-ci` action.
 - [Build and sign desktop apps in CI](/how-to/operate-an-app/github-actions/build-and-sign-in-ci)—build, sign, and notarize macOS, Windows, and Linux distributables on hosted runners.

--- a/content/getting-started/from-a-template/start-from-hello-pear-react-native.mdx
+++ b/content/getting-started/from-a-template/start-from-hello-pear-react-native.mdx
@@ -159,4 +159,4 @@ Before you ship:
 - [Type a native RPC bridge](/how-to/run-on-native/type-a-native-rpc-bridge)—replace raw IPC strings with a typed, schema-generated seam.
 - [Bundle a Bare app](/how-to/run-on-native/bundle-a-bare-app)—more on the `bare-pack` step behind `npm run bundle:bare`.
 
-For a real app extending this template, see [`holepunchto/snake-mobile`](https://github.com/holepunchto/snake-mobile)—a production-shaped P2P multiplayer game built on `hello-pear-react-native`. Its worker keeps its own custom Hyperswarm protocol in `workers/main.js` instead of `hello-pear-worker`, layered on the same updater scaffolding—worth reading if you're about to add real peer-to-peer logic of your own.
+For a real app extending this template, see [Add custom peer-to-peer logic to a React Native app](/how-to/run-on-native/add-custom-p2p-logic-to-a-react-native-app)—it walks through [`holepunchto/snake-mobile`](https://github.com/holepunchto/snake-mobile), a production-shaped P2P multiplayer game built on `hello-pear-react-native`. Its worker keeps its own custom Hyperswarm protocol in `workers/main.js` instead of `hello-pear-worker`, layered on the same updater scaffolding.

--- a/content/getting-started/from-a-template/start-from-hello-pear-react-native.mdx
+++ b/content/getting-started/from-a-template/start-from-hello-pear-react-native.mdx
@@ -1,0 +1,161 @@
+---
+title: "Start from the hello-pear-react-native template"
+description: >-
+  An alternative getting started path: clone the hello-pear-react-native
+  boilerplate and learn where the React Native view lives, where the app
+  logic lives, and how pear-mobile wires a Bare worklet and over-the-air
+  updates into an Expo app.
+docType: getting-started
+schemaType: TechArticle
+---
+
+This is the mobile counterpart to [Start from the hello-pear-electron template](/getting-started/from-a-template/start-from-hello-pear-electron). Instead of an Electron window, you start from a finished Expo/React Native boilerplate and learn where your view lives, where your peer-to-peer logic lives, and how [`pear-mobile`](/reference/pear/mobile) connects them.
+
+[`holepunchto/hello-pear-react-native`](https://github.com/holepunchto/hello-pear-react-native) is Holepunch's official React Native template—end-to-end boilerplate for embedding [`pear-mobile`](/reference/pear/mobile) into an Expo app and deploying peer-to-peer application updates. It's a clone-first tour, the same shape as the [hello-pear-electron](/getting-started/from-a-template/start-from-hello-pear-electron) tour: where to put your UI, where to put your peer-to-peer logic, and how the two talk.
+
+This is a different page from [Embed Bare in a React Native app](/how-to/run-on-native/embed-bare-in-react-native). That how-to shows the raw [`bare-kit`](/reference/bare/bare-kit) primitive—a `Worklet` and an `IPC` channel, nothing else. This page is the production-shaped template built on top of it: over-the-air updates, application storage, and a staged deployment pipeline, the mobile equivalent of what `hello-pear-electron`'s page is to the desktop primitives.
+
+<Callout type="warn">
+Both `hello-pear-react-native` and the [`pear-mobile`](/reference/pear/mobile) module it embeds are MVP and experimental—expect the API to keep moving.
+</Callout>
+
+<include>../../_snippets/_install-pear-cli-callout.mdx</include>
+
+<include>../../_snippets/_interactive-menu-callout.mdx</include>
+
+## Clone and run
+
+### 1. Clone the repository
+
+Clone the repository and install dependencies with the following commands:
+
+```bash
+git clone https://github.com/holepunchto/hello-pear-react-native
+cd hello-pear-react-native
+npm install
+```
+
+### 2. Create a valid `upgrade` link
+
+The committed `upgrade` field is the placeholder `pear://<YOUR_KEY_HERE>`. Create a real link with [`pear touch`](/reference/pear/cli#pear-touch-flags):
+
+```bash
+pear touch
+```
+
+This prints a link, for example: `pear://qxenz5wmspmryjc13m9yzsqj1conqotn8fb4ocbufwtz9mtbqq5o`. Set it in `package.json`:
+
+```json
+"upgrade": "pear://qxenz5wmspmryjc13m9yzsqj1conqotn8fb4ocbufwtz9mtbqq5o"
+```
+
+### 3. Bundle the worker
+
+Unlike the desktop templates, mobile has one extra step before the app can run. Pack the Bare worker into a worklet bundle with [`bare-pack`](https://github.com/holepunchto/bare-pack):
+
+```bash
+npm run bundle:bare
+```
+
+This writes `src/worker.bundle.js`, imported directly by `src/App.tsx`. Rerun it after every change to `workers/main.js` or a package it imports—nothing rebuilds it automatically, and a stale bundle fails **silently**: the app still boots and looks normal, it's just running old worker code.
+
+### 4. Run the app
+
+```bash
+npm run ios
+# or
+npm run android
+```
+
+<Callout type="info">
+Both scripts run `scripts/check-upgrade.js` first, which parses `package.json`'s `upgrade` field with [`pear-link`](https://github.com/holepunchto/pear-link) and refuses to launch on an invalid link—so a leftover placeholder fails fast with a clear message instead of silently killing the worklet at startup. Requires Xcode ≥ 26.2 for iOS (iOS ≥ 15.1) and Android ≥ API 29.
+</Callout>
+
+Development builds always load JavaScript from Metro, so the update path itself isn't exercised. Use the release variants for that:
+
+```bash
+npm run production:ios
+npm run production:android
+```
+
+## Map the template
+
+| Path | What it is | Do you edit it? |
+| --- | --- | --- |
+| [`src/App.tsx`](https://github.com/holepunchto/hello-pear-react-native/blob/main/src/App.tsx) | The frontend—starts the worklet, wires the update UI. | Yes—this is your UI. |
+| [`workers/main.js`](https://github.com/holepunchto/hello-pear-react-native/blob/main/workers/main.js) | The app logic—a [Bare](/reference/modules/bare-modules) worker that owns the swarm, storage, and updater. | Yes—this is your backend. |
+| [`package.json`](https://github.com/holepunchto/hello-pear-react-native/blob/main/package.json) | App metadata, scripts, and the `upgrade` link. | Yes—branding and release link. |
+| [`pear.json`](https://github.com/holepunchto/hello-pear-react-native/blob/main/pear.json) | The `updates.minver` compatibility floor and multisig config placeholder for production. | At production time. |
+| [`app.json`](https://github.com/holepunchto/hello-pear-react-native/blob/main/app.json) | Expo config—icons, bundle identifiers, and the `pear-runtime-react-native` config plugin registration. | Yes—brand assets and platform identifiers. |
+| [`metro.config.js`](https://github.com/holepunchto/hello-pear-react-native/blob/main/metro.config.js) | Merges the React Native and Expo Metro defaults, used to produce OTA payloads. | Rarely. |
+| [`scripts/check-upgrade.js`](https://github.com/holepunchto/hello-pear-react-native/blob/main/scripts/check-upgrade.js) | Validates `package.json#upgrade` before `npm run ios`/`android` hand off to Expo. | Rarely. |
+
+The two pieces you care about day to day are `src/App.tsx` (view) and `workers/main.js` (logic).
+
+## How the pieces connect
+
+```mermaid
+flowchart LR
+  app["src/App.tsx (React Native view)"] <-->|"PearRuntime.run() + FramedStream IPC"| worker["workers/main.js (Bare worklet, via bare-kit)"]
+  worker --> stack["Hyperswarm + Corestore + updater"]
+```
+
+Desktop's `hello-pear-electron` splits into three processes—renderer, Electron main, and Bare worker—connected by a preload bridge and an IPC proxy. Mobile collapses that into two: the React Native view starts the worklet directly and talks to it over one IPC duplex. There's no separate main process to proxy through.
+
+## Where the frontend goes
+
+Your UI lives in `src/App.tsx`. On mount, it starts the worklet with [`PearRuntime.run`](/reference/pear/mobile#starting-the-worklet-react-native-side) and wraps its `IPC` in a [`FramedStream`](https://www.npmjs.com/package/framed-stream):
+
+```js file=<rootDir>/examples/getting-started/hello-pear-react-native/src/App.tsx#L24-L30 title="src/App.tsx"
+```
+
+There is no framework requirement beyond Expo/React Native itself—the template ships plain `View`/`Text`/`Pressable`, but bring your own component library. The only rule is: your UI reaches the peer-to-peer core **only** through this one IPC pipe.
+
+## Where the app logic goes
+
+<include>../../_snippets/_hello-pear-worker-source-callout.mdx</include>
+
+This is the *same* worker every `hello-pear-*` template uses—see [One core, many platforms](/explanation/bare-on-native) for why that portability is the point. On mobile, `hello-pear-worker`'s own `require('pear-runtime')` resolves to [`pear-mobile`](/reference/pear/mobile) instead of the desktop package; nothing in `workers/main.js` itself has to change. Remember to re-run [`npm run bundle:bare`](#3-bundle-the-worker) after editing it.
+
+## How to connect them
+
+There's no bridge or preload layer here—`src/App.tsx` talks to the worker directly over the `FramedStream`-framed pipe, in plain strings:
+
+| Direction | Message | Meaning |
+| --- | --- | --- |
+| view → worker | `pear:applyUpdate` | Apply a downloaded update and report back. |
+| worker → view | `updating` | An update started downloading. |
+| worker → view | `updated` | The update is staged; ready to apply. |
+| worker → view | `minver-required` | The available update needs a newer native build—see [the `minver` gate](/reference/pear/mobile#the-minver-gate). Mobile-only; desktop has no equivalent. |
+| worker → view | `pear:updateApplied` | Reply once `applyUpdate()` has finished. |
+
+## Mobile-only concerns
+
+<Callout type="info">
+**Worklet lifecycle.** The worklet must stop active I/O when the app is backgrounded or the OS force-terminates it. See [Handle app suspension](/how-to/run-on-native/handle-app-suspension) for the suspend/resume patterns.
+</Callout>
+
+<Callout type="info">
+**OTA differs from desktop.** A mobile OTA payload is a JavaScript bundle per host, not a set of native distributables, and native/OTA releases share one SemVer sequence gated by `pear.json`'s `updates.minver`—see [Pear Mobile OTA](/reference/pear/mobile#the-minver-gate). The full staging, provisioning, and multisig ceremony is documented in the upstream [`hello-pear-react-native` README](https://github.com/holepunchto/hello-pear-react-native#deployments)—it reuses [Deploy your application](/how-to/operate-an-app/manual-deployment/deployment)'s model but with a different build step, so that page's distributables flow doesn't apply here verbatim.
+</Callout>
+
+## Customize for your brand
+
+Before you ship:
+
+- `package.json`—set `name`, `productName`, `version`, and the `upgrade` `pear://` link.
+- `app.json`—replace the icons and splash assets, and set `ios.bundleIdentifier` and `android.package`.
+- `pear.json`—set `updates.minver` whenever a release changes the native/OTA contract (see [the `minver` gate](/reference/pear/mobile#the-minver-gate)), and fill the multisig placeholders at production time.
+
+## Where to go next
+
+- [Start from a template](/getting-started/from-a-template)—all three boilerplates, side by side.
+- [Start from the hello-pear-electron template](/getting-started/from-a-template/start-from-hello-pear-electron)—the desktop counterpart.
+- [Pear Mobile OTA](/reference/pear/mobile)—the full `pear-mobile` API this template embeds.
+- [Embed Bare in a React Native app](/how-to/run-on-native/embed-bare-in-react-native)—the raw `bare-kit` primitive this template builds on.
+- [One core, many platforms](/explanation/bare-on-native)—the pattern behind sharing `workers/main.js` across every template.
+- [Handle app suspension](/how-to/run-on-native/handle-app-suspension)—keep the worklet in step with the OS lifecycle.
+- [Type a native RPC bridge](/how-to/run-on-native/type-a-native-rpc-bridge)—replace raw IPC strings with a typed, schema-generated seam.
+- [Bundle a Bare app](/how-to/run-on-native/bundle-a-bare-app)—more on the `bare-pack` step behind `npm run bundle:bare`.
+
+For a real app extending this template, see [`holepunchto/snake-mobile`](https://github.com/holepunchto/snake-mobile)—a production-shaped P2P multiplayer game built on `hello-pear-react-native`. Its worker keeps its own custom Hyperswarm protocol in `workers/main.js` instead of `hello-pear-worker`, layered on the same updater scaffolding—worth reading if you're about to add real peer-to-peer logic of your own.

--- a/content/getting-started/from-a-template/start-from-hello-pear-react-native.mdx
+++ b/content/getting-started/from-a-template/start-from-hello-pear-react-native.mdx
@@ -68,7 +68,7 @@ npm run android
 ```
 
 <Callout type="info">
-Both scripts run `scripts/check-upgrade.js` first, which parses `package.json`'s `upgrade` field with [`pear-link`](https://github.com/holepunchto/pear-link) and refuses to launch on an invalid link—so a leftover placeholder fails fast with a clear message instead of silently killing the worklet at startup. Requires Xcode ≥ 26.2 for iOS (iOS ≥ 15.1) and Android ≥ API 29.
+Both scripts run `scripts/check-upgrade.js` first, which parses `package.json`'s `upgrade` field with [`pear-link`](https://github.com/holepunchto/pear-link) and refuses to launch on an invalid link—so a leftover placeholder fails fast with a clear message instead of silently killing the worklet at startup. Requires Node.js ≥ 20.19.4, plus Xcode ≥ 26.2 for iOS (iOS ≥ 15.1) and Android ≥ API 29.
 </Callout>
 
 Development builds always load JavaScript from Metro, so the update path itself isn't exercised. Use the release variants for that:
@@ -85,7 +85,7 @@ npm run production:android
 | [`src/App.tsx`](https://github.com/holepunchto/hello-pear-react-native/blob/main/src/App.tsx) | The frontend—starts the worklet, wires the update UI. | Yes—this is your UI. |
 | [`workers/main.js`](https://github.com/holepunchto/hello-pear-react-native/blob/main/workers/main.js) | The app logic—a [Bare](/reference/modules/bare-modules) worker that owns the swarm, storage, and updater. | Yes—this is your backend. |
 | [`package.json`](https://github.com/holepunchto/hello-pear-react-native/blob/main/package.json) | App metadata, scripts, and the `upgrade` link. | Yes—branding and release link. |
-| [`pear.json`](https://github.com/holepunchto/hello-pear-react-native/blob/main/pear.json) | The `updates.minver` compatibility floor and multisig config placeholder for production. | At production time. |
+| [`pear.json`](https://github.com/holepunchto/hello-pear-react-native/blob/main/pear.json) | The `updates.minver` compatibility floor. Ships inside every OTA payload, so a `multisig` block added here travels with it. | At production time. |
 | [`app.json`](https://github.com/holepunchto/hello-pear-react-native/blob/main/app.json) | Expo config—icons, bundle identifiers, and the `pear-runtime-react-native` config plugin registration. | Yes—brand assets and platform identifiers. |
 | [`metro.config.js`](https://github.com/holepunchto/hello-pear-react-native/blob/main/metro.config.js) | Merges the React Native and Expo Metro defaults, used to produce OTA payloads. | Rarely. |
 | [`scripts/check-upgrade.js`](https://github.com/holepunchto/hello-pear-react-native/blob/main/scripts/check-upgrade.js) | Validates `package.json#upgrade` before `npm run ios`/`android` hand off to Expo. | Rarely. |
@@ -124,6 +124,7 @@ There's no bridge or preload layer here—`src/App.tsx` talks to the worker dire
 | Direction | Message | Meaning |
 | --- | --- | --- |
 | view → worker | `pear:applyUpdate` | Apply a downloaded update and report back. |
+| worker → view | `Hello from worker` | Sent once when the worker comes up. The template's view ignores it; it's there as a liveness check you can hook. |
 | worker → view | `updating` | An update started downloading. |
 | worker → view | `updated` | The update is staged; ready to apply. |
 | worker → view | `minver-required` | The available update needs a newer native build—see [the `minver` gate](/reference/pear/mobile#the-minver-gate). Mobile-only; desktop has no equivalent. |
@@ -145,7 +146,7 @@ Before you ship:
 
 - `package.json`—set `name`, `productName`, `version`, and the `upgrade` `pear://` link.
 - `app.json`—replace the icons and splash assets, and set `ios.bundleIdentifier` and `android.package`.
-- `pear.json`—set `updates.minver` whenever a release changes the native/OTA contract (see [the `minver` gate](/reference/pear/mobile#the-minver-gate)), and fill the multisig placeholders at production time.
+- `pear.json`—set `updates.minver` whenever a release changes the native/OTA contract (see [the `minver` gate](/reference/pear/mobile#the-minver-gate)). The template ships this file with `updates.minver` only; add a `multisig` block at production time, and note that editing it derives a different production key while editing `minver` does not.
 
 ## Where to go next
 

--- a/content/how-to/index.mdx
+++ b/content/how-to/index.mdx
@@ -12,7 +12,7 @@ If you want to look up a CLI flag, an API, or a config field, that's **[Referenc
 
 ## Start here
 
-Many recipes below build on one of two starting points. Chat-focused guides extend the **`pear-chat` scaffold** (Electron shell, Bare worker, [Autobase](/reference/building-blocks/autobase)-backed chat room) built step by step in the **[Getting Started](/getting-started)** path—see [Reshape into a production app](/getting-started/build-a-peer-to-peer-chat/reshape-into-a-production-app). Guides that don't need chat start from one of the boilerplates in **[Start from a template](/getting-started/from-a-template)**—desktop ([`hello-pear-electron`](/getting-started/from-a-template/start-from-hello-pear-electron)) or terminal ([`hello-pear-bare`](/getting-started/from-a-template/start-from-hello-pear-bare)). Each guide states its base up front. If you're new, work through Getting Started first so you understand each piece before adapting it.
+Many recipes below build on one of two starting points. Chat-focused guides extend the **`pear-chat` scaffold** (Electron shell, Bare worker, [Autobase](/reference/building-blocks/autobase)-backed chat room) built step by step in the **[Getting Started](/getting-started)** path—see [Reshape into a production app](/getting-started/build-a-peer-to-peer-chat/reshape-into-a-production-app). Guides that don't need chat start from one of the boilerplates in **[Start from a template](/getting-started/from-a-template)**—desktop ([`hello-pear-electron`](/getting-started/from-a-template/start-from-hello-pear-electron)), terminal ([`hello-pear-bare`](/getting-started/from-a-template/start-from-hello-pear-bare)), or mobile ([`hello-pear-react-native`](/getting-started/from-a-template/start-from-hello-pear-react-native)). Each guide states its base up front. If you're new, work through Getting Started first so you understand each piece before adapting it.
 
 ## In this section
 
@@ -56,6 +56,7 @@ Several guides below extend a base scaffold—either the `pear-chat` app from th
 ### Run on mobile & native
 
 - [Embed Bare in a React Native app](/how-to/run-on-native/embed-bare-in-react-native)
+- [Add custom peer-to-peer logic to a React Native app](/how-to/run-on-native/add-custom-p2p-logic-to-a-react-native-app)
 - [Type a native RPC bridge](/how-to/run-on-native/type-a-native-rpc-bridge)
 - [Bundle a Bare app](/how-to/run-on-native/bundle-a-bare-app)
 

--- a/content/how-to/run-on-native/add-custom-p2p-logic-to-a-react-native-app.mdx
+++ b/content/how-to/run-on-native/add-custom-p2p-logic-to-a-react-native-app.mdx
@@ -63,9 +63,9 @@ The updater swarm from `hello-pear-worker` stays exactly as-is. Alongside it, op
 
 ### Serialize join and leave
 
-Only one game topic is ever joined at a time, and a fast leave-then-join from the UI must not race two discovery sessions for the same topic. `enqueue` chains every `joinGame`/`leaveGame` call onto one promise so they always run in order:
+Only one game topic is ever joined at a time, and a fast leave-then-join from the UI must not race two discovery sessions for the same topic. `enqueue` chains every `joinGame`/`leaveGame` call onto one promise so they always run in order. `send` is the matching helper for the other direction—every worker-to-view message in this guide goes through it:
 
-```js file=<rootDir>/examples/how-to/run-on-native/snake-mobile/workers/main.custom.js#L56-L62 title="workers/main.js" skip="example-import"
+```js file=<rootDir>/examples/how-to/run-on-native/snake-mobile/workers/main.custom.js#L56-L66 title="workers/main.js" skip="example-import"
 ```
 
 The two functions it serializes:
@@ -83,12 +83,12 @@ The comment on `leaveGame` matters: Hyperswarm keeps connections open across `le
 
 `hello-pear-worker` speaks plain strings (`'updating'`, `'pear:applyUpdate'`, ...). A custom worker is free to speak whatever it wants over the same `FramedStream`-framed pipe—here, small JSON envelopes with a `type` field:
 
+```js file=<rootDir>/examples/how-to/run-on-native/snake-mobile/workers/main.custom.js#L120-L146 title="workers/main.js" skip="example-import"
+```
+
 <Callout type="info">
 Hand-rolled envelopes like these are worth reaching for only while the protocol is small. Once it grows past a handful of messages, [`hrpc`](https://www.npmjs.com/package/hrpc) generates typed methods for both ends from one schema instead—see [Structured RPC over IPC](/explanation/workers#structured-rpc-over-ipc). It rides any duplex stream, including this worklet pipe.
 </Callout>
-
-```js file=<rootDir>/examples/how-to/run-on-native/snake-mobile/workers/main.custom.js#L120-L146 title="workers/main.js" skip="example-import"
-```
 
 The full message set, extending the plain template's table:
 

--- a/content/how-to/run-on-native/add-custom-p2p-logic-to-a-react-native-app.mdx
+++ b/content/how-to/run-on-native/add-custom-p2p-logic-to-a-react-native-app.mdx
@@ -36,7 +36,7 @@ flowchart LR
 ```js file=<rootDir>/examples/how-to/run-on-native/snake-mobile/workers/main.custom.js#L1 title="workers/main.js" skip="example-import"
 ```
 
-snake-mobile's `package.json` still carries a copy of the same `imports` block `hello-pear-worker` uses, left over from before this worker was written—but nothing here requires the bare specifier `pear-runtime` that it remaps, so the field is inert. Don't copy it into a mobile-only worker; requiring `pear-mobile` directly is simpler and is what this worker actually does.
+snake-mobile's `package.json` carries a copy of the same `imports` block `hello-pear-worker` uses, but nothing in this app requires the bare specifier `pear-runtime` that it remaps, so the field has no effect here. Don't copy it into a mobile-only worker; requiring `pear-mobile` directly is simpler and is what this worker actually does.
 </Callout>
 
 <Steps>
@@ -45,9 +45,14 @@ snake-mobile's `package.json` still carries a copy of the same `imports` block `
 
 ### Add a second Hyperswarm for the game topic
 
-The updater swarm from `hello-pear-worker` stays exactly as-is. Alongside it, open a second `Hyperswarm` for the actual multiplayer topic, and gate its connection handler on whether a game is currently joined—a peer connecting before anyone has created or joined one gets dropped immediately rather than left dangling:
+The updater swarm from `hello-pear-worker` stays exactly as-is. Alongside it, open a second `Hyperswarm` for the actual multiplayer topic, plus a `joined` variable holding the current topic:
 
-```js file=<rootDir>/examples/how-to/run-on-native/snake-mobile/workers/main.custom.js#L68-L75 title="workers/main.js" skip="example-import"
+```js file=<rootDir>/examples/how-to/run-on-native/snake-mobile/workers/main.custom.js#L49-L54 title="workers/main.js" skip="example-import"
+```
+
+`joined` doubles as a gate on the connection handler: a peer that connects before anyone has created or joined a game is dropped immediately rather than left dangling. Everything after that gate is the per-peer wiring that forwards traffic to the view:
+
+```js file=<rootDir>/examples/how-to/run-on-native/snake-mobile/workers/main.custom.js#L68-L90 title="workers/main.js" skip="example-import"
 ```
 
 `joined` is `null` until [`joinGame`](#serialize-join-and-leave) sets it, and back to `null` once [`leaveGame`](#serialize-join-and-leave) runs—so this same check also rejects any peer that reconnects mid-leave.
@@ -59,6 +64,11 @@ The updater swarm from `hello-pear-worker` stays exactly as-is. Alongside it, op
 ### Serialize join and leave
 
 Only one game topic is ever joined at a time, and a fast leave-then-join from the UI must not race two discovery sessions for the same topic. `enqueue` chains every `joinGame`/`leaveGame` call onto one promise so they always run in order:
+
+```js file=<rootDir>/examples/how-to/run-on-native/snake-mobile/workers/main.custom.js#L56-L62 title="workers/main.js" skip="example-import"
+```
+
+The two functions it serializes:
 
 ```js file=<rootDir>/examples/how-to/run-on-native/snake-mobile/workers/main.custom.js#L96-L118 title="workers/main.js" skip="example-import"
 ```
@@ -72,6 +82,10 @@ The comment on `leaveGame` matters: Hyperswarm keeps connections open across `le
 ### Extend the protocol
 
 `hello-pear-worker` speaks plain strings (`'updating'`, `'pear:applyUpdate'`, ...). A custom worker is free to speak whatever it wants over the same `FramedStream`-framed pipe—here, small JSON envelopes with a `type` field:
+
+<Callout type="info">
+Hand-rolled envelopes like these are worth reaching for only while the protocol is small. Once it grows past a handful of messages, [`hrpc`](https://www.npmjs.com/package/hrpc) generates typed methods for both ends from one schema instead—see [Structured RPC over IPC](/explanation/workers#structured-rpc-over-ipc). It rides any duplex stream, including this worklet pipe.
+</Callout>
 
 ```js file=<rootDir>/examples/how-to/run-on-native/snake-mobile/workers/main.custom.js#L120-L146 title="workers/main.js" skip="example-import"
 ```
@@ -109,6 +123,7 @@ The `handleMessage` switch that sets `screen` from each incoming worker message�
 - [Start from the hello-pear-react-native template](/getting-started/from-a-template/start-from-hello-pear-react-native)—the template this guide extends.
 - [Pear Mobile OTA](/reference/pear/mobile)—the `pear-mobile` API the updater half still runs on.
 - [One core, many platforms](/explanation/bare-on-native)—why the worker's peer-to-peer logic is portable regardless of what protocol it speaks.
-- [Type a native RPC bridge](/how-to/run-on-native/type-a-native-rpc-bridge)—a typed, schema-generated alternative to hand-rolled JSON messages like the ones here.
+- [Structured RPC over IPC](/explanation/workers#structured-rpc-over-ipc)—replacing these hand-rolled JSON envelopes with schema-generated typed methods once the protocol grows past a few messages.
+- [Type a native RPC bridge](/how-to/run-on-native/type-a-native-rpc-bridge)—the `bare-rpc` equivalent, for when one end is a native shell rather than JavaScript.
 - [Handle app suspension](/how-to/run-on-native/handle-app-suspension)—keep both Hyperswarm instances in step with the OS lifecycle.
 - [`holepunchto/snake-mobile`](https://github.com/holepunchto/snake-mobile)—the full app, including the game engine, screens, and UI this guide doesn't cover.

--- a/content/how-to/run-on-native/add-custom-p2p-logic-to-a-react-native-app.mdx
+++ b/content/how-to/run-on-native/add-custom-p2p-logic-to-a-react-native-app.mdx
@@ -1,0 +1,114 @@
+---
+title: "Add custom peer-to-peer logic to a React Native app"
+description: "Replace hello-pear-worker's plain-string updater protocol with your own JSON protocol and a second Hyperswarm topic, using the real snake-mobile game as the worked example."
+docType: how-to
+schemaType: TechArticle
+---
+
+import { Steps, Step } from 'fumadocs-ui/components/steps'
+
+This guide extends [Start from the hello-pear-react-native template](/getting-started/from-a-template/start-from-hello-pear-react-native)—read that first if you haven't; this page assumes the template is already running and picks up exactly where it leaves off, at `workers/main.js`.
+
+The worked example throughout is [`holepunchto/snake-mobile`](https://github.com/holepunchto/snake-mobile), a real P2P multiplayer snake game built on the template. Its worker does not use [`hello-pear-worker`](https://github.com/holepunchto/hello-pear-worker) at all—it ships a custom `workers/main.js` with a second [Hyperswarm](/reference/building-blocks/hyperswarm) topic and a small JSON protocol in place of the template's plain updater strings. That is exactly the shape most real apps end up in: keep the OTA half the template already gives you, and add your own swarm and protocol next to it.
+
+## What changes
+
+| Layer | Change |
+| --- | --- |
+| Worker (`workers/main.js`) | A second `Hyperswarm` (the game topic) joins `hello-pear-worker`'s single updater swarm; a JSON message protocol (`join`/`leave`/`send`/`applyUpdate` in, `ready`/`connected`/`disconnected`/`data`/`update`/... out) replaces the plain updater strings. |
+| View (`src/App.tsx`) | Routes between a setup screen, a loading screen, and a game screen based on worker messages, instead of rendering one screen with just an update banner. |
+| `package.json` | No `hello-pear-worker` dependency—`hyperswarm`, `corestore`, and `hypercore-crypto` are used directly. |
+
+Everything else is untouched: bundling with `bare-pack`, the updater swarm and drive, the `minver` gate, and where storage lives all work exactly as the template documents.
+
+```mermaid skip="architecture-diagram"
+flowchart LR
+  u1["hello-pear-worker: updater Hyperswarm"] --> d1["update drive"]
+  u2["snake-mobile worker: updater Hyperswarm"] --> d2["update drive"]
+  g["snake-mobile worker: game Hyperswarm"] --> peers((game peers))
+```
+
+## Require `pear-mobile` directly
+
+<Callout type="info">
+`hello-pear-worker` does `require('pear-runtime')` and relies on its own `package.json`'s conditional `imports` to redirect that specifier to [`pear-mobile`](/reference/pear/mobile) on iOS, Android, and simulator hosts—see [Where the app logic goes](/getting-started/from-a-template/start-from-hello-pear-react-native#where-the-app-logic-goes). A custom worker that only ever runs on mobile doesn't need that indirection:
+
+```js file=<rootDir>/examples/how-to/run-on-native/snake-mobile/workers/main.custom.js#L1 title="workers/main.js" skip="example-import"
+```
+
+snake-mobile's `package.json` still carries a copy of the same `imports` block `hello-pear-worker` uses, left over from before this worker was written—but nothing here requires the bare specifier `pear-runtime` that it remaps, so the field is inert. Don't copy it into a mobile-only worker; requiring `pear-mobile` directly is simpler and is what this worker actually does.
+</Callout>
+
+<Steps>
+
+<Step>
+
+### Add a second Hyperswarm for the game topic
+
+The updater swarm from `hello-pear-worker` stays exactly as-is. Alongside it, open a second `Hyperswarm` for the actual multiplayer topic, and gate its connection handler on whether a game is currently joined—a peer connecting before anyone has created or joined one gets dropped immediately rather than left dangling:
+
+```js file=<rootDir>/examples/how-to/run-on-native/snake-mobile/workers/main.custom.js#L68-L75 title="workers/main.js" skip="example-import"
+```
+
+`joined` is `null` until [`joinGame`](#serialize-join-and-leave) sets it, and back to `null` once [`leaveGame`](#serialize-join-and-leave) runs—so this same check also rejects any peer that reconnects mid-leave.
+
+</Step>
+
+<Step>
+
+### Serialize join and leave
+
+Only one game topic is ever joined at a time, and a fast leave-then-join from the UI must not race two discovery sessions for the same topic. `enqueue` chains every `joinGame`/`leaveGame` call onto one promise so they always run in order:
+
+```js file=<rootDir>/examples/how-to/run-on-native/snake-mobile/workers/main.custom.js#L96-L118 title="workers/main.js" skip="example-import"
+```
+
+The comment on `leaveGame` matters: Hyperswarm keeps connections open across `leave()`, so without the explicit `peer.destroy()` loop, peers from a game you've left keep streaming state at you—and rejoining that same topic later never re-emits `'connection'` for them, since the connection never actually closed.
+
+</Step>
+
+<Step>
+
+### Extend the protocol
+
+`hello-pear-worker` speaks plain strings (`'updating'`, `'pear:applyUpdate'`, ...). A custom worker is free to speak whatever it wants over the same `FramedStream`-framed pipe—here, small JSON envelopes with a `type` field:
+
+```js file=<rootDir>/examples/how-to/run-on-native/snake-mobile/workers/main.custom.js#L120-L146 title="workers/main.js" skip="example-import"
+```
+
+The full message set, extending the plain template's table:
+
+| Direction | Message | Meaning |
+| --- | --- | --- |
+| view → worker | `{ type: 'join', topic }` | Join a game (`topic` a hex string), or create one (`topic: null`). |
+| view → worker | `{ type: 'leave' }` | Leave the current game. |
+| view → worker | `{ type: 'send', data }` | Broadcast local game state to every connected peer. |
+| view → worker | `{ type: 'applyUpdate' }` | Apply a downloaded OTA update—same as the plain template. |
+| worker → view | `{ type: 'ready', id, topic }` | The swarm has flushed; the game can start. |
+| worker → view | `{ type: 'connected', id }` | A peer joined. |
+| worker → view | `{ type: 'disconnected', id }` | A peer dropped. |
+| worker → view | `{ type: 'data', id, payload }` | Game state from a peer. |
+| worker → view | `{ type: 'update', connections }` | The peer count changed. |
+| worker → view | `{ type: 'updating' }` / `{ type: 'updated' }` / `{ type: 'minverRequired', minver }` / `{ type: 'updateFailed', error }` / `{ type: 'updateApplied' }` | The same updater events the plain template sends as bare strings, now wrapped as typed messages so they can coexist with the game protocol on one pipe. |
+
+</Step>
+
+</Steps>
+
+## Route the view
+
+On the view side, the structural change from the plain template is routing between screens instead of rendering one screen with just an update banner. `screen` flips to `'game'` once a `ready` message arrives, and back to `'setup'` on leave:
+
+```js file=<rootDir>/examples/how-to/run-on-native/snake-mobile/src/App.tsx#L195-L218 title="src/App.tsx" skip="example-import"
+```
+
+The `handleMessage` switch that sets `screen` from each incoming worker message—and the `createGame`/`joinGame`/`leaveGame` functions that write the outgoing `join`/`leave` commands—are ordinary React state handling once the protocol above is in place; nothing about them is specific to Bare or Hyperswarm.
+
+## Where to go next
+
+- [Start from the hello-pear-react-native template](/getting-started/from-a-template/start-from-hello-pear-react-native)—the template this guide extends.
+- [Pear Mobile OTA](/reference/pear/mobile)—the `pear-mobile` API the updater half still runs on.
+- [One core, many platforms](/explanation/bare-on-native)—why the worker's peer-to-peer logic is portable regardless of what protocol it speaks.
+- [Type a native RPC bridge](/how-to/run-on-native/type-a-native-rpc-bridge)—a typed, schema-generated alternative to hand-rolled JSON messages like the ones here.
+- [Handle app suspension](/how-to/run-on-native/handle-app-suspension)—keep both Hyperswarm instances in step with the OS lifecycle.
+- [`holepunchto/snake-mobile`](https://github.com/holepunchto/snake-mobile)—the full app, including the game engine, screens, and UI this guide doesn't cover.

--- a/content/how-to/run-on-native/index.mdx
+++ b/content/how-to/run-on-native/index.mdx
@@ -12,6 +12,7 @@ Recipes for running Bare peer-to-peer logic inside mobile and native shells.
 
 <Cards>
   <Card href="/how-to/run-on-native/embed-bare-in-react-native" title="Embed Bare in a React Native app" description="Run a Bare worklet from a React Native or Expo app and exchange messages over the bare-kit IPC channel." />
+  <Card href="/how-to/run-on-native/add-custom-p2p-logic-to-a-react-native-app" title="Add custom peer-to-peer logic to a React Native app" description="Replace hello-pear-worker's protocol with your own—a second Hyperswarm topic and a JSON message protocol, using the real snake-mobile app as the example." />
   <Card href="/how-to/run-on-native/type-a-native-rpc-bridge" title="Type a native RPC bridge" description="Replace raw IPC bytes with a typed, schema-generated RPC seam using hyperschema and bare-rpc." />
   <Card href="/how-to/run-on-native/bundle-a-bare-app" title="Bundle a Bare app" description="Package a Bare program as an embeddable bundle or a standalone executable." />
   <Card href="/how-to/run-on-native/handle-app-suspension" title="Handle app suspension" description="Stop active I/O handles cleanly when a Bare process is suspended on mobile." />

--- a/content/reference/index.mdx
+++ b/content/reference/index.mdx
@@ -17,6 +17,7 @@ If you're trying to accomplish a specific task, see **[How To](/how-to)**. For t
 
 - [Pear CLI](/reference/pear/cli)—covers `pear stage`, `pear seed`, `pear build`, `pear install`, and every flag.
 - [Pear OTA](/reference/pear/runtime)—the `pear-runtime` library and JavaScript API for over-the-air updates inside a running Pear app.
+- [Pear Mobile OTA](/reference/pear/mobile)—the `pear-mobile` module: the same OTA and storage model, embedded in React Native and Expo apps via a Bare worklet.
 - [Configuration](/reference/pear/configuration)—every key in `package.json`'s `pear` block.
 - [Pear API (removed)](/reference/pear/api)—the older direct-access `global.Pear` API, removed in v3. Use the Pear OTA (`pear-runtime`) module instead.
 

--- a/content/reference/pear/mobile.mdx
+++ b/content/reference/pear/mobile.mdx
@@ -27,7 +27,7 @@ Unlike desktop's `pear-runtime`, which is required the same way on both sides of
 - From the **React Native/Expo JS thread**—the `react-native` condition—`pear-mobile` is a static launcher for the worklet: [`PearRuntime.run(filename, bundle, argv)`](https://github.com/holepunchto/pear-mobile/blob/v4.3.0/react-native.js).
 - From **inside the Bare worklet** (`workers/main.js`)—the default condition—`pear-mobile` is [the same shape as desktop's `PearRuntime` class](https://github.com/holepunchto/pear-mobile/blob/v4.3.0/bare.js): `new PearRuntime(opts)`, with `.storage`, `.updater`, `.ready()`, and `.close()`.
 
-This is also why [`hello-pear-worker`](https://github.com/holepunchto/hello-pear-worker) works unmodified across desktop and mobile templates: it always does `require('pear-runtime')`, and its own conditional `exports`/`imports` redirect that specifier to `pear-mobile` on iOS, Android, and simulator hosts. See [Where the app logic goes](/getting-started/from-a-template/start-from-hello-pear-react-native#where-the-app-logic-goes) for that in context.
+This is also why [`hello-pear-worker`](https://github.com/holepunchto/hello-pear-worker) works unmodified across desktop and mobile templates: it always does `require('pear-runtime')`, and its own conditional `imports` map redirects that specifier to `pear-mobile` on iOS, Android, and simulator hosts. See [Where the app logic goes](/getting-started/from-a-template/start-from-hello-pear-react-native#where-the-app-logic-goes) for that in context.
 
 ## Starting the worklet (React Native side)
 
@@ -63,7 +63,7 @@ pear.on('minver-required', ({ minver, version }) => {
 - `version` `<String>` - Current app version; used to decide whether an update should be stored.
 - `dir` `<String>` - Directory to store runtime data. Defaults to the platform's persistent app-data directory (resolved via [`bare-storage`](/reference/modules/bare-modules)'s `persistent()`—iOS: the app's Application Support directory; Android: the app's `files` directory).
 - `storage` `<String>` - Override the peer-to-peer application storage path. Defaults to `<dir>/app-storage`.
-- `app` `<String>` - Path the updater stages the OTA payload into. Defaults to `<dir>/pear-runtime/ota`.
+- `app` `<String>` - Path to the installed OTA bundle, as booted by the native code. `applyUpdate()` swaps the staged payload into it; staging itself happens under `<dir>/pear-runtime/next/`. Defaults to `<dir>/pear-runtime/ota`.
 - `store` `<Corestore>` & `swarm` `<Hyperswarm>` - Supply an existing [Corestore](/reference/helpers/corestore) and [Hyperswarm](/reference/building-blocks/hyperswarm) for update replication. Both must be passed together; when omitted, `pear-mobile` creates and swarms its own.
 - `updates` `<Boolean>` - Set to `false` to opt out of updates.
 - `bootstrap` `<Array>` - Override the [HyperDHT](/reference/building-blocks/hyperdht) bootstrap nodes used for update replication.

--- a/content/reference/pear/mobile.mdx
+++ b/content/reference/pear/mobile.mdx
@@ -1,0 +1,112 @@
+---
+title: "Pear Mobile OTA"
+description: "Pear Mobile OTA (the pear-mobile module) for embedding Pear's over-the-air updates and Bare worklets into React Native and Expo apps."
+seoTitle: "Pear Mobile OTA: React Native P2P Updates"
+docType: reference
+schemaType: APIReference
+---
+
+# Pear Mobile OTA
+
+**Pear Mobile OTA** is the mobile counterpart to [Pear OTA](/reference/pear/runtime), provided by the [`pear-mobile`](https://github.com/holepunchto/pear-mobile) module. It embeds the same over-the-air update and storage model into React Native and Expo apps, running the peer-to-peer core in a Bare worklet via [`react-native-bare-kit`](/reference/bare/bare-kit) instead of a desktop `pear-runtime` process.
+
+<Callout type="warn">
+`pear-mobile` is MVP and experimental—its API may still change.
+</Callout>
+
+Install it into a React Native or Expo app:
+
+```sh
+npm install pear-mobile
+```
+
+## Two entry points, one package
+
+Unlike desktop's `pear-runtime`, which is required the same way on both sides of a worker boundary, `pear-mobile` resolves to a **different export depending on which side requires it**—governed by its `package.json` `exports` conditions:
+
+- From the **React Native/Expo JS thread**—the `react-native` condition—`pear-mobile` is a static launcher for the worklet: [`PearRuntime.run(filename, bundle, argv)`](https://github.com/holepunchto/pear-mobile/blob/v4.3.0/react-native.js).
+- From **inside the Bare worklet** (`workers/main.js`)—the default condition—`pear-mobile` is [the same shape as desktop's `PearRuntime` class](https://github.com/holepunchto/pear-mobile/blob/v4.3.0/bare.js): `new PearRuntime(opts)`, with `.storage`, `.updater`, `.ready()`, and `.close()`.
+
+This is also why [`hello-pear-worker`](https://github.com/holepunchto/hello-pear-worker) works unmodified across desktop and mobile templates: it always does `require('pear-runtime')`, and its own conditional `exports`/`imports` redirect that specifier to `pear-mobile` on iOS, Android, and simulator hosts. See [Where the app logic goes](/getting-started/from-a-template/start-from-hello-pear-react-native#where-the-app-logic-goes) for that in context.
+
+## Starting the worklet (React Native side)
+
+```js
+import PearRuntime from 'pear-mobile'
+import bundle from './worker.bundle.js'
+
+const IPC = PearRuntime.run('/worker.bundle', bundle, [
+  updatesEnabled.toString(),
+  version,
+  upgrade,
+  productName
+])
+```
+
+`PearRuntime.run` is **static**—there is no instance on this side. It starts a [`react-native-bare-kit`](/reference/bare/bare-kit) `Worklet` with the given entry filename and bundle, passes `argv` through as the worklet's positional `Bare.argv`, and returns the worklet's `IPC` duplex. Unlike desktop's `PearRuntime.run(specifier, args)`, mobile takes the bundle's **content** (`bundle`) rather than just a path—there is no filesystem for the worklet to load from on a device, so the JS source has to be handed over directly. Bundle the worker first with [`bare-pack`](https://github.com/holepunchto/bare-pack) (see [Bundle a Bare app](/how-to/run-on-native/bundle-a-bare-app)); a stale bundle fails silently rather than erroring.
+
+## Instantiating (inside the worklet)
+
+```js
+const PearRuntime = require('pear-mobile') // or require('pear-runtime') via hello-pear-worker's redirect
+const pear = new PearRuntime({ dir, version, upgrade, name, app })
+pear.on('error', console.error)
+pear.on('minver-required', ({ minver, version }) => {
+  // prompt the user to update from the App Store / Play Store
+})
+```
+
+### Options
+
+- `upgrade` `<String>` - Required. Pear upgrade link, typically from the `package.json` `upgrade` field.
+- `name` `<String>` - Required. The application's product name.
+- `version` `<String>` - Current app version; used to decide whether an update should be stored.
+- `dir` `<String>` - Directory to store runtime data. Defaults to the platform's persistent app-data directory (resolved via [`bare-storage`](/reference/modules/bare-modules)'s `persistent()`—iOS: the app's Application Support directory; Android: the app's `files` directory).
+- `storage` `<String>` - Override the peer-to-peer application storage path. Defaults to `<dir>/app-storage`.
+- `app` `<String>` - Path the updater stages the OTA payload into. Defaults to `<dir>/pear-runtime/ota`.
+- `store` `<Corestore>` & `swarm` `<Hyperswarm>` - Supply an existing [Corestore](/reference/helpers/corestore) and [Hyperswarm](/reference/building-blocks/hyperswarm) for update replication. Both must be passed together; when omitted, `pear-mobile` creates and swarms its own.
+- `updates` `<Boolean>` - Set to `false` to opt out of updates.
+- `bootstrap` `<Array>` - Override the [HyperDHT](/reference/building-blocks/hyperdht) bootstrap nodes used for update replication.
+- `skipUpdate` `<Function>` - Optional async hook, checked before the built-in `minver` gate. Return `true` to skip an available update for a reason of your own.
+
+## Updates
+
+Update events mirror desktop [Pear OTA](/reference/pear/runtime#updates)—`pear.updater` emits `updating`, then `updated` once the new version is staged:
+
+```js
+pear.updater.on('updating', () => {
+  // update view to indicate updating in progress
+})
+pear.updater.on('updated', () => {
+  // update view to indicate update ready; call pear.updater.applyUpdate() when the user confirms
+})
+```
+
+### The `minver` gate
+
+Mobile adds one event desktop doesn't have. Before taking an update, `pear-mobile` reads `/pear.json` from the update drive and compares its `updates.minver` against the **running native version**:
+
+- native version is `>=` `minver` — the update proceeds as normal.
+- native version is `<` `minver` — nothing is downloaded, and the instance emits `minver-required` with `{ minver, version }` instead.
+
+This exists because a mobile OTA replaces the **JavaScript bundle only**—native code changes still require an App Store / Play Store release, so an OTA payload can require a newer native build than the one it's about to update. Set `pear.json` `updates.minver` whenever a release changes the native/OTA contract; see [Version management](https://github.com/holepunchto/hello-pear-react-native#version-management) in the `hello-pear-react-native` README for the full sequencing rules.
+
+## Lifecycle
+
+Instantiation is eager, same as desktop—`pear-mobile` starts opening its store and swarm as soon as `new PearRuntime(opts)` returns:
+
+```js
+await pear.ready()
+```
+
+```js
+goodbye(() => pear.close()) // e.g. via graceful-goodbye
+```
+
+## See also
+
+- [Pear OTA](/reference/pear/runtime)—the desktop counterpart this module mirrors.
+- [`hello-pear-worker`](https://github.com/holepunchto/hello-pear-worker)—the shared worker that requires `pear-runtime` and lets each template's `package.json` redirect it to `pear-mobile` on mobile.
+- [Start from the hello-pear-react-native template](/getting-started/from-a-template/start-from-hello-pear-react-native)—this module in a working template.
+- [Bare Kit](/reference/bare/bare-kit)—the `Worklet` and `IPC` API `pear-mobile` runs on.
+- [Handle app suspension](/how-to/run-on-native/handle-app-suspension)—keeping the worklet in step with the OS lifecycle.

--- a/examples/getting-started/hello-pear-react-native/README.md
+++ b/examples/getting-started/hello-pear-react-native/README.md
@@ -1,0 +1,32 @@
+# hello-pear-react-native (documentation snapshot)
+
+Vendored from [holepunchto/hello-pear-react-native](https://github.com/holepunchto/hello-pear-react-native),
+branch **`main`**, at commit `5c79f39`
+([tree](https://github.com/holepunchto/hello-pear-react-native/tree/5c79f39dc9d65ac44c80a9ebab54f0d3f1ae1696)).
+
+`src/App.tsx` backs the code import in
+`content/getting-started/from-a-template/start-from-hello-pear-react-native.mdx`
+(via `file=<rootDir>/examples/getting-started/hello-pear-react-native/src/App.tsx#L…`).
+
+This is a partial, documentation-only snapshot — only the one imported file is vendored, so it is
+not a runnable app.
+
+## No vendored `workers/main.js`
+
+Unlike the `hello-pear-electron` and `hello-pear-bare` snapshots beside it, this snapshot does
+**not** vendor a copy of `workers/main.js`. Upstream's is the literal `require('hello-pear-worker')`
+one-liner — identical in spirit to the other two templates — and the docs already inline and explain
+that shared worker once, via `content/_snippets/_hello-pear-worker-source-callout.mdx`, which imports
+from the **canonical** copy at `examples/getting-started/hello-pear-electron/workers/main.js`. This
+page's "Where the app logic goes" section includes that same snippet rather than duplicating the
+explanation. Do not add a `workers/main.js` here to "complete" this snapshot — it would just be a
+second, unwatched copy of text already covered by the canonical one.
+
+`src/App.tsx` matches upstream byte-for-byte.
+
+## Refreshing
+
+Drift is polled weekly by `.github/workflows/watch-boilerplates.yml`, which opens a tracking issue
+when `main` moves past the pinned commit. Copy the upstream `src/App.tsx` for the new commit,
+re-check the `#L…` range in the MDX (a shifted range fails silently), then bump both the `pinned`
+SHA in that workflow and the commit recorded here.

--- a/examples/getting-started/hello-pear-react-native/src/App.tsx
+++ b/examples/getting-started/hello-pear-react-native/src/App.tsx
@@ -1,0 +1,164 @@
+/* global __DEV__ */
+
+import { useState, useEffect, useRef } from 'react'
+import { LinearGradient } from 'expo-linear-gradient'
+import { reloadAppAsync } from 'expo-modules-core'
+import { StatusBar } from 'expo-status-bar'
+import { Platform, Pressable, StyleSheet, Text, View } from 'react-native'
+import PearRuntime from 'pear-mobile'
+
+import FramedStream from 'framed-stream'
+import b4a from 'b4a'
+import bundle from './worker.bundle.js'
+import { version, upgrade, name, productName } from '../package.json'
+
+const appName = productName ?? name
+
+export default function App() {
+  const [status, setStatus] = useState('')
+  const [error, setError] = useState('')
+  const [applyUpdate, setApplyUpdate] = useState<(() => void) | null>(null)
+  const shouldReload = useRef(false)
+
+  useEffect(() => {
+    const IPC = PearRuntime.run('/worker.bundle', bundle, [
+      (!__DEV__).toString(),
+      version,
+      upgrade,
+      appName
+    ])
+    const pipe = new FramedStream(IPC)
+
+    setApplyUpdate(() => () => pipe.write('pear:applyUpdate'))
+
+    pipe.on('data', (data) => {
+      const parsed = b4a.toString(data)
+
+      if (parsed === 'updating') {
+        setStatus('updating')
+        return
+      }
+
+      if (parsed === 'updated') {
+        setStatus('updated')
+        return
+      }
+
+      if (parsed === 'minver-required') {
+        setStatus('incompatible')
+        return
+      }
+
+      if (parsed.startsWith('pear:updateFailed')) {
+        shouldReload.current = false
+        setError(parsed.slice('pear:updateFailed '.length) || 'Update failed')
+        setStatus('failed')
+        return
+      }
+
+      if (parsed === 'pear:updateApplied') {
+        if (shouldReload.current) {
+          reloadAppAsync('Pear update applied').catch((err) => {
+            setError(`Reload failed: ${err instanceof Error ? err.message : String(err)}`)
+            setStatus('failed')
+          })
+          return
+        }
+
+        setStatus('')
+        return
+      }
+    })
+
+    pipe.on('error', (err) => console.error(err))
+
+    return () => {
+      pipe.destroy()
+    }
+  }, [])
+
+  const title =
+    status === 'updating'
+      ? 'UPDATING...'
+      : status === 'updated' || status === 'applying'
+        ? 'Update ready!'
+        : status === 'incompatible'
+          ? `Update available on the ${Platform.OS === 'ios' ? 'App Store' : 'Play Store'}`
+          : status === 'failed'
+            ? error
+            : `v${version}`
+
+  return (
+    <LinearGradient
+      colors={['#21c437', '#0e4f15']}
+      end={{ x: 1, y: 1 }}
+      start={{ x: 0, y: 0 }}
+      style={styles.container}
+    >
+      <View style={styles.content}>
+        <Text style={styles.title}>{title}</Text>
+        {(status === 'updated' || status === 'applying') && (
+          <Pressable
+            disabled={status === 'applying' || !applyUpdate}
+            onPress={() => {
+              setStatus('applying')
+              try {
+                shouldReload.current = true
+                applyUpdate?.()
+              } catch (err) {
+                shouldReload.current = false
+                setError(`Update failed: ${err instanceof Error ? err.message : String(err)}`)
+                setStatus('failed')
+              }
+            }}
+            style={({ pressed }) => [
+              styles.updateButton,
+              (pressed || status === 'applying') && styles.updateButtonActive
+            ]}
+          >
+            <Text style={styles.updateButtonText}>
+              {status === 'applying' ? 'Updating...' : 'Apply update'}
+            </Text>
+          </Pressable>
+        )}
+      </View>
+      <StatusBar style='light' />
+    </LinearGradient>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  content: {
+    alignItems: 'center'
+  },
+  title: {
+    color: '#fff',
+    fontSize: 48,
+    fontWeight: '700',
+    textAlign: 'center',
+    textShadowColor: 'rgba(0, 0, 0, 0.3)',
+    textShadowOffset: { width: 2, height: 2 },
+    textShadowRadius: 4
+  },
+  updateButton: {
+    marginTop: 20,
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderWidth: 2,
+    borderColor: '#fff',
+    borderRadius: 8,
+    backgroundColor: '#008000'
+  },
+  updateButtonActive: {
+    backgroundColor: '#adff2f'
+  },
+  updateButtonText: {
+    color: '#fff',
+    fontSize: 18
+  }
+})

--- a/examples/how-to/run-on-native/snake-mobile/README.md
+++ b/examples/how-to/run-on-native/snake-mobile/README.md
@@ -1,0 +1,37 @@
+# snake-mobile (documentation snapshot)
+
+Vendored from [holepunchto/snake-mobile](https://github.com/holepunchto/snake-mobile),
+branch **`main`**, at commit `87694ee`
+([tree](https://github.com/holepunchto/snake-mobile/tree/87694ee010d4916f6d06800fa8b409082a67d6ad)).
+
+`workers/main.custom.js` and `src/App.tsx` back the code imports in
+`content/how-to/run-on-native/add-custom-p2p-logic-to-a-react-native-app.mdx`
+(via `file=<rootDir>/examples/how-to/run-on-native/snake-mobile/…#L…`).
+
+This is a partial, documentation-only snapshot — only the two imported files are vendored, so it is
+not a runnable app.
+
+## Deliberate deviation from upstream
+
+Preserve this when refreshing; it is intentional, not drift:
+
+- **`workers/main.custom.js` is vendored under a renamed filename.** The real upstream path is
+  `workers/main.js`. It is stored here as `workers/main.custom.js` solely so
+  `scripts/check-workers-in-sync.ts` — which recursively byte-compares every
+  `examples/**/workers/main.js` against the canonical `hello-pear-worker` inline vendored at
+  `examples/getting-started/hello-pear-electron/workers/main.js` — does not treat this
+  legitimately different, app-specific worker as drift from that shared source. snake-mobile does
+  **not** use `hello-pear-worker`; it ships its own custom worker with a second `Hyperswarm` for
+  the game topic and a JSON message protocol, which is the entire point of the how-to this
+  snapshot backs. Do **not** rename it back to `workers/main.js` when refreshing — that would make
+  `npm run check:workers-in-sync` fail on the next run.
+
+  Both files otherwise match upstream byte-for-byte.
+
+## Refreshing
+
+Drift is polled weekly by `.github/workflows/watch-boilerplates.yml`, which opens a tracking issue
+when `main` moves past the pinned commit. Copy the upstream files for the new commit into this
+snapshot — keeping `workers/main.js` renamed to `workers/main.custom.js` as above — re-check the
+`#L…` ranges in the MDX (a shifted range fails silently), then bump both the `pinned` SHA in that
+workflow and the commit recorded here.

--- a/examples/how-to/run-on-native/snake-mobile/src/App.tsx
+++ b/examples/how-to/run-on-native/snake-mobile/src/App.tsx
@@ -1,0 +1,242 @@
+/* global __DEV__ */
+
+import { useCallback, useEffect, useReducer, useRef, useState } from 'react'
+import {
+  Dimensions,
+  Platform,
+  SafeAreaView,
+  StatusBar as NativeStatusBar,
+  StyleSheet,
+  Text,
+  View
+} from 'react-native'
+import { StatusBar } from 'expo-status-bar'
+import { reloadAppAsync } from 'expo-modules-core'
+import * as SplashScreen from 'expo-splash-screen'
+import PearRuntime from 'pear-mobile'
+import FramedStream from 'framed-stream'
+import b4a from 'b4a'
+
+import bundle from './worker.bundle.js'
+import { version, upgrade, name, productName } from '../package.json'
+import { SnakeGame } from './game/engine'
+import { TILES, Direction } from './game/constants'
+import { SetupScreen } from './screens/SetupScreen'
+import { GameScreen } from './screens/GameScreen'
+import { UpdateBanner, UpdateStatus } from './components/UpdateBanner'
+import { AnimatedSplash } from './components/AnimatedSplash'
+import { theme } from './theme'
+
+const appName = productName ?? name
+
+// Hold the native splash until the AnimatedSplash overlay has painted its
+// first frame — otherwise there is a flash of bare root view in between.
+SplashScreen.preventAutoHideAsync().catch(() => {})
+
+// Board edge rounded down to a whole number of tiles so every cell is crisp.
+const win = Dimensions.get('window')
+const maxBoard = Math.min(win.width - 24, win.height * 0.55, 420)
+const BOARD_SIZE = Math.max(TILES, Math.floor(maxBoard / TILES) * TILES)
+
+type ScreenName = 'setup' | 'loading' | 'game'
+
+export default function App() {
+  const [screen, setScreen] = useState<ScreenName>('setup')
+  const [topic, setTopic] = useState('')
+  const [peers, setPeers] = useState(0)
+  const [over, setOver] = useState(false)
+  const [updateStatus, setUpdateStatus] = useState<UpdateStatus>('')
+  const [minver, setMinver] = useState('')
+  const [error, setError] = useState('')
+  const [splashDone, setSplashDone] = useState(false)
+  const [renderCount, forceRender] = useReducer((n: number) => n + 1, 0)
+
+  const pipeRef = useRef<FramedStream | null>(null)
+  const shouldReload = useRef(false)
+
+  // The worker sends JSON messages; App writes JSON commands back.
+  function sendToWorker(msg: unknown) {
+    pipeRef.current?.write(JSON.stringify(msg))
+  }
+
+  // One engine for the app's lifetime — reset on leave rather than recreated,
+  // so the message handler's closure always targets the live instance.
+  const gameRef = useRef<SnakeGame | null>(null)
+  if (gameRef.current === null) {
+    gameRef.current = new SnakeGame({
+      onChange: forceRender,
+      send: (data) => sendToWorker({ type: 'send', data }),
+      onOver: () => setOver(true)
+    })
+  }
+  const game = gameRef.current
+
+  useEffect(() => {
+    const IPC = PearRuntime.run('/worker.bundle', bundle, [
+      (!__DEV__).toString(),
+      version,
+      upgrade,
+      appName
+    ])
+    const pipe = new FramedStream(IPC)
+    pipeRef.current = pipe
+
+    pipe.on('data', (data) => {
+      let msg: any = null
+      try {
+        msg = JSON.parse(b4a.toString(data))
+      } catch {
+        return
+      }
+      handleMessage(msg)
+    })
+    pipe.on('error', (err) => console.error(err))
+
+    return () => {
+      game.destroy()
+      pipe.destroy()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  function handleMessage(msg: any) {
+    switch (msg.type) {
+      case 'updating':
+        setUpdateStatus('updating')
+        break
+      case 'updated':
+        setUpdateStatus('updated')
+        break
+      case 'updateApplied':
+        if (shouldReload.current) {
+          reloadAppAsync('Pear update applied').catch((err) => {
+            setError(err instanceof Error ? err.message : String(err))
+            setUpdateStatus('failed')
+          })
+        } else {
+          setUpdateStatus('')
+        }
+        break
+      case 'minverRequired':
+        setMinver(msg.minver)
+        break
+      case 'updateFailed':
+        setError(msg.error || '')
+        setUpdateStatus('failed')
+        break
+      case 'ready':
+        setTopic(msg.topic)
+        game.start(msg.id, b4a.from(msg.topic, 'hex'))
+        setOver(false)
+        setScreen('game')
+        break
+      case 'connected':
+        game.addPeer(msg.id)
+        forceRender()
+        break
+      case 'disconnected':
+        game.removePeer(msg.id)
+        forceRender()
+        break
+      case 'data': {
+        let state: any = null
+        try {
+          state = JSON.parse(msg.payload)
+        } catch {
+          return
+        }
+        game.applyPeerState(state)
+        forceRender()
+        break
+      }
+      case 'update':
+        setPeers(msg.connections)
+        break
+    }
+  }
+
+  function createGame() {
+    setScreen('loading')
+    sendToWorker({ type: 'join', topic: null })
+  }
+
+  function joinGame(topicHex: string) {
+    setScreen('loading')
+    sendToWorker({ type: 'join', topic: topicHex })
+  }
+
+  function leaveGame() {
+    // Tell the worker to actually leave the swarm topic, not just drop the local
+    // board — otherwise the old game's peers stay connected and keep streaming.
+    sendToWorker({ type: 'leave' })
+    game.leave()
+    setOver(false)
+    setPeers(0)
+    setTopic('')
+    setScreen('setup')
+  }
+
+  function applyUpdate() {
+    shouldReload.current = true
+    setUpdateStatus('applying')
+    sendToWorker({ type: 'applyUpdate' })
+  }
+
+  // Stable across ticks so the memoized DPad does not remount its buttons.
+  const handleDirection = useCallback((dir: Direction) => {
+    gameRef.current?.setDirection(dir)
+  }, [])
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <StatusBar style='light' />
+      <UpdateBanner status={updateStatus} minver={minver} error={error} onApply={applyUpdate} />
+
+      {screen === 'setup' && <SetupScreen onCreate={createGame} onJoin={joinGame} />}
+
+      {screen === 'loading' && (
+        <View style={styles.centered}>
+          <Text style={styles.loading}>Loading ...</Text>
+        </View>
+      )}
+
+      {screen === 'game' && (
+        <GameScreen
+          game={game}
+          size={BOARD_SIZE}
+          topic={topic}
+          peers={peers}
+          over={over}
+          version={renderCount}
+          onDirection={handleDirection}
+          onLeave={leaveGame}
+          onPlayAgain={() => {
+            setOver(false)
+            game.reset()
+          }}
+        />
+      )}
+
+      {!splashDone && <AnimatedSplash onDone={() => setSplashDone(true)} />}
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.background,
+    // RN's SafeAreaView only insets on iOS; on Android pad below the status bar
+    paddingTop: Platform.OS === 'android' ? (NativeStatusBar.currentHeight ?? 0) : 0
+  },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  loading: {
+    color: theme.accent,
+    fontFamily: theme.mono,
+    fontSize: 18
+  }
+})

--- a/examples/how-to/run-on-native/snake-mobile/workers/main.custom.js
+++ b/examples/how-to/run-on-native/snake-mobile/workers/main.custom.js
@@ -1,0 +1,153 @@
+const PearRuntime = require('pear-mobile') // pear-runtime on desktop; pear-mobile on mobile (see package.json "imports")
+const Hyperswarm = require('hyperswarm')
+const Corestore = require('corestore')
+const goodbye = require('graceful-goodbye')
+const FramedStream = require('framed-stream')
+const crypto = require('hypercore-crypto')
+const b4a = require('b4a')
+const path = require('bare-path')
+const storage = require('bare-storage')
+const { isBareKit } = require('which-runtime')
+
+// On desktop, Bare.argv starts with the executable path (argv[0]) and the
+// worker entry path (argv[1]); on mobile (BareKit) the passed args land at
+// argv[0..]. Offset the indices so the same arg order works on every platform.
+const argv = (index) => Bare.argv[index + (isBareKit ? 0 : 2)]
+
+const updaterConfig = {
+  updates: argv(0) !== 'false',
+  version: argv(1),
+  upgrade: argv(2),
+  name: argv(3),
+  dir: argv(4) || storage.persistent(), // argv[4] is undefined on mobile — resolve a persistent dir
+  app: argv(5) // argv[5] is undefined on mobile
+}
+
+const pipe = new FramedStream(Bare.IPC)
+
+const store = new Corestore(path.join(updaterConfig.dir, 'pear-runtime', 'corestore'))
+const updaterSwarm = new Hyperswarm()
+const pear = new PearRuntime({ ...updaterConfig, swarm: updaterSwarm, store })
+
+pear.updater.on('error', (err) => {
+  console.error(err)
+  send({ type: 'updateFailed', error: err.message || String(err) })
+})
+if (updaterConfig.updates !== false) {
+  updaterSwarm.on('connection', (connection) => store.replicate(connection))
+  updaterSwarm.join(pear.updater.drive.core.discoveryKey, {
+    client: true,
+    server: false
+  })
+}
+
+pear.updater.on('updating', () => send({ type: 'updating' }))
+pear.updater.on('updated', () => send({ type: 'updated' }))
+
+pear.on('minver-required', ({ minver }) => send({ type: 'minverRequired', minver }))
+
+const gameSwarm = new Hyperswarm()
+
+// Only one game topic is ever joined at a time. `joined` holds it while a game
+// is live and doubles as the gate below: leaving stops us announcing the topic,
+// but a peer that is still in that game may hold our key and dial back in.
+let joined = null
+
+// Join and leave are serialised so that a quick Leave -> Join cannot leave two
+// discovery sessions for the same topic racing each other.
+let commands = Promise.resolve()
+
+function enqueue(fn) {
+  commands = commands.then(fn).catch(console.error)
+}
+
+function send(msg) {
+  pipe.write(Buffer.from(JSON.stringify(msg)))
+}
+
+gameSwarm.on('connection', (peer) => {
+  const id = b4a.toString(peer.remotePublicKey, 'hex').slice(0, 6)
+
+  if (joined === null) {
+    peer.on('error', () => {})
+    peer.destroy()
+    return
+  }
+
+  send({ type: 'connected', id })
+
+  peer.on('data', (message) => {
+    send({ type: 'data', id, payload: message.toString() })
+  })
+
+  peer.on('error', () => {
+    send({ type: 'disconnected', id })
+  })
+
+  peer.on('close', () => {
+    send({ type: 'disconnected', id })
+  })
+})
+
+gameSwarm.on('update', () => {
+  send({ type: 'update', connections: gameSwarm.connections.size })
+})
+
+async function joinGame(topicHex) {
+  await leaveGame()
+  const topicBuffer = topicHex ? b4a.from(topicHex, 'hex') : crypto.randomBytes(32)
+  const topic = b4a.toString(topicBuffer, 'hex')
+  const id = b4a.toString(gameSwarm.keyPair.publicKey, 'hex').slice(0, 6)
+  joined = topicBuffer
+  const discovery = gameSwarm.join(topicBuffer, { client: true, server: true })
+  await discovery.flushed()
+  send({ type: 'ready', id, topic })
+}
+
+// Stop announcing the topic and drop the peers it found. hyperswarm keeps
+// connections open across leave(), so without the explicit destroy the peers of
+// a game the player has left keep streaming their state, and rejoining that
+// same topic never re-emits 'connection' for them — they stay invisible.
+async function leaveGame() {
+  if (joined === null) return
+  const topic = joined
+  joined = null
+  await gameSwarm.leave(topic)
+  // snapshot: destroying removes the connection from the live set
+  for (const peer of [...gameSwarm.connections]) peer.destroy()
+}
+
+pipe.on('data', async (data) => {
+  let msg = null
+  try {
+    msg = JSON.parse(data.toString())
+  } catch {
+    return
+  }
+  if (msg.type === 'join') {
+    enqueue(() => joinGame(msg.topic))
+  } else if (msg.type === 'leave') {
+    enqueue(() => leaveGame())
+  } else if (msg.type === 'send') {
+    for (const peer of gameSwarm.connections) {
+      peer.write(msg.data)
+    }
+  } else if (msg.type === 'applyUpdate') {
+    // Report failures back: without this a throw here is swallowed by the async
+    // handler and the banner sits on "Applying..." forever with no reason given.
+    try {
+      await pear.ready()
+      await pear.updater.applyUpdate()
+      send({ type: 'updateApplied' })
+    } catch (err) {
+      send({ type: 'updateFailed', error: err.message })
+    }
+  }
+})
+
+goodbye(async () => {
+  await gameSwarm.destroy()
+  await updaterSwarm.destroy()
+  await pear.close()
+  await store.close()
+})

--- a/src/lib/custom-tree.ts
+++ b/src/lib/custom-tree.ts
@@ -56,6 +56,11 @@ export const customTree: Node[] = [
             name: 'Start from the hello-pear-bare template',
             url: '/getting-started/from-a-template/start-from-hello-pear-bare',
           },
+          {
+            type: 'page',
+            name: 'Start from the hello-pear-react-native template',
+            url: '/getting-started/from-a-template/start-from-hello-pear-react-native',
+          },
         ],
       },
     ],
@@ -443,6 +448,7 @@ export const customTree: Node[] = [
             url: '/reference/pear/cli',
           },
           { type: 'page', name: 'Pear OTA', url: '/reference/pear/runtime' },
+          { type: 'page', name: 'Pear Mobile OTA', url: '/reference/pear/mobile' },
           {
             type: 'page',
             name: 'Configuration',

--- a/src/lib/custom-tree.ts
+++ b/src/lib/custom-tree.ts
@@ -305,6 +305,11 @@ export const customTree: Node[] = [
           },
           {
             type: 'page',
+            name: 'Add custom peer-to-peer logic to a React Native app',
+            url: '/how-to/run-on-native/add-custom-p2p-logic-to-a-react-native-app',
+          },
+          {
+            type: 'page',
             name: 'Type a native RPC bridge',
             url: '/how-to/run-on-native/type-a-native-rpc-bridge',
           },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -45,6 +45,7 @@
     "out/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "examples"
   ]
 }


### PR DESCRIPTION
## Summary
- New how-to, [Add custom peer-to-peer logic to a React Native app](content/how-to/run-on-native/add-custom-p2p-logic-to-a-react-native-app.mdx), stacked on #361: extends the hello-pear-react-native template by walking through how `holepunchto/snake-mobile` replaces `hello-pear-worker`'s plain-string protocol with a custom one — a second Hyperswarm for the game topic, join/leave serialization, and a JSON message protocol.
- Uses real vendored excerpts from snake-mobile (not illustrative pseudo-code), matching this repo's existing bar for template snapshots — `examples/how-to/run-on-native/snake-mobile/`, pinned to `87694ee`.
- The vendored worker is stored as `workers/main.custom.js` (not `main.js`) so `scripts/check-workers-in-sync.ts`'s byte-identity check against the shared `hello-pear-worker` inline doesn't false-positive on this legitimately different, app-specific worker — documented in the snapshot's README.
- New `watch-boilerplates.yml` entry to track drift against upstream `snake-mobile`.
- Cross-links added to `how-to/run-on-native/index.mdx` and `how-to/index.mdx` (plus a stale two-template mention fixed there); the template page's closing snake-mobile pointer now links into this guide instead of dead-ending at GitHub.
- `tsconfig.json` now excludes `examples/` from type-checking — vendored `.tsx` snapshots (this one and #361's) reference React Native/Expo packages that aren't dependencies of this docs site, which broke `npm run build`'s typecheck step.

## Test plan
- [x] `npm run check:workers-in-sync` — 10 workers, unaffected by the renamed `main.custom.js`
- [x] `npm run check:includes`
- [x] `npm run check:doctypes`
- [x] `npx tsx scripts/check-internal-links.ts`
- [x] `npx tsx scripts/check-examples.ts --no-execute` — new fences correctly annotated `skip="example-import"` / `skip="architecture-diagram"`
- [x] `npm run build` — full production build succeeds, new page renders with real content in `out/`
- [x] `npm run types:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)