### PR TITLE
docs: point deployment links at docs pages, not hello-pear-electron README

### DIFF
--- a/content/explanation/deployment-releasing-apps-p2p.mdx
+++ b/content/explanation/deployment-releasing-apps-p2p.mdx
@@ -163,7 +163,7 @@ That directory must at least contain `package.json` and `by-arch/.../app` trees 
 
 ## Multisig setup and signing
 
-The diagrams below follow [`hello-pear-electron`'s Foundational Steps](https://github.com/holepunchto/hello-pear-electron#foundational-steps)—the same Electron + Bare worker template [Keet](https://keet.io) and [PearPass](https://pass.pears.com) ship. **One-time** multisig wiring is in [Set up multisig](/how-to/operate-an-app/multisig/set-up-multisig); every production shipment after that uses [Sign with multisig](/how-to/operate-an-app/multisig/sign-with-multisig). If a commit fails mid-flight, see [Troubleshoot multisig](/how-to/operate-an-app/multisig/troubleshoot-multisig).
+The diagrams below follow the same Foundational Steps as [Deploy your application](/how-to/operate-an-app/manual-deployment/deployment)—the flow behind [`hello-pear-electron`](https://github.com/holepunchto/hello-pear-electron), the Electron + Bare worker template [Keet](https://keet.io) and [PearPass](https://pass.pears.com) ship. **One-time** multisig wiring is in [Set up multisig](/how-to/operate-an-app/multisig/set-up-multisig); every production shipment after that uses [Sign with multisig](/how-to/operate-an-app/multisig/sign-with-multisig). If a commit fails mid-flight, see [Troubleshoot multisig](/how-to/operate-an-app/multisig/troubleshoot-multisig).
 
 ### How setup connects to the release cycle
 
@@ -206,7 +206,7 @@ graph TB
 
 ## Release lines
 
-For [`hello-pear-electron`](https://github.com/holepunchto/hello-pear-electron), one [`pear build`](https://github.com/holepunchto/hello-pear-electron#deploying) output can feed parallel **stage** links; **prerelease** and **production** are the provision and multisig gates on the trust ladder.
+For [`hello-pear-electron`](https://github.com/holepunchto/hello-pear-electron), one [`pear build`](/how-to/operate-an-app/manual-deployment/deployment#4-build-the-deployment-directory) output can feed parallel **stage** links; **prerelease** and **production** are the provision and multisig gates on the trust ladder.
 
 ```mermaid
 graph TB

--- a/content/explanation/storage-and-distribution.mdx
+++ b/content/explanation/storage-and-distribution.mdx
@@ -77,7 +77,7 @@ For a long time the way to launch a Pear application was `pear run pear://<key>`
 
 That runtime capability has been unbundled from the CLI: `pear run` was **removed in Pear v3** in favour of the embeddable **[Pear OTA](/reference/pear/runtime)** (`pear-runtime`) library, so any JavaScript project can carry peer-to-peer over-the-air updates without depending on the CLI. The CLI's remaining focus is deployment and, now, installation. The full rationale is in [Pear Evolution](https://pears.com/news/pear-evolution/).
 
-Installing replaces "run from a link" with a first-class on-disk install. [`pear install pear://<key>`](/reference/pear/cli#pear-install) pulls an application built with [`pear build`](https://github.com/holepunchto/hello-pear-electron#deploying) from the swarm and sets it up locally, the same way the platform binary arrives—there is still no download server, only peers. The command works for both applications and standalone binaries.
+Installing replaces "run from a link" with a first-class on-disk install. [`pear install pear://<key>`](/reference/pear/cli#pear-install) pulls an application built with [`pear build`](/how-to/operate-an-app/manual-deployment/deployment#4-build-the-deployment-directory) from the swarm and sets it up locally, the same way the platform binary arrives—there is still no download server, only peers. The command works for both applications and standalone binaries.
 
 ```bash
 # install an application peer-to-peer

--- a/content/how-to/operate-an-app/manual-deployment/deployment.mdx
+++ b/content/how-to/operate-an-app/manual-deployment/deployment.mdx
@@ -5,7 +5,7 @@ docType: how-to
 schemaType: TechArticle
 ---
 
-This is the operator reference for the desktop release flow. The conceptual picture lives in [Release pipeline](/explanation/deployment-releasing-apps-p2p); the type-along path is in [Ship your app](/getting-started/build-a-peer-to-peer-chat/ship) and [Deploy over-the-air updates](/getting-started/build-a-peer-to-peer-chat/update). Use this page when you need exact commands for the eight **Foundational Steps** documented in [`hello-pear-electron`'s Foundational Steps](https://github.com/holepunchto/hello-pear-electron#foundational-steps).
+This is the operator reference for the desktop release flow. The conceptual picture lives in [Release pipeline](/explanation/deployment-releasing-apps-p2p); the type-along path is in [Ship your app](/getting-started/build-a-peer-to-peer-chat/ship) and [Deploy over-the-air updates](/getting-started/build-a-peer-to-peer-chat/update). Use this page when you need exact commands for the eight **Foundational Steps**.
 
 <include>../../../_snippets/_ci-publish-shortcut-callout.mdx</include>
 

--- a/content/how-to/operate-an-app/migration.mdx
+++ b/content/how-to/operate-an-app/migration.mdx
@@ -26,7 +26,7 @@ Running every app on a single vendor-signed Electron build made shipping trivial
 | `pear run` (removed) | Pear OTA — `pear-runtime` |
 | --- | --- |
 | The CLI runtime launches the app and provides the ambient `Pear` global | You import [`pear-runtime`](/reference/pear/runtime) in your own JS entrypoint |
-| `pear stage` deploys the app contents | [`pear build`](https://github.com/holepunchto/hello-pear-electron#build-deploy-directory) produces a build folder that *is* the deployment folder |
+| `pear stage` deploys the app contents | [`pear build`](/how-to/operate-an-app/manual-deployment/deployment#4-build-the-deployment-directory) produces a build folder that *is* the deployment folder |
 | `global.Pear.worker.run()` spawns workers | [`pear-runtime`](/reference/pear/runtime)'s `run()` method (backed by `bare-sidecar`, which bundles the native Bare runtime) |
 
 ## Steps
@@ -48,7 +48,7 @@ npm start
 
 Move your HTML, JS, CSS, assets, and dependencies into the template's structure. For a guided tour of where each piece goes, see [Start from the hello-pear-electron template](/getting-started/from-a-template/start-from-hello-pear-electron).
 
-The build directory layout `pear-runtime` expects is produced by the [`pear build`](https://github.com/holepunchto/hello-pear-electron#build-deploy-directory) command (Pear v2.5.0+). Your `package.json` needs an `upgrade` field set to the application's `pear://` link—see [Configuration](/reference/pear/configuration#packagejson).
+The build directory layout `pear-runtime` expects is produced by the [`pear build`](/how-to/operate-an-app/manual-deployment/deployment#4-build-the-deployment-directory) command (Pear v2.5.0+). Your `package.json` needs an `upgrade` field set to the application's `pear://` link—see [Configuration](/reference/pear/configuration#packagejson).
 
 </Step>
 


### PR DESCRIPTION
## Why

hello-pear-electron's README `## Peer-to-Peer Deployments` section (the canonical stage/provision/multisig release-process writeup) is moving to docs.pears.com so it's maintained in one place. Companion README edits: holepunchto/hello-pear-electron and holepunchto/hello-pear-bare (pending review, not yet opened).

## What

Repoints every docs link that currently points *into* hello-pear-electron's README anchors that are about to disappear:

- `deployment.mdx` and `deployment-releasing-apps-p2p.mdx`: dropped the citation of hello-pear-electron's `#foundational-steps` anchor — both pages already document the eight Foundational Steps themselves, so the external link was redundant and about to be dead.
- `deployment-releasing-apps-p2p.mdx` and `storage-and-distribution.mdx`: repointed a `#deploying` anchor (never actually existed in the README) to [Deploy your application § 4](/how-to/operate-an-app/manual-deployment/deployment#4-build-the-deployment-directory).
- `migration.mdx` (x2): repointed `#build-deploy-directory` references to the same step.

Left untouched: links into README sections that aren't part of the Deployments section being removed (`#workers`, `#stage-size-increases`, `#scripts`, `#store-submissions`) — all still resolve.

No new content needed — the docs side (explanation, how-to, and reference pages) was already comprehensive and current relative to the README.

## Verification

```
npm run check:internal-links
npm run check:cross-links
npm run check:doctypes
npm run check:examples:lint
npm run types:check
```

All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)