### PR TITLE
ci: validate remark-code-import ranges (and fix two broken ones)

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -2,6 +2,8 @@ name: Docs lint
 
 # Gates docs changes on every PR (and on push to main):
 #   - internal-links: the in-repo link/anchor/asset checker.
+#   - code-imports:   `file=...#L…` ranges resolve, are in bounds, and render
+#                     balanced code (a wrong range fails silently otherwise).
 #   - vale:           Google-style prose linting of content/.
 # External links are network-flaky, so they run on a schedule instead
 # (see .github/workflows/external-links.yml).
@@ -13,6 +15,10 @@ on:
     paths:
       - 'content/**'
       - 'scripts/check-internal-links.ts'
+      - 'scripts/check-code-imports.ts'
+      # Editing a vendored example shifts line numbers and can silently
+      # invalidate a `file=...#L…` range, so example changes run this too.
+      - 'examples/**'
       - 'scripts/check-docs-versions.ts'
       - 'src/lib/docs-versions.ts'
       - 'scripts/helpers.ts'
@@ -33,6 +39,10 @@ on:
     paths:
       - 'content/**'
       - 'scripts/check-internal-links.ts'
+      - 'scripts/check-code-imports.ts'
+      # Editing a vendored example shifts line numbers and can silently
+      # invalidate a `file=...#L…` range, so example changes run this too.
+      - 'examples/**'
       - 'scripts/check-docs-versions.ts'
       - 'src/lib/docs-versions.ts'
       - 'scripts/helpers.ts'
@@ -75,6 +85,25 @@ jobs:
           cp -R "$RUNNER_TEMP/checker/node_modules/." node_modules/
       - name: Check internal links
         run: ./node_modules/.bin/tsx scripts/check-internal-links.ts
+
+  code-imports:
+    name: code imports
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+      # Same throwaway-prefix trick as the internal-links job above: a full
+      # `npm install` can't run here (token-gated @tetherto/* packages), and
+      # scripts/helpers.ts imports github-slugger as an ESM bare specifier.
+      - name: Install checker deps
+        run: |
+          npm install --no-save --prefix "$RUNNER_TEMP/checker" tsx github-slugger
+          mkdir -p node_modules
+          cp -R "$RUNNER_TEMP/checker/node_modules/." node_modules/
+      - name: Check code-import ranges
+        run: ./node_modules/.bin/tsx scripts/check-code-imports.ts
 
   agent-ready:
     name: agent-ready metadata

--- a/content/getting-started/from-a-template/start-from-hello-pear-bare.mdx
+++ b/content/getting-started/from-a-template/start-from-hello-pear-bare.mdx
@@ -101,7 +101,7 @@ It resolves a storage directory, then hands the runtime configuration to a `new 
 
 `App` (in `app.js`) is a [`ready-resource`](https://github.com/holepunchto/ready-resource). When it opens, it spawns the Bare worker with [`PearRuntime.run`](/reference/pear/runtime#running-workers)—passing the runtime config as arguments—and wraps the worker's IPC pipe in a [`FramedStream`](https://www.npmjs.com/package/framed-stream):
 
-```js file=<rootDir>/examples/getting-started/hello-pear-bare/app.js#L20-L31 title="app.js"
+```js file=<rootDir>/examples/getting-started/hello-pear-bare/app.js#L20-L38 title="app.js"
 ```
 
 The worker owns the peer-to-peer code and the [`pear-runtime`](/reference/pear/runtime) updater. It messages the host, and `App` turns those into `updating`, `updated`, and `update-applied` events—which `bin.mjs` logs—applying each downloaded release automatically. `SIGHUP`, `SIGINT`, `SIGQUIT`, and `SIGTERM` handlers call `app.exit()` to close cleanly. For the model behind these updates, see [Pear OTA](/reference/pear/runtime#updates):
@@ -139,7 +139,7 @@ git clone -b variant/single-thread https://github.com/holepunchto/hello-pear-bar
 
 Same `App` [`ready-resource`](https://github.com/holepunchto/ready-resource) shape as `main`, emitting the `updating`, `updated`, `update-applied`, and `error` events `bin.mjs` logs—plus `updating-delta`, which carries download progress and which `main`'s worker never actually forwards. (`main` also emits a generic `message` event for anything else the worker writes over the pipe; with no worker, single-thread has no equivalent.) The difference is in `_open()`, which constructs `PearRuntime` directly instead of spawning a worker and wrapping its IPC in a `FramedStream`:
 
-```js file=<rootDir>/examples/getting-started/hello-pear-bare-single-thread/app.js#L23-L41 title="app.js"
+```js file=<rootDir>/examples/getting-started/hello-pear-bare-single-thread/app.js#L23-L57 title="app.js"
 ```
 
 See [`app.js`](https://github.com/holepunchto/hello-pear-bare/blob/variant/single-thread/app.js) on the `variant/single-thread` branch for the full file.

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "check:examples": "tsx scripts/check-examples.ts",
     "check:examples:lint": "tsx scripts/check-examples.ts --no-execute",
     "check:includes": "tsx scripts/check-includes.ts",
+    "check:code-imports": "tsx scripts/check-code-imports.ts",
     "check:upstream-pins": "tsx scripts/check-upstream-pins.ts",
     "check:workers-in-sync": "tsx scripts/check-workers-in-sync.ts",
     "check:agent-ready": "tsx scripts/check-agent-ready-metadata.ts",

--- a/scripts/check-code-imports.ts
+++ b/scripts/check-code-imports.ts
@@ -1,0 +1,311 @@
+// scripts/check-code-imports.ts
+//
+// Validates every `remark-code-import` fence under content/ — the
+// ```js file=<rootDir>/examples/...#L12-L34 ``` blocks that pull doc code out
+// of the runnable/vendored apps in examples/.
+//
+// Why this exists: a wrong `#L…` range fails SILENTLY. remark-code-import does
+// a bare `lines.slice(start - 1, end)` with no bounds check and no syntax
+// awareness, so an off-by-N range renders plausible-but-wrong code, and a range
+// that starts mid-block renders brace-unbalanced JavaScript. Neither the MDX
+// build, `check-examples.ts` (imported fences carry `skip=`, so it never runs
+// them), nor executing the source file itself can catch it: the *file* is fine,
+// the *excerpt* is the lie. Three such defects shipped to review on one branch
+// before this check existed.
+//
+// Two rules:
+//
+//   1. RESOLUTION + BALANCE (error). The path resolves, the range is in bounds,
+//      and — for brace languages — the extracted excerpt has balanced (), [], {}
+//      once strings and comments are stripped. An unbalanced excerpt is nearly
+//      always a range starting or ending mid-block.
+//
+//   2. PROSE COVERAGE (warning). If the paragraph introducing a fence names an
+//      identifier in `backticks`, and that identifier exists in the imported
+//      SOURCE FILE but not in the rendered excerpt, the range is probably wrong:
+//      the page is explaining something it isn't showing. Scoping the check to
+//      identifiers that exist in the same file is what keeps this quiet — prose
+//      nouns and other files' symbols never match.
+//
+// Run as `npm run check:code-imports`. Exit 1 on any rule-1 error; rule-2
+// warnings do not fail the build unless `--strict` is passed.
+import { readFile } from 'fs/promises';
+import { existsSync } from 'fs';
+import { dirname, resolve, relative } from 'path';
+import { EOL } from 'os';
+import { CONTENT_DIR, getFiles } from './helpers';
+
+const ROOT = process.cwd();
+
+/** Languages whose excerpts we can meaningfully balance-check. */
+const BRACE_LANGS = new Set(['js', 'jsx', 'ts', 'tsx', 'mjs', 'cjs', 'json', 'javascript', 'typescript']);
+
+/**
+ * Mirrors remark-code-import's own meta parsing and line slicing exactly
+ * (node_modules/remark-code-import/dist/index.js). Kept byte-faithful on
+ * purpose: a checker that disagrees with the renderer is worse than none.
+ */
+const FILE_META_RE = /^file=(?<path>.+?)(?:(?:#(?:L(?<from>\d+)(?<dash>-)?)?)(?:L(?<to>\d+))?)?$/;
+
+interface Fence {
+  mdx: string;
+  line: number;
+  lang: string;
+  meta: string;
+  /** The paragraph immediately above the fence, for rule 2. */
+  lead: string;
+}
+
+interface Resolved {
+  filePath: string;
+  from?: number;
+  to?: number;
+  hasDash: boolean;
+}
+
+function parseFileMeta(meta: string): Resolved | null {
+  // Same escaped-space split the plugin uses.
+  const fileMeta = meta.split(/(?<!\\) /g).find((m) => m.startsWith('file='));
+  if (!fileMeta) return null;
+  const res = FILE_META_RE.exec(fileMeta);
+  if (!res?.groups?.path) return null;
+  const from = res.groups.from ? parseInt(res.groups.from, 10) : undefined;
+  return {
+    filePath: res.groups.path.replace(/\\ /g, ' '),
+    from,
+    to: res.groups.to ? parseInt(res.groups.to, 10) : undefined,
+    hasDash: !!res.groups.dash || from === undefined,
+  };
+}
+
+/** remark-code-import's extractLines, reproduced. */
+function extractLines(content: string, from: number | undefined, hasDash: boolean, to: number | undefined) {
+  const lines = content.split(EOL);
+  const start = from || 1;
+  let end: number;
+  if (!hasDash) end = start;
+  else if (to) end = to;
+  else if (lines[lines.length - 1] === '') end = lines.length - 1;
+  else end = lines.length;
+  return { excerpt: lines.slice(start - 1, end).join('\n'), start, end, total: lines.length };
+}
+
+/**
+ * Characters after which a `/` begins a regex literal rather than division.
+ * The usual heuristic: an operand cannot precede a regex, so anything that
+ * leaves the parser expecting a value does.
+ */
+const REGEX_PRECEDERS = new Set(['(', ',', '=', ':', '[', '!', '&', '|', '?', '{', '}', ';', '+', '-', '*', '%', '~', '^', '<', '>']);
+
+/**
+ * Strip line comments, block comments, string/template/regex literals so brace
+ * counting isn't fooled by a `}` inside a string, a prose comment, or a `"`
+ * inside a regex character class. Not a real parser — deliberately
+ * conservative, and only used for balance counting.
+ */
+function stripLiterals(src: string): string {
+  let out = '';
+  let i = 0;
+  let lastSig = '';
+  type Mode = 'code' | 'line' | 'block' | 'single' | 'double' | 'template' | 'regex';
+  let mode: Mode = 'code';
+  let inCharClass = false;
+  while (i < src.length) {
+    const c = src[i];
+    const n = src[i + 1];
+    if (mode === 'code') {
+      if (c === '/' && n === '/') { mode = 'line'; i += 2; continue; }
+      if (c === '/' && n === '*') { mode = 'block'; i += 2; continue; }
+      if (c === '/' && (lastSig === '' || REGEX_PRECEDERS.has(lastSig))) {
+        mode = 'regex'; inCharClass = false; i++; continue;
+      }
+      if (c === "'") { mode = 'single'; i++; continue; }
+      if (c === '"') { mode = 'double'; i++; continue; }
+      if (c === '`') { mode = 'template'; i++; continue; }
+      if (!/\s/.test(c)) lastSig = c;
+      out += c; i++; continue;
+    }
+    if (mode === 'regex') {
+      if (c === '\\') { i += 2; continue; }
+      if (c === '[') inCharClass = true;
+      else if (c === ']') inCharClass = false;
+      else if (c === '/' && !inCharClass) { mode = 'code'; lastSig = '/'; i++; continue; }
+      else if (c === '\n') { mode = 'code'; out += c; i++; continue; } // unterminated: bail
+      i++; continue;
+    }
+    if (mode === 'line') { if (c === '\n') { mode = 'code'; out += c; } i++; continue; }
+    if (mode === 'block') { if (c === '*' && n === '/') { mode = 'code'; i += 2; continue; } if (c === '\n') out += c; i++; continue; }
+    // string-ish modes
+    if (c === '\\') { i += 2; continue; }
+    if ((mode === 'single' && c === "'") || (mode === 'double' && c === '"') || (mode === 'template' && c === '`')) {
+      mode = 'code'; i++; continue;
+    }
+    if (c === '\n') out += c;
+    i++;
+  }
+  return out;
+}
+
+function balanceReport(excerpt: string): string | null {
+  const code = stripLiterals(excerpt);
+  const pairs: [string, string, string][] = [
+    ['{', '}', 'brace'],
+    ['(', ')', 'paren'],
+    ['[', ']', 'bracket'],
+  ];
+  const problems: string[] = [];
+  for (const [open, close, name] of pairs) {
+    let depth = 0;
+    let wentNegative = false;
+    for (const ch of code) {
+      if (ch === open) depth++;
+      else if (ch === close) { depth--; if (depth < 0) wentNegative = true; }
+    }
+    if (depth > 0) problems.push(`${depth} unclosed ${name}${depth > 1 ? 's' : ''}`);
+    else if (depth < 0 || wentNegative) problems.push(`${Math.abs(depth) || 1} unopened ${name}${Math.abs(depth) > 1 ? 's' : ''}`);
+  }
+  return problems.length ? problems.join(', ') : null;
+}
+
+/** Backticked bare identifiers in the lead paragraph, e.g. `enqueue`, `send()`. */
+function proseIdentifiers(lead: string): string[] {
+  const out = new Set<string>();
+  for (const m of lead.matchAll(/`([^`\n]+)`/g)) {
+    const raw = m[1].trim().replace(/\(\)$/, '');
+    if (/^[A-Za-z_$][\w$]*$/.test(raw) && raw.length >= 3) out.add(raw);
+  }
+  return [...out];
+}
+
+/** Whole-word presence, so `send` doesn't match `resend` or `sender`. */
+function mentions(src: string, id: string): boolean {
+  return new RegExp(`\\b${id.replace(/[$]/g, '\\$')}\\b`).test(src);
+}
+
+/**
+ * Is `id` *declared* in this source (not merely mentioned as an event name,
+ * string, or imported symbol)? Rule 2 only fires on declarations — that is what
+ * separates "the prose explains a helper the excerpt forgot to show" from "the
+ * prose happens to quote an event string that appears elsewhere in the file".
+ */
+function declares(src: string, id: string): boolean {
+  const e = id.replace(/[$]/g, '\\$');
+  return (
+    new RegExp(`\\b(?:function|class|const|let|var)\\s+${e}\\b`).test(src) ||
+    new RegExp(`^\\s*(?:async\\s+)?(?:static\\s+)?${e}\\s*\\(`, 'm').test(src) ||
+    new RegExp(`\\b${e}\\s*[:=]\\s*(?:async\\s*)?(?:function\\b|\\()`).test(src)
+  );
+}
+
+/** `VideoRoom` <-> video-room.js, `App` <-> app.js, `WorkerTask` <-> worker-task.js. */
+function isFileSubject(filePath: string, id: string): boolean {
+  const base = (filePath.split('/').pop() ?? '').replace(/\.[^.]+$/, '');
+  const norm = (s: string) => s.replace(/[-_]/g, '').toLowerCase();
+  return norm(base) === norm(id);
+}
+
+const FENCE_RE = /^(`{3,})([^\s`]*)([^\n]*)\n([\s\S]*?)^\1\s*$/gm;
+
+function parseFences(mdx: string, content: string): Fence[] {
+  const out: Fence[] = [];
+  let m: RegExpExecArray | null;
+  FENCE_RE.lastIndex = 0;
+  while ((m = FENCE_RE.exec(content)) !== null) {
+    const meta = (m[3] || '').trim();
+    if (!meta.includes('file=')) continue;
+    const before = content.slice(0, m.index);
+    const line = before.split('\n').length;
+    // Lead paragraph: the last non-empty block before the fence.
+    const blocks = before.split(/\n\s*\n/).filter((b) => b.trim());
+    out.push({ mdx, line, lang: (m[2] || '').trim(), meta, lead: blocks[blocks.length - 1] ?? '' });
+  }
+  return out;
+}
+
+async function main() {
+  const strict = process.argv.includes('--strict');
+  const files = (await getFiles(CONTENT_DIR)).filter((f) => /\.mdx?$/.test(f)).sort();
+
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  let checked = 0;
+
+  for (const mdx of files) {
+    const content = await readFile(mdx, 'utf8');
+    for (const fence of parseFences(mdx, content)) {
+      const parsed = parseFileMeta(fence.meta);
+      if (!parsed) {
+        errors.push(`${fence.mdx}:${fence.line}: could not parse \`file=\` meta: ${fence.meta}`);
+        continue;
+      }
+      const abs = resolve(dirname(mdx), parsed.filePath.replace(/^<rootDir>/, ROOT));
+      if (!existsSync(abs)) {
+        errors.push(`${fence.mdx}:${fence.line}: imported file does not exist: ${relative(ROOT, abs)}`);
+        continue;
+      }
+      checked++;
+      const source = await readFile(abs, 'utf8');
+      const { excerpt, start, end, total } = extractLines(source, parsed.from, parsed.hasDash, parsed.to);
+      const rel = relative(ROOT, abs);
+
+      if (start > total || end > total) {
+        errors.push(
+          `${fence.mdx}:${fence.line}: range #L${start}-L${end} is out of bounds — ${rel} has ${total} lines`,
+        );
+        continue;
+      }
+      if (!excerpt.trim()) {
+        errors.push(`${fence.mdx}:${fence.line}: range #L${start}-L${end} of ${rel} is empty`);
+        continue;
+      }
+
+      if (BRACE_LANGS.has(fence.lang)) {
+        const problem = balanceReport(excerpt);
+        if (problem) {
+          errors.push(
+            `${fence.mdx}:${fence.line}: range #L${start}-L${end} of ${rel} renders unbalanced code (${problem})\n` +
+              `      first: ${excerpt.split('\n')[0].trim().slice(0, 72)}\n` +
+              `      last:  ${excerpt.split('\n').slice(-1)[0].trim().slice(0, 72)}`,
+          );
+        }
+      }
+
+      // Rule 2: prose names something that lives in this file but isn't shown.
+      for (const id of proseIdentifiers(fence.lead)) {
+        if (mentions(excerpt, id)) continue;
+        if (!declares(source, id)) continue;
+        // The file's own subject — `VideoRoom` in video-room.js, `App` in
+        // app.js. Prose routinely names the enclosing class while the excerpt
+        // shows one method of it; that is not a wrong range.
+        if (isFileSubject(rel, id)) continue;
+        warnings.push(
+          `${fence.mdx}:${fence.line}: prose names \`${id}\`, which exists in ${rel} but is outside the rendered range #L${start}-L${end}`,
+        );
+      }
+    }
+  }
+
+  console.log(`🔍 Checking ${checked} code-import fence(s) across ${files.length} files...\n`);
+
+  if (errors.length) {
+    console.log('✖ Errors\n');
+    for (const e of errors) console.log(`   ${e}`);
+    console.log('');
+  }
+  if (warnings.length) {
+    console.log(`⚠️  Possible range/prose mismatches (${warnings.length})\n`);
+    for (const w of warnings) console.log(`   ${w}`);
+    console.log('');
+  }
+
+  if (!errors.length && !warnings.length) {
+    console.log('✅ Every code-import range resolves, is in bounds, and renders balanced code.');
+  }
+
+  if (errors.length || (strict && warnings.length)) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/check-code-imports.ts
+++ b/scripts/check-code-imports.ts
@@ -116,7 +116,11 @@ function stripLiterals(src: string): string {
     if (mode === 'code') {
       if (c === '/' && n === '/') { mode = 'line'; i += 2; continue; }
       if (c === '/' && n === '*') { mode = 'block'; i += 2; continue; }
-      if (c === '/' && (lastSig === '' || REGEX_PRECEDERS.has(lastSig))) {
+      // `/>` is a JSX self-closing tag, never a regex start. Without this, a
+      // line like `<Foo bar={baz} />` looks like a regex opening right after
+      // the `}` preceder, and the "literal" swallows the rest of the line —
+      // including its braces — which reports balanced TSX as unbalanced.
+      if (c === '/' && n !== '>' && (lastSig === '' || REGEX_PRECEDERS.has(lastSig))) {
         mode = 'regex'; inCharClass = false; i++; continue;
       }
       if (c === "'") { mode = 'single'; i++; continue; }


### PR DESCRIPTION
## Why

A wrong `#L…` range in a `file=` fence **fails silently**. `remark-code-import` does a bare `lines.slice(start - 1, end)` — no bounds check, no syntax awareness — so an off-by-N range renders plausible-but-wrong code, and a range starting mid-block renders unbalanced JavaScript.

Nothing catches it today. The MDX build doesn't care. `check-examples.ts` skips imported fences by design (they carry `skip=`). And executing the imported source file wouldn't help either: the *file* is valid upstream code, the *excerpt* is where the lie is.

Three such defects surfaced in review on one branch recently. This check closes that gap for the whole repo.

## What

`scripts/check-code-imports.ts`, wired into `docs-lint` as a `code imports` job. Triggered by `content/**` and `examples/**` — editing a vendored example shifts line numbers and can invalidate a range in a file nobody touched.

**Error (fails CI):** path resolves, range is in bounds and non-empty, and for brace languages the excerpt balances `()` `[]` `{}` once strings, comments and regex literals are stripped.

**Warning (advisory, `--strict` to enforce):** the introducing paragraph names a `backticked` identifier that is *declared* in the imported file but falls outside the rendered range — i.e. the page explains something it doesn't show.

Meta parsing and line slicing mirror the plugin's own implementation byte-for-byte; a checker that disagrees with the renderer is worse than no checker.

Rule 2 is deliberately tuned for precision: it fires only on declarations, and skips a file's own subject (`VideoRoom` in `video-room.js`). That takes it from 18 hits to 4 on the current corpus, and all 4 are legitimate passing architectural references — hence advisory, not blocking.

## Two live defects it found, fixed here

Both on `published`, both the same shape — `_open() {` cut off mid-method, so the page shipped an unclosed brace:

- `start-from-hello-pear-bare.mdx:104` — `app.js#L20-L31` → `#L20-L38`
- `start-from-hello-pear-bare.mdx:142` — `hello-pear-bare-single-thread/app.js#L23-L41` → `#L23-L57`

## Test plan

- [x] `npm run check:code-imports` — 77 fences, 0 errors, 4 advisory warnings
- [x] Regression-tested: reintroducing `#L20-L31` makes it report the unclosed brace and exit 1
- [x] False positive found and fixed during development — a regex literal containing quotes (`/Version="[^"]*"/` in `forge.config.js`) desynchronized string tracking; the stripper now handles regex literals with char-class awareness
- [x] `check-internal-links`, `types:check` pass
- [x] `docs-lint.yml` parses as valid YAML, 6 jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)