### PR TITLE
Document Pear 3.4.0

### DIFF
--- a/content/explanation/availability-and-blind-peering.mdx
+++ b/content/explanation/availability-and-blind-peering.mdx
@@ -56,6 +56,10 @@ The stack has three parts:
 
 ### Running a blind peer server
 
+<Callout type="tip">
+Since Pear 3.4.0, [`pear blind-peer start [--trusted-peer <peer>]`](/reference/pear/cli#pear-blind-peer) runs the same server natively—no separate install. Use it for a Pear-managed deployment; the standalone `blind-peer-cli` package below still applies for a plain Node/Bare process, or anywhere outside a Pear install. The command reference also covers `identity` (print this peer's own key) and `request` (ask a peer to seed something on demand).
+</Callout>
+
 Install the CLI and start the server:
 
 ```bash
@@ -111,6 +115,10 @@ await blinds.addAutobase(base)
 `addCore` / `addAutobase` connect to the closest configured blind peers and request that they replicate and seed the given cores—without the blind peer ever being able to read them.
 </Callout>
 
+<Callout type="tip">
+For the common case of registering a single drive you're already seeding, [`pear seed <link> --blind-peer <key>`](/reference/pear/cli#pear-seed) (since Pear 3.4.0) does this without writing any client code. Reach for the `blind-peering` client shown above when you need multiple cores, an Autobase, or control beyond a single seed session.
+</Callout>
+
 Consider letting users configure which blind peers they trust—default infrastructure may not match privacy or jurisdiction requirements (for example location-sensitive data).
 
 ### Finding the keys to keep available
@@ -131,6 +139,7 @@ Blind peering does not replace end-to-end encryption or capability checks on the
 
 ## See also
 
+- [Pear CLI: `pear blind-peer` and `pear seed`](/reference/pear/cli#pear-blind-peer)—the platform-native commands, since Pear 3.4.0.
 - [Storage and distribution](/explanation/storage-and-distribution)—on-disk layout and the `pear seed` distribution model.
 - [Deploy your application](/how-to/operate-an-app/manual-deployment/deployment)—staging and announcing releases.
 - [Peer-to-peer, demystified](/explanation/peer-to-peer-demystified)—how peers find one another on the swarm.

--- a/content/explanation/peer-to-peer-demystified.mdx
+++ b/content/explanation/peer-to-peer-demystified.mdx
@@ -36,6 +36,8 @@ Most devices sit behind home routers or carrier-grade network address translatio
 
 **User Datagram Protocol (UDP) hole punching** coordinates both peers through a rendezvous point so that each opens a path through its local firewall. Once the "hole" exists, Pear's transport can carry encrypted traffic over it. Hole punching works on most consumer networks; it is not guaranteed on every corporate or symmetric-NAT setup, which is why Pear also supports relay paths when direct connectivity fails.
 
+As of Pear 3.4.0, that relay path has a concrete CLI surface: [`pear blind-relay start`](/reference/pear/cli#pear-blind-relay) runs a relay host that forwards connections between two peers that cannot hole-punch each other, and [`--relay <key>`](/reference/pear/cli#relay-flag) registers one with the local sidecar, which falls back to it when a connection cannot be made directly. See [Relay connections through a blind relay](/how-to/connect-to-peers/relay-connections-through-a-blind-relay) for the setup. This is unrelated to [blind peering](/explanation/availability-and-blind-peering)'s core replication despite the shared "blind" name—a blind relay forwards connections, it does not store data.
+
 [HyperDHT](#hyperdht-discovery-and-encrypted-connections) implements this discovery and connection machinery. You rarely call hole punching directly; you create a DHT node or join a [Hyperswarm](/reference/building-blocks/hyperswarm) topic and the stack handles traversal.
 
 ## HyperDHT: discovery and encrypted connections

--- a/content/how-to/blind-peering/keep-data-available-with-blind-peering.mdx
+++ b/content/how-to/blind-peering/keep-data-available-with-blind-peering.mdx
@@ -21,7 +21,7 @@ This is purely Pear-end logic: it lives in a [Bare](/reference/modules/bare-modu
 
 | Role | What it runs | Holds read key? |
 | --- | --- | --- |
-| **Blind peer** | An always-on server with its own key pair, run with [`blind-peer-cli`](https://github.com/holepunchto/blind-peer-cli)—which provides the `blind-peer` command on top of the [`blind-peer`](https://github.com/holepunchto/blind-peer) library. Seeds whatever it is asked to. | No |
+| **Blind peer** | An always-on server with its own key pair. Run it with [`pear blind-peer start`](/reference/pear/cli#pear-blind-peer) (since Pear 3.4.0) or the standalone [`blind-peer-cli`](https://github.com/holepunchto/blind-peer-cli) package—both wrap the [`blind-peer`](https://github.com/holepunchto/blind-peer) library. Seeds whatever it is asked to. | No |
 | **Client** | Your app, using the `blind-peering` module to ask one or more blind peers (by public key) to keep specific cores available. | Yes |
 
 You point the client at the **public keys** of the blind peers you want to mirror to. Those can be blind peers you run yourself, or shared ones.
@@ -73,7 +73,9 @@ await store.close()
 
 ## Run your own blind peer
 
-To control availability yourself rather than relying on shared blind peers, run the [`blind-peer-cli`](https://github.com/holepunchto/blind-peer-cli) server (`npm i -g blind-peer-cli`, then `blind-peer`) on an always-on machine. It prints a public key—pass that key in the client's `keys` array. See [Availability and blind peering](/explanation/availability-and-blind-peering) for the full setup, including a systemd unit.
+To control availability yourself rather than relying on shared blind peers, run a server on an always-on machine—either [`pear blind-peer start`](/reference/pear/cli#pear-blind-peer) (since Pear 3.4.0, no separate install) or the standalone [`blind-peer-cli`](https://github.com/holepunchto/blind-peer-cli) package (`npm i -g blind-peer-cli`, then `blind-peer`). Either way it prints a public key—pass that key in the client's `keys` array. See [Availability and blind peering](/explanation/availability-and-blind-peering) for the full setup, including a systemd unit.
+
+For the single-drive case—no custom client code, just keep one seed session's drive available—[`pear seed <link> --blind-peer <key>`](/reference/pear/cli#pear-seed) does the client side of this too, in place of the "Wire the client" section above.
 
 ## See also
 

--- a/content/how-to/connect-to-peers/connect-two-peers-by-key-with-hyperdht.mdx
+++ b/content/how-to/connect-to-peers/connect-two-peers-by-key-with-hyperdht.mdx
@@ -16,6 +16,8 @@ This means users can connect to each other irrespective of their location, even 
 HyperDHT's holepunching will fail if both the client peer and the server peer are on randomizing [NATs](https://en.wikipedia.org/wiki/Network_address_translation), in which case the connection must be relayed through a third peer. HyperDHT does not do any relaying by default.
 
 For example, Keet implements its relaying system wherein other call participants can serve as relays -- the more participants in the call, the stronger overall connectivity becomes.
+
+For Pear itself, [Relay connections through a blind relay](/how-to/connect-to-peers/relay-connections-through-a-blind-relay) covers running a relay and pointing peers at it.
 </Callout>
 
 Use the HyperDHT to create a basic CLI chat app where a client peer connects to a server peer by public key.

--- a/content/how-to/connect-to-peers/index.mdx
+++ b/content/how-to/connect-to-peers/index.mdx
@@ -14,4 +14,5 @@ Recipes for finding other peers and opening direct, end-to-end-encrypted connect
   <Card href="/how-to/connect-to-peers/connect-two-peers-by-key-with-hyperdht" title="Connect two peers by key with HyperDHT" description="Connect client and server peers by public key using HyperDHT hole punching." />
   <Card href="/how-to/connect-to-peers/connect-to-many-peers-by-topic-with-hyperswarm" title="Connect to many peers by topic with Hyperswarm" description="Discover peers on a topic and keep connections alive with Hyperswarm." />
   <Card href="/how-to/connect-to-peers/host-multiple-rooms-in-one-chat-app" title="Host multiple rooms in one chat app" description="Extend the pear-chat scaffold from a single room to an account that owns and switches between many rooms." />
+  <Card href="/how-to/connect-to-peers/relay-connections-through-a-blind-relay" title="Relay connections through a blind relay" description="Run a blind relay and point peers at it with --relay, for networks where hole punching cannot connect." />
 </Cards>

--- a/content/how-to/connect-to-peers/relay-connections-through-a-blind-relay.mdx
+++ b/content/how-to/connect-to-peers/relay-connections-through-a-blind-relay.mdx
@@ -1,0 +1,104 @@
+---
+title: "Relay connections through a blind relay"
+description: "Run a blind relay and point peers at it with --relay, for networks where hole punching cannot establish a direct connection."
+docType: how-to
+schemaType: TechArticle
+---
+
+Most peers reach each other directly: [hole punching](/explanation/peer-to-peer-demystified#hole-punching-and-nat-traversal) opens a path through both firewalls and the connection carries on without an intermediary. On some networks it cannot. A **randomizing NAT**—common on corporate and carrier-grade networks—assigns an unpredictable external port per connection, so neither side can tell the other where to dial.
+
+A **blind relay** is the fallback: a third machine that forwards encrypted stream messages between two peers that cannot meet directly. It is "blind" in the same sense as a [blind peer](/explanation/availability-and-blind-peering)—it moves bytes it cannot read. Unlike a blind peer, it stores nothing; it only forwards live connections.
+
+<Callout type="info">
+Since Pear 3.4.0 this is built into the CLI: [`pear blind-relay start`](/reference/pear/cli#pear-blind-relay) runs the relay, and [`--relay <key>`](/reference/pear/cli#relay-flag) points a peer at one.
+</Callout>
+
+## Before you start
+
+You need a **third machine** that both peers can reach—a VPS or any always-on host with working connectivity. A relay on one of the two peers' own networks defeats the purpose: if that network is the one blocking direct connections, it cannot rescue them.
+
+## Run the relay
+
+On the relay host:
+
+```bash skip="live-relay"
+pear blind-relay start
+```
+
+It prints a live table. The first row is the one you need:
+
+```text skip="sample-output"
+ Public Key:          <relay-key>
+ Sessions Accepted:   0
+ Sessions Opened:     0
+ Sessions Closed:     0
+ Sessions Active:     0
+ Pairings Requested:  0
+ Pairings Matched:    0
+ Pairings Pending:    0
+ Pairings Active:     0
+ Streams Opened:      0
+ Streams Closed:      0
+ Streams Errors:      0
+ Streams Active:      0
+```
+
+Copy `<relay-key>`. That is what peers pass to `--relay`.
+
+The relay's key pair is derived from the platform corestore on that machine, so **the key is stable across restarts**—note it down once and reuse it. The process must stay running to relay anything; put it under a service manager for anything long-lived.
+
+<Callout type="tip">
+Only one relay runs per sidecar. Starting a second fails with `Blind relay is already running, cannot start another`.
+</Callout>
+
+## Point a peer at the relay
+
+On each peer that needs relaying, pass the relay's key once:
+
+```bash skip="live-relay"
+pear --relay <relay-key> info
+```
+
+Any command works—`info` is just a cheap one to run. The point is the flag, not the command.
+
+<Callout type="warn">
+`--relay` registers the relay with the **sidecar**, the shared background process, not with the command you attached it to. That has two consequences worth knowing up front:
+
+- You only need to pass it **once**. It stays in effect for everything that sidecar does afterwards, so there is no need to add `--relay` to every subsequent command.
+- There is no flag that unsets it. To stop relaying, restart the sidecar with [`pear sidecar shutdown`](/reference/pear/cli#pear-sidecar).
+</Callout>
+
+An invalid key is rejected before the command runs:
+
+```text skip="sample-output"
+--relay <key> must supply a valid public key
+```
+
+## What actually happens next
+
+Registering a relay does **not** push your traffic through it. The swarm keeps connecting directly whenever it can, and consults the relay only when a connection genuinely needs relaying—or when this machine's DHT node is randomized, which is the unpredictable-NAT case hole punching cannot solve.
+
+So on a healthy network you may register a relay and never see it carry a byte. That is the intended behaviour, not a misconfiguration.
+
+## Confirm it is working
+
+Watch the relay's table while the peers connect. Relayed traffic moves these counters:
+
+- **Pairings Requested / Matched** — two peers asked the relay to introduce them, and it matched them by token. A request that never matches means only one side reached the relay.
+- **Streams Opened / Active** — forwarding is underway.
+- **Streams Errors** — forwarded streams that failed.
+
+`Sessions` count peers connected to the relay itself, so a peer that registered the relay but never needed it shows a session with no pairings.
+
+If the counters stay at zero while two peers fail to connect, check in this order:
+
+1. Both peers registered the **same** relay key—`--relay` on one side only cannot pair.
+2. The relay host is reachable from both peers, and `pear blind-relay start` is still running.
+3. The peers' sidecars actually picked the flag up. Each sidecar keeps its own relay setting, and it is lost on restart—if a sidecar restarted, pass `--relay` again.
+
+## See also
+
+- [`pear blind-relay` and `--relay` reference](/reference/pear/cli#pear-blind-relay)—every flag and the stats fields.
+- [Peer-to-peer, demystified](/explanation/peer-to-peer-demystified#hole-punching-and-nat-traversal)—why hole punching fails on randomizing NATs.
+- [Availability and blind peering](/explanation/availability-and-blind-peering)—the other "blind" service, which keeps data available rather than forwarding connections.
+- [Connect two peers by key with HyperDHT](/how-to/connect-to-peers/connect-two-peers-by-key-with-hyperdht)—the direct-connection path this falls back from.

--- a/content/reference/pear/cli.mdx
+++ b/content/reference/pear/cli.mdx
@@ -14,7 +14,7 @@ The Command Line Interface is the primary interface for Pear Development.
 <include>../../_snippets/_interactive-menu-callout.mdx</include>
 
 <Callout type="info">
-This page tracks **Pear 3.3.0**. Several commands were removed in v3—most notably `pear run`, which is replaced by embedding the **[Pear OTA](/reference/pear/runtime)** (`pear-runtime`) library. Removed commands are kept below with a badge and migration guidance.
+This page tracks **Pear 3.4.0**. Several commands were removed in v3—most notably `pear run`, which is replaced by embedding the **[Pear OTA](/reference/pear/runtime)** (`pear-runtime`) library. Removed commands are kept below with a badge and migration guidance.
 
 Anything a release adds or removes carries an inline badge—<Since v="3.1.0" /> or <Until v="3.1.0" />—so you can tell whether your build has it. Run `pear versions` to check what you are on, and see the [Release Overview](/release-overview) for the full history.
 </Callout>
@@ -73,6 +73,8 @@ Run `npx pear` to move onto the v3 platform. From v3 on, the CLI is a standalone
 
 Hints are advisory terminal output, not results. They are written after the command's own output, and they are **suppressed under [`--json`](#json-output)**, so nothing about them affects a script that parses JSON.
 
+<Since v="3.4.0" /> Hints write to **stderr**. On 3.3.0 they wrote to stdout instead, which is what let one leak into command substitution—see the callout under [`pear touch`](#pear-touch).
+
 Two commands moved existing output into a hint rather than adding one, which does change their default human-readable output:
 
 - [`pear provision`](#pear-provision)'s `Provisioned:` block no longer ends with a `Seed with:` heading and a `pear seed <link>` line.
@@ -98,7 +100,9 @@ For commands that take a subcommand, **where you put `--json` matters—and it i
 | Command | Position | Works | Rejected |
 | --- | --- | --- | --- |
 | [`pear data`](#pear-data), [`pear gc`](#pear-gc) | **before** the subcommand | `pear data --json dht` | `pear data dht --json` |
+| [`pear blind-peer`](#pear-blind-peer) <Since v="3.4.0" /> | **before** the subcommand | `pear blind-peer --json identity` | `pear blind-peer identity --json` |
 | [`pear multisig`](#pear-multisig) | **after** the subcommand | `pear multisig keys list --json` | `pear multisig --json keys list` |
+| [`pear blind-relay`](#pear-blind-relay) <Since v="3.4.0" /> | **after** the subcommand | `pear blind-relay start --json` | `pear blind-relay --json start` |
 
 The wrong position is rejected with `✖ Unrecognized Flag: --json`, so a script that guesses will fail loudly rather than silently emit human-readable text.
 
@@ -135,7 +139,13 @@ pear://<key>
     $ pear stage --dry-run pear://<key> <dir>
 ```
 
-The hint goes to **stdout**, not stderr, so `LINK=$(pear touch)` captures the whole block rather than the link alone. Scripts should use [`--json`](#json-output) and read `.data.link`, which omits the hint entirely, or keep only the first line.
+The hint goes to **stdout**, not stderr, so `LINK=$(pear touch)` captures the whole block rather than the link alone. <Until v="3.4.0" label="Fixed in 3.4.0" /> Scripts should use [`--json`](#json-output) and read `.data.link`, which omits the hint entirely, or keep only the first line.
+</VersionGate>
+
+<VersionGate since="3.4.0">
+<Callout type="info">
+<Since v="3.4.0" /> The hint moved to **stderr**, so `LINK=$(pear touch)` is safe again—command substitution only sees the link. Its indentation changed with it: the title is flush left and its items indent two spaces, where 3.3.0 indented them by two and four.
+</Callout>
 </VersionGate>
 
 ```
@@ -168,6 +178,10 @@ As of Pear v3, `pear build` is provided by the standalone [`pear-build`](https:/
 
 <Callout type="info">
 <Since v="3.3.0" /> `--config [path]` points `pear build` at the project's `pear.json`. It is **mandatory for mobile targets** (`--ios-*`, `--android-arm64`). Added by [`pear-build`](https://github.com/holepunchto/pear-build) v1.2.0, which ships with Pear 3.3.0; the same release also checks up front that each `--<platform-arch>-app` source actually exists.
+</Callout>
+
+<Callout type="info">
+<Since v="3.4.0" /> Each `--<platform-arch>-app` flag can be passed **more than once**, placing several artifacts under the same architecture—which is how a standalone binary ships alongside a desktop app. Every artifact has to be named after `productName` (falling back to `name`), or after one of the `bin` names when `bin` is an object. Added by [`pear-build`](https://github.com/holepunchto/pear-build) v1.3.0, which ships with Pear 3.4.0.
 </Callout>
 
 ```
@@ -205,13 +219,14 @@ Outputs diff information and project link.
 Each time new changes are staged, the length will increase. This change can be replicated to any peer who know the link and is connected. If they run `pear info <link>`, they will see the `length` update even if the application is not being seeded. Connections can potentially linger after seeding an application but will eventually close.
 
 ```
-  --dry-run|-d       Execute a stage without writing
-  --ignore <paths>   Don't stage these comma-separated paths
-  --purge            Also delete already-staged files that now match the ignore list
-  --only <paths>     Only stage these comma-separated paths
-  --truncate <n>     Advanced. Truncate the project to this version length. Destructive — later versions are dropped
-  --json             Newline delimited JSON output
-  --help|-h          Show help
+  --dry-run|-d          Execute a stage without writing
+  --ignore <paths>      Don't stage these comma-separated paths
+  --purge               Also delete already-staged files that now match the ignore list
+  --only <paths>        Only stage these comma-separated paths
+  --truncate <n>        Advanced. Truncate the project to this version length. Destructive — later versions are dropped
+  --skip-package-json   Stage a folder without package.json   [!version since=3.4.0]
+  --json                Newline delimited JSON output
+  --help|-h             Show help
 ```
 
 <VersionGate since="3.3.0">
@@ -222,11 +237,31 @@ Each time new changes are staged, the length will increase. This change can be r
 
 `--ignore` supports glob patterns (`*`, `**`) and a leading `!` to un-ignore. `--only` does not—it matches by exact path or directory prefix. Both **add to** rather than replace the corresponding list in [`pear.json`](/reference/pear/configuration), and `--purge` also switches on automatically when `pear.json` sets `stage.purge`.
 
-`<dir>` defaults to the directory you run the command from. If that directory has no `package.json`, Pear searches upward through its parents for one. Passing a versioned verlink as `<link>` is accepted, but only its key is used—staging always targets the current head and ignores the version segment. `--truncate`'s `n` is the length segment of a verlink (`pear://<fork>.<length>.<key>`).
+`<dir>` defaults to the directory you run the command from. <Until v="3.4.0" label="Changed in 3.4.0" /> On 3.3.0 and earlier, if that directory had no `package.json`, Pear searched upward through its parents for one. Passing a versioned verlink as `<link>` is accepted, but only its key is used—staging always targets the current head and ignores the version segment. `--truncate`'s `n` is the length segment of a verlink (`pear://<fork>.<length>.<key>`).
 
 <Callout type="info">
 <Since v="3.3.0" /> An invalid project directory reports `ERR_INVALID_PROJECT_DIR` as a plain error message. On 3.2.0 and earlier it printed a full stack trace.
 </Callout>
+
+<VersionGate since="3.4.0">
+<Callout type="warn">
+<Since v="3.4.0" /> **`pear stage` no longer searches parent directories for a `package.json`—it looks only in `<dir>` itself.** A project that relied on being staged from a subdirectory of its real root now needs `<dir>` pointed at the root, or `--skip-package-json`.
+
+When `<dir>` has no `package.json` and `--skip-package-json` is not passed:
+
+- Under `--json` or a non-interactive shell, staging fails immediately with `ERR_INVALID_PROJECT_DIR`: `package.json not found in <dir>. Pass --skip-package-json to stage without one`.
+- In an interactive terminal, it prompts instead of failing:
+
+  ```
+  ⚠️  The folder does not contain a valid package.json file. To confirm type "STAGE"
+  Stage folder without package.json? STAGE
+  ```
+
+  Only the literal uppercase `STAGE` is accepted; anything else prints `✖ uppercase STAGE to confirm` and asks again.
+
+A `package.json` that exists but isn't valid JSON, or isn't a JSON object, fails with the new `ERR_INVALID_MANIFEST` rather than being silently ignored.
+</Callout>
+</VersionGate>
 
 <VersionGate since="3.3.0">
 A stage that wrote ends with a [next-step hint](#next-step-hints) suggesting `pear seed` for the staged version, and `pear touch` plus `pear provision --dry-run` for a preview build. A `--dry-run` stage instead suggests re-running without the flag.
@@ -333,6 +368,7 @@ Seeding will sparsely replicate the application. This means the entire history o
 ```
   --no-tty                          Print plain log lines instead of the live terminal UI
   --until-sync <key>                Exit once this peer has synced. Pass multiple flags to wait for more peers   [!version since=3.2.0]
+  --blind-peer <key>                Add the drive being seeded to this blind peer key   [!version since=3.4.0]
   --stats-interval <milliseconds>   Stats refresh interval in milliseconds
   --json                            Newline delimited JSON output
   --help|-h                         Show help
@@ -342,8 +378,20 @@ Seeding will sparsely replicate the application. This means the entire history o
 
 <Since v="3.2.0" /> `--until-sync <key>` takes a peer's public key (z32) and exits automatically once every specified peer has fully synced—pass the flag multiple times to wait for more than one peer. Useful for scripting a seed session that should end on its own instead of running indefinitely. The live view lists Seeding, Drive Key, Drive Length, Discovery Key, Content Key, Firewalled, NAT Type, Whoami and Network above an unlabelled log; the key to pass here is the one printed after each peer join or peer sync line.
 
+<Since v="3.4.0" /> `--blind-peer <key>` takes a [blind peer](/explanation/availability-and-blind-peering)'s public key (z32) and registers the drive being seeded with it, so it stays available after this session ends. The live log shows `adding core`, `confirming add core`, and `added core` lines as the request progresses. Registering does not end the session: the blind peer's key is added to the `--until-sync` set, so `pear seed` then waits for that peer to fully sync the drive's cores before exiting—on a large drive that is a long wait, not a quick handshake. Reaching the blind peer at all has its own 30-second budget, after which the command fails with `ERR_OPERATION_FAILED`, `Timed out connecting to blind peer <key>`. Passing both flags is fine; the blind peer is simply one more key to wait for. This is a one-flag alternative to wiring the [`blind-peering`](https://github.com/holepunchto/blind-peering) client library directly for the common case of registering one drive—see [Keep data available with blind peering](/how-to/blind-peering/keep-data-available-with-blind-peering) for when you'd still reach for the library instead (multiple cores, Autobases, or finer control).
+
+<VersionGate since="3.4.0">
+<Callout type="warn">
+The request asks the blind peer to **announce** the drive, but that only sticks if the blind peer trusts you—its operator has to have started it with `--trusted-peer <your-key>`, where your key is what [`pear blind-peer identity`](#pear-blind-peer) prints on this machine. Against a blind peer that does not trust you the drive is still stored and served, but never announced, so peers will not discover it through that blind peer. Nothing in the command's output distinguishes the two cases; check the blind peer's own logs for a downgraded announce.
+</Callout>
+</VersionGate>
+
 <Callout type="info">
 <Since v="3.2.0" /> The seed session's stats (terminal display and [`--json`](#json-output) `stats` tag) gained a `semver` field alongside `driveLength`. Also fixed: `driveKey`, `discoveryKey`, `contentKey`, and `whoami` in `--json` output are now z32-encoded strings, matching every other Pear key—on 3.1.0 and earlier they were raw hex.
+</Callout>
+
+<Callout type="info">
+<Since v="3.4.0" /> The terminal stats table replaces the standalone `Semantic Version:` row with `App:` (`<name>@<version>`, falling back to `-` when the manifest has neither) and adds a `Blobs Size:` row. The underlying [`--json`](#json-output) `stats` data gains matching `name` and `blobsByteLength` fields—`semver` was already present. On 3.3.0 and earlier the table carries `Semantic Version:` and no blobs size, and `stats` has no `name`.
 </Callout>
 
 ### `pear install <link>`
@@ -351,7 +399,17 @@ Seeding will sparsely replicate the application. This means the entire history o
 
 Install a Pear application—or the Pear platform itself—from a `pear://` link.
 
-`pear install pear://<key>` installs any application built with [`pear build`](#pear-build), pulling it from the swarm and wiring it up locally so it can be launched and kept up to date over the air. It works for both applications and binaries. Installs go directly into the OS application folder.
+`pear install pear://<key>` installs any application built with [`pear build`](#pear-build), pulling it from the swarm and wiring it up locally so it can be launched and kept up to date over the air. It works for both applications and binaries.
+
+<Callout type="info">
+<Since v="3.4.0" /> Where an install lands, and the fact that it can edit your shell config, both changed with [`pear-install`](https://www.npmjs.com/package/pear-install) v1.3.0, which ships with Pear 3.4.0:
+
+- **Applications** go to `~/Applications` on macOS. On Linux Pear uses `~/Applications` or `~/AppImages` if one exists, and falls back to `~/.local/bin`.
+- **Binaries** go to `%LOCALAPPDATA%\Programs\<app>\` on Windows and `~/.local/bin` elsewhere. On non-Windows, installing a binary also **appends `~/.local/bin` to your `PATH` by editing your shell config**—`export PATH=…` for POSIX shells, `fish_add_path` for fish. It checks first, so it will not add a duplicate entry.
+- `--to <dir>` overrides all of the above.
+
+These are user-level locations, not system ones—no `sudo`, and nothing is written to `/Applications`.
+</Callout>
 
 ```
   --only <paths>          Advanced. Filter by app filenames
@@ -386,6 +444,88 @@ Use the pear-runtime module instead: https://www.npmjs.com/package/pear-runtime
 ```
 
 Applications are now launched by embedding the **[Pear OTA](/reference/pear/runtime)** (`pear-runtime`) library, which provides over-the-air peer-to-peer updates, application storage, and Bare workers. See [Migrate from `pear run` to Pear OTA](/how-to/operate-an-app/migration) for the move.
+
+## Blind peers and relays
+<VersionSection since="3.4.0" />
+
+<Since v="3.4.0" /> Two commands bring peer-to-peer availability and connectivity services natively into the platform CLI: **blind peers**, which replicate cores on your behalf without reading them (see [Availability and blind peering](/explanation/availability-and-blind-peering)), and **blind relays**, which forward connections between peers that cannot hole-punch directly (see [Peer-to-peer, demystified](/explanation/peer-to-peer-demystified#hole-punching-and-nat-traversal)). Both existed as separate packages before 3.4.0; these commands run the same functionality through `pear` directly.
+
+### `pear blind-peer [command]`
+
+<a name="pear-blind-peer"></a>
+
+Manage blind peers.
+
+| Command | Description |
+| --- | --- |
+| `start` | Start a blind peer |
+| `identity` | Show peer identity key |
+| `request <key>` | Request a blind peer to seed |
+
+```
+  --trusted-peer <peer>   Trusted peer key to allow requests from (start; repeatable)
+  --peer <peer>           Peer key to request from (request)
+  --core-only             Request only the db core instead of also the content core (request)
+  --json                  Newline delimited JSON output
+  --help|-h               Show help
+```
+
+`--json` is declared on `pear blind-peer` itself, so it goes **before** the subcommand—`pear blind-peer --json identity`, not `pear blind-peer identity --json` (see [`--json` position](#json-output)). Note that [`pear blind-relay`](#pear-blind-relay) takes it the other way round.
+
+**Two different keys are in play, and mixing them up is the easy mistake:**
+
+| Key | Where it comes from | What it's for |
+| --- | --- | --- |
+| The blind peer's own key | `start` prints `Blind peer started listening using public key: <publicKey>` | The **target**: what others pass to [`pear seed --blind-peer <key>`](#pear-seed) or `pear blind-peer request --peer <key>` |
+| A client's identity key | `pear blind-peer identity`, run **on the client machine** | The **authorization**: what the blind peer's operator passes to `start --trusted-peer <peer>` |
+
+`pear blind-peer start` runs the server. `--trusted-peer` may be passed more than once; each value must be a valid public key or the command rejects with `A valid trusted peer key must be specified`. Trust is what decides whether a request is honored in full. A trusted peer's cores are **announced**, so the blind peer advertises itself as a source for them; an untrusted peer's request has `announce` forced to `false`—the cores are still stored and served, but the blind peer never announces them, so peers looking for a source will not find it through the blind peer. Untrusted requests are also capped to a lower retention priority, and deleting a core is refused outright (`Only trusted peers can delete cores`). Only one blind peer runs per sidecar: starting a second fails with `ERR_OPERATION_FAILED`—`Blind peer is already running, cannot start another`. Its storage is a `blind-peer` directory in the Pear platform directory, beside the platform database and [`pear.log`](#sidecar-logs).
+
+`pear blind-peer identity` prints **this machine's** sidecar public key—the identity a blind peer operator authorizes with `--trusted-peer`. It reports that key whether or not a blind peer is running here, and follows it with a hint showing the `start --trusted-peer=<key>` invocation that would authorize it.
+
+`pear blind-peer request <key> --peer <peer>` asks the blind peer at `--peer` to seed `<key>`—a `pear://` link (a drive, or with `--core-only`, a bare core) or a raw public key. Both `--peer` and `<key>` are required and validated; an invalid or missing value fails with `ERR_INVALID_INPUT` before any request is sent.
+
+Without `--core-only` this registers **two** cores—the drive's metadata core and its blobs core—and to do that it first resolves the blobs core over the swarm, so the drive has to be reachable at the time you run it. The request itself gives the blind peer 30 seconds to answer, failing with `ERR_OPERATION_FAILED`, `Timed out connecting to blind peer <key>`. Like [`pear seed --blind-peer`](#pear-seed), the request always asks for the core to be announced—there is no flag to turn that off—so the trust rules above decide whether the announce actually sticks.
+
+This is the platform-native equivalent of running the standalone [`blind-peer-cli`](https://github.com/holepunchto/blind-peer-cli) package—see [Availability and blind peering](/explanation/availability-and-blind-peering#running-a-blind-peer-server) for the operational picture. Note that the disk budget described there is a `blind-peer-cli` flag (`-m <size>`); `pear blind-peer start` exposes no equivalent and uses the library default.
+
+### `pear blind-relay [command]`
+
+<a name="pear-blind-relay"></a>
+
+Run a blind relay for peers that cannot hole-punch directly with each other—similar to TURN for UDX/Protomux streams. A relay pairs two peers by a pre-exchanged token, allocates a stream for each, and forwards messages between them without otherwise participating in the connection.
+
+| Command | Description |
+| --- | --- |
+| `start` | Start the blind relay |
+
+```
+  --no-tty                          Print plain log lines instead of the live terminal UI
+  --stats-interval <milliseconds>   Stats refresh interval in milliseconds
+  --json                            Newline delimited JSON output
+  --help|-h                         Show help
+```
+
+Unlike [`pear blind-peer`](#pear-blind-peer), `--json` here belongs to the `start` subcommand, so it goes **after** it—`pear blind-relay start --json` (see [`--json` position](#json-output)).
+
+`--stats-interval` defaults to 500 milliseconds with the live UI on, or 3000 milliseconds under `--no-tty`—same convention as [`pear seed`](#pear-seed). The live view (and each `--json`/`--no-tty` line) reports `Public Key`; `Sessions` (`Accepted`, `Opened`, `Closed`, `Active`); `Pairings` (`Requested`, `Matched`, `Cancelled`, `Pending`, `Active`); and `Streams` (`Opened`, `Closed`, `Errors`, `Active`). The counters are cumulative for the process's lifetime; `Active` and `Pending` reflect current state.
+
+Like [`pear blind-peer`](#pear-blind-peer), only one relay runs per sidecar—starting a second fails with `ERR_OPERATION_FAILED`, `Blind relay is already running, cannot start another`. The relay's key pair is derived from the platform corestore, so a given machine keeps the same relay key across restarts.
+
+A peer connects through a running relay with the global `--relay <key>` flag below.
+
+### Global `--relay <key>` flag
+
+<a name="relay-flag"></a>
+
+Any command accepts `--relay <key>`, where `<key>` is a running [`pear blind-relay`](#pear-blind-relay)'s public key. An invalid key fails fast, before the command itself runs: `--relay <key> must supply a valid public key`.
+
+Two things about it are easy to get wrong:
+
+- **It registers the relay with the sidecar, not with the command.** The flag sets the relay on the shared, long-running sidecar process, so it stays in effect for everything that sidecar does afterwards—not just the command you passed it to. You only need to pass it once. There is no flag that unsets it; [`pear sidecar shutdown`](#pear-sidecar) clears it by restarting the process.
+- **It is a fallback, not a tunnel.** Registering a relay does not push your traffic through it. The swarm consults it only when a connection actually needs relaying, or when this machine's DHT node is randomized—the unpredictable-NAT case where hole punching cannot work. Otherwise connections stay direct.
+
+Reach for this when direct hole-punching isn't working—see [Relay connections through a blind relay](/how-to/connect-to-peers/relay-connections-through-a-blind-relay) for the end-to-end setup, and [Hole punching and NAT traversal](/explanation/peer-to-peer-demystified#hole-punching-and-nat-traversal) for why it fails.
 
 ## Inspecting apps and links
 
@@ -488,13 +628,13 @@ List platform corestore cores.
 <Since v="3.1.0" /> On 3.0.1 and earlier, `pear cores` fails with `✖ Unrecognized Argument at index 0 with value cores`.
 </Callout>
 
-Lists the cores in the platform corestore, followed by a `Total cores: <n> | Writable: <n>` summary, or `No cores` when the store is empty.
+Lists the cores in the platform corestore, followed by a summary line.
 
 <Callout type="info">
 <Since v="3.3.0" /> Output is a sorted, column-aligned table: application name, a `[core]`/`[blobs]` type column, the `pear://` link, and the length/writable suffix. Rows are ordered named-first, then by name, then by drive, with a drive's `[core]` row ahead of its `[blobs]` row; a core with no application name renders `-`. On 3.2.0 and earlier the output is one plain line per core with no name and no type column.
 </Callout>
 
-<VersionGate since="3.3.0">
+<VersionGate since="3.3.0" until="3.4.0">
 ```
 myapp [core]  pear://<key> (length: 42, writable)
 myapp [blobs] pear://<key> (length: 118, writable)
@@ -503,6 +643,25 @@ Total cores: 3 | Writable: 2
 ```
 
 The name column is padded to the widest name present and the type column to the width of `[blobs]`; every other gap is a single space.
+</VersionGate>
+
+<Callout type="info">
+<Since v="3.4.0" /> The table gains a header row and `Size` column, and the type column drops its brackets. On 3.3.0 it has no header row, no size, and bracketed `[core]`/`[blobs]` types:
+</Callout>
+
+<VersionGate since="3.4.0">
+```
+ Name   Type   Link          Length  Writable  Size
+──────────────────────────────────────────────────────
+ myapp  core   pear://<key>  42      ✔         1.2 MB
+ myapp  blobs  pear://<key>  118     ✔         14.8 MB
+ -      core   pear://<key>  7                 0 B
+──────────────────────────────────────────────────────
+Total cores: 3 (writable: 2)
+Total size:  16 MB
+```
+
+A separator rule also appears between cores belonging to different drives when more than one application is listed. `blobs` rows render dimmed. The empty-store message is now `[ No cores ]`, replacing the bare `No cores` used through 3.3.0. This sample is derived from source (`cmd/cores.js`), not a captured run—re-verify exact spacing against a real 3.4.0 build.
 </VersionGate>
 
 <Callout type="info">
@@ -515,7 +674,7 @@ The name column is padded to the widest name present and the type column to the 
   --help|-h     Show help
 ```
 
-With [`--json`](#json-output), each core is emitted as a `"tag": "core"` object carrying `{ link, writable }` (plus `length` <Since v="3.2.0" />, and `name`, `blobs`, and `drive` <Since v="3.3.0" />—`drive` is the metadata link a blobs core belongs to, and the core's own link otherwise), and the closing `"tag": "final"` object carries `{ count, writable }`. Under `--json` the rows are emitted unsorted, as they are produced—the table ordering above is a terminal-output concern only.
+With [`--json`](#json-output), each core is emitted as a `"tag": "core"` object carrying `{ link, writable }` (plus `length` <Since v="3.2.0" />, `name`, `blobs`, and `drive` <Since v="3.3.0" />—`drive` is the metadata link a blobs core belongs to, and the core's own link otherwise, and `byteLength` <Since v="3.4.0" />), and the closing `"tag": "final"` object carries `{ count, writable }` (plus `byteLength`, the total, <Since v="3.4.0" />). Under `--json` the rows are emitted unsorted, as they are produced—the table ordering above is a terminal-output concern only.
 
 Distinct from [`pear gc cores`](#pear-gc), which *clears* corestore cores rather than listing them.
 
@@ -729,3 +888,5 @@ To scaffold a project, clone the official template instead—[`holepunchto/hello
 - [Manage installed applications](/how-to/manage-installed-applications)—resetting and inspecting installed apps.
 - [Distribute as a binary](/how-to/operate-an-app/build-and-package/distribute-as-binary)—packaging a release built from these commands.
 - [Pear OTA reference](/reference/pear/runtime)—the `pear-runtime` library that replaces `pear run`.
+- [Availability and blind peering](/explanation/availability-and-blind-peering)—the concept behind `pear blind-peer` and `pear seed --blind-peer`.
+- [Peer-to-peer, demystified](/explanation/peer-to-peer-demystified)—hole punching and the relay paths `pear blind-relay` and `--relay` provide as a fallback.

--- a/content/release-overview/index.mdx
+++ b/content/release-overview/index.mdx
@@ -9,6 +9,39 @@ A curated record of changes across Pear and its modules, newest first. Entries a
 
 {/* changelog:insert — automation inserts draft entries below this marker; keep it directly above the newest entry. */}
 
+## 2026-09-09 — Pear 3.4.0
+
+Pear 3.4.0 is a feature release on top of Pear 3.3.0. Nothing in it is breaking, but one change affects existing project layouts: `pear stage` no longer searches parent directories for a `package.json`, so a project staged from a subdirectory of its real root now needs `--skip-package-json` or `<dir>` pointed at the root. Otherwise the release adds blind peers and blind relays as native CLI commands, gives `pear seed` and `pear cores` more informative output, and moves next-step hints to stderr.
+
+### pear (CLI) — v3.4.0
+
+- Added: [`pear blind-peer`](/reference/pear/cli#pear-blind-peer)—`start [--trusted-peer <peer>]` runs a blind peer server natively, `identity` prints this machine's key for an operator to authorize, and `request <key> --peer <peer>` asks a blind peer to seed something on demand. See [Availability and blind peering](/explanation/availability-and-blind-peering).
+- Added: [`pear blind-relay start`](/reference/pear/cli#pear-blind-relay) and the global [`--relay <key>`](/reference/pear/cli#relay-flag) flag—run a relay for peers that cannot hole-punch directly, and route a command's connections through one. See [Peer-to-peer, demystified](/explanation/peer-to-peer-demystified#hole-punching-and-nat-traversal).
+- Added: [`pear seed --blind-peer <key>`](/reference/pear/cli#pear-seed) registers the drive being seeded with a blind peer in one flag, without wiring the `blind-peering` client directly.
+- Added: [`pear stage --skip-package-json`](/reference/pear/cli#pear-stage) stages a folder without a `package.json`.
+- Changed: [`pear stage`](/reference/pear/cli#pear-stage) no longer searches parent directories for a `package.json`—only `<dir>` itself is checked. Interactively it now prompts for typed `STAGE` confirmation when none is found; under `--json` or a non-interactive shell it fails immediately with `ERR_INVALID_PROJECT_DIR` instead.
+- Changed: [`pear cores`](/reference/pear/cli#pear-cores) prints a header row and a `Size` column with a total-size summary; the type column drops its `[...]` brackets.
+- Changed: [`pear seed`](/reference/pear/cli#pear-seed)'s stats replace the standalone `Semantic Version:` row with `App: <name>@<version>` and add a `Blobs Size:` row.
+- Changed: [next-step hints](/reference/pear/cli#next-step-hints) write to stderr instead of stdout—`LINK=$(pear touch)` no longer risks capturing one.
+
+### blind-peer, blind-peering, blind-relay — new to Pear's dependency tree
+
+New bundled packages backing the commands above: [`blind-peer`](https://github.com/holepunchto/blind-peer) v3.12.6 (server), [`blind-peering`](https://github.com/holepunchto/blind-peering) v2.6.3 (client), [`blind-relay`](https://github.com/holepunchto/blind-relay) v1.6.1 (relay protocol). None carry a dedicated reference page—see [Availability and blind peering](/explanation/availability-and-blind-peering) and the `pear blind-peer`/`pear blind-relay` CLI reference instead.
+
+### pear-build — v1.3.0
+
+- Added: each [`--<platform-arch>-app`](/reference/pear/cli#pear-build) flag accepts multiple values, so a standalone binary can ship alongside a desktop app under one architecture. Each artifact must be named after `productName`/`name`, or after a `bin` name when `bin` is an object.
+
+### pear-install — v1.3.0
+
+- Changed: [`pear install`](/reference/pear/cli#pear-install) places applications in `~/Applications` (macOS, and Linux where it or `~/AppImages` exists), and binaries in `%LOCALAPPDATA%\Programs\<app>\` on Windows or `~/.local/bin` elsewhere—all user-level, no `sudo`.
+- Added: installing a binary on non-Windows appends `~/.local/bin` to `PATH` by editing your shell config (`export PATH=…`, or `fish_add_path` for fish), skipping it when already present.
+- Fixed: `--timeout <seconds>` works, and an unset `SHELL` no longer breaks shell-config detection.
+
+### Internal — deps bump
+
+`hyperdht` v6.33.2 (now a direct pin), `pear-ipc` v6.15.0. No documented surface changes.
+
 ## 2026-08-24 — Pear 3.3.0
 
 Pear 3.3.0 is a feature release on top of Pear 3.2.0. Nothing in it is breaking, but one change affects scripts: `pear gc cores` now stops for typed confirmation before clearing a writable core. Otherwise the release is about making the CLI easier to follow—deployment commands suggest the next step, `pear cores` prints a readable table, and help text and per-field hints were rewritten across every command.

--- a/docs/plans/PEAR-3.4.0-RELEASE-PLAN.md
+++ b/docs/plans/PEAR-3.4.0-RELEASE-PLAN.md
@@ -1,0 +1,184 @@
+# Pear 3.4.0 docs update — review and execution plan
+
+Status: implemented against the final `v3.4.0` tag (upstream cut it before this pass started—no rc gap to track down, unlike 3.3.0).
+
+Base branch: `feat/3.4.0-updates`, cut from `published` after fast-forwarding local `published` 13 commits to match `origin/published` (it had drifted behind since before 3.2.0 shipped).
+
+This plan mirrors the process used for 3.3.0 (`PEAR-3.3.0-RELEASE-PLAN.md`, PR #357): review the upstream surface diff, update the reference pages with version-gated badges, register the new doc-state, extend the release-overview changelog, and re-run the drift checks.
+
+## 0. Baseline correction
+
+Two bookkeeping pins were never advanced past their pre-3.2.0-review values despite 3.2.0 and 3.3.0 both having shipped and been fully documented:
+
+- `scripts/upstream-commits-state.json`'s `pear-cli` was still `e388e63c7571613fb99d3b519821fbb2db9f78a2`.
+- `scripts/upstream-releases-state.json`'s `holepunchto/pear` was still `v3.2.0`.
+
+Both are bumped straight to `v3.4.0` / its commit SHA as part of this release (§5)—no separate catch-up pass.
+
+## 1. Review the upstream delta
+
+### 1.1 Commits in scope
+
+`v3.3.0..v3.4.0` is 16 commits (from a scratch clone of `holepunchto/pear`):
+
+| Commit | Subject |
+| --- | --- |
+| `16204fa` | 3.4.0 |
+| `392b007` | CHANGELOG |
+| `983c1c2` | Implement `pear seed --blind-peer <key>` (#1210) |
+| `12479ac` | output hints through std err (#1213) |
+| `d133cc3` | add relay flag (#1209) |
+| `aa01463` | fix blind relay (#1212) |
+| `aee742c` | stage without package.json (#1207) |
+| `4616ab6` | adjust hint tabs (#1208) |
+| `a0e71f0` | remove tests numbers (#1206) |
+| `a124322` | use inner sidecar error details in CLI output (#1196) |
+| `c68e7db` | Add blind-peer (#1195) |
+| `b0fe863` | pear seed blobs size (#1205) |
+| `6580285` | pear seed: field `App: {name}@{version}` (#1202) |
+| `f45db56` | Fix error handling in pear seed and blind-relay (#1204) |
+| `d0c575f` | bump deps (#1203) |
+| `7ce9260` | Implement pear blind-relay start (#1201) |
+| `0536b1c` | `$ pear cores` improvements (#1198) |
+| `a79f418` | 3.4.0-rc.0 (#1200) |
+
+Files touched (`git diff v3.3.0 v3.4.0 --stat -- cmd/ lib/ subsystems/`): two new commands—`cmd/blind-peer.js` (118 lines), `cmd/blind-relay.js` (177 lines)—plus `cmd/index.js`, `cmd/cores.js`, `cmd/seed.js`, `cmd/stage.js`, `lib/cmd.js`, `lib/terminal.js`, a new `lib/package.js`, and matching `subsystems/sidecar/` wiring. 16 files, +1166/-124.
+
+### 1.2 Upstream's own CHANGELOG.md for v3.4.0
+
+**Features:** `pear blind-peer` (`start --trusted-peer <peer>`, `identity`, `request <key> [--peer <peer>] [--core-only]`); `pear blind-relay start [--no-tty] [--stats-interval <ms>]`; `pear seed --blind-peer <key>` (implies exit-on-complete like `--until-sync`); global `pear --relay <key>`; `pear stage --skip-package-json`.
+
+**Improvements:** `pear cores` gains a header row plus `Length`/`Writable`/`Size` columns and a total-size summary; `pear seed` gains an `App: <name>@<version>` field and blobs size in its output; hints now write to stderr instead of stdout, with adjusted alignment; `pear stage`'s `package.json` validation is hardened—no more upward search through parent directories; internal deps bump.
+
+No "Fixes" section this release. Nothing is called out as breaking upstream, but two items affect existing automation (see §2.5, §2.6).
+
+## 2. API and CLI surface changes to document
+
+All in `content/reference/pear/cli.mdx`, using `<Since v="3.4.0" />`, `<VersionSection>`, `<VersionGate>`, or `[!version since=3.4.0]` per `docs/plans/VERSIONED-REFERENCE-AUTHORING.md`.
+
+### 2.1 `pear blind-peer` — new command group (highest-impact item)
+
+From `cmd/blind-peer.js` + the `cmd/index.js` registration:
+
+- `pear blind-peer start [--trusted-peer <peer>]`—starts a blind peer server. `--trusted-peer` is repeatable (`.multiple()`); each value must be a valid hypercore-id key or the command rejects with `A valid trusted peer key must be specified`. Prints `Blind peer started listening using public key: <publicKey>`.
+- `pear blind-peer identity`—prints the running peer's own public key (unconditionally to stdout, even under most flag combinations), then a hint suggesting `pear blind-peer start --trusted-peer=<key>`.
+- `pear blind-peer request <key> --peer <peer> [--core-only]`—asks a specific blind peer (`--peer`, required, validated) to seed `<key>`. `<key>` may be a `pear://` link (parsed as a drive link, or a core key under `--core-only`) or a raw hypercore-id key; both `--peer` and `<key>` reject with `ERR_INVALID_INPUT` when missing/invalid. Prints `Requested blind peer to seed {core|drive} <key> (announce: <announce>)`.
+- `--json` is declared on the parent `blind-peer` command (applies to all three subcommands).
+
+This is new territory for the CLI reference—no existing section to extend, so it needs a new `##` heading. Group it near `pear seed`/`pear install` ("Distributing and running apps") since it's part of the same seeding/availability story, not with the maintenance commands.
+
+Concept cross-link: **`docs/plans` note—do not re-explain blind peering from scratch.** `content/explanation/availability-and-blind-peering.mdx` and `content/how-to/blind-peering/keep-data-available-with-blind-peering.mdx` already document the concept in depth, built around the standalone `blind-peer-cli` package (`npm i -g blind-peer-cli`) and the `blind-peering` client library. Both need updating to mention `pear blind-peer` as the now-native alternative that ships with the platform—not a new page. See §6.
+
+### 2.2 `pear blind-relay` — new command group
+
+From `cmd/blind-relay.js`:
+
+- `pear blind-relay start [--no-tty] [--stats-interval <milliseconds>]`—runs a blind relay: a host that relays UDX/Protomux stream messages between two peers that cannot hole-punch directly (TURN-like). Confirmed against the upstream `blind-relay` package's own README (protocol + stats shape).
+- Live stats table (TTY) / NDJSON-per-line (`--no-tty`) fields: `Public Key`, `Sessions {Accepted,Opened,Closed,Active}`, `Pairings {Requested,Matched,Cancelled,Pending,Active}`, `Streams {Opened,Closed,Errors,Active}`. `--stats-interval` defaults to 500ms with the live UI, 3000ms under `--no-tty`—same convention as `pear seed`.
+- `--no-tty`'s hint text: "In the interactive form this appears as an unchecked 'tty' box; checking it passes --no-tty and turns off the live UI"—reuse or paraphrase for the reference prose.
+
+This pairs with the new global `--relay <key>` flag (§2.4)—a blind relay is the server; `--relay` is how a peer *uses* one. Cross-link both directions, and add a concrete pointer to this from `content/explanation/peer-to-peer-demystified.mdx`'s existing (currently vague) "Pear also supports relay paths when direct connectivity fails" sentence (§6).
+
+### 2.3 `pear seed --blind-peer <key>`
+
+- New flag, positioned between `--until-sync` and `--stats-interval` in the flags block. Validated as a z32 key (`ERR_INVALID_INPUT` otherwise). Adds the drive being seeded to the given blind peer; like `--until-sync`, causes the session to exit once the add-to-blind-peer flow completes rather than seeding indefinitely (confirmed: `if (ctrlTTY && (untilSync || blindPeer)) Bare.exit(0)`).
+- New live-log lines while it runs: `adding core <key> to blind peer <peer>`, `confirming add core <key> to blind peer <peer>`, `added core <key> to blind peer <peer>`.
+- **Table shape change** (not called out in upstream's CHANGELOG, found in the diff): the stats table's standalone `Semantic Version:` row (added in 3.2.0) is replaced by `App:` (`<name>@<version>`, or `-` when the manifest has neither) and a new `Blobs Size:` row. The underlying `--json` `stats` data gains matching `name` and `blobsByteLength` fields—`semver` was already present, `name` is new.
+- This is the one-flag alternative to hand-wiring the `blind-peering` client library shown in the existing how-to guide—worth a sentence in `content/how-to/blind-peering/keep-data-available-with-blind-peering.mdx` (§6), not a full rewrite.
+
+### 2.4 Global `--relay <key>` flag
+
+Declared in `lib/cmd.js` alongside `--log-level`, `--sidecar`, `--dht-bootstrap`, `--menu`. Validated in `cmd/index.js`: must be a valid hypercore-id public key or the command prints `--relay <key> must supply a valid public key` and exits 1; otherwise calls `ipc.relay({ publicKey })` before running the actual command. Usable with any command, like `--log-level`. Document it near the new `pear blind-relay` section rather than inventing a "global flags" table that doesn't otherwise exist on this page (the existing convention documents `--menu` under its own heading and `--log-level` under `pear sidecar`).
+
+### 2.5 `pear stage --skip-package-json` and hardened validation
+
+- New flag: `--skip-package-json`—stage a folder without a `package.json`.
+- **Behavior change:** `localPkg()` no longer searches upward through parent directories for a `package.json` (confirmed via the `subsystems/sidecar/ops/stage.js` diff—the old recursive-parent-search function is deleted outright, replaced by the new `lib/package.js` which reads exactly `dir`). The `<dir>` arg's hint text is updated to match (the "Pear searches upward through parent directories" sentence is removed upstream).
+- If `package.json` is missing and `--skip-package-json` is not passed:
+  - Under `--json` or a non-TTY shell: fails immediately with `ERR_INVALID_PROJECT_DIR`, message `package.json not found in <dir>. Pass --skip-package-json to stage without one`.
+  - Interactively: prompts for typed `STAGE` confirmation (`ansi.warning` + "The folder does not contain a valid package.json file. To confirm type \"STAGE\"", re-prompting on anything else with `✖ uppercase STAGE to confirm`)—same confirmation pattern as 3.3.0's `pear gc cores`, but note the difference: **scripts get a clear error, not a hang**, since the `--json`/non-TTY branch never reaches the prompt.
+  - If `package.json` exists but isn't valid JSON or isn't an object: new error code `ERR_INVALID_MANIFEST` (added to the CLI's error codemap as message-only).
+- `staging` output's header line falls back to the directory name when there's no `package.json` name to show (`Staging ${name || dir}`).
+
+This is the item worth a `<Callout type="warn">` similar to 3.3.0's `gc cores` one—it's the only genuinely breaking-ish behavior change this release (a project that relied on the upward parent search now fails, or needs `--skip-package-json`/a `package.json` at the exact stage dir).
+
+### 2.6 `pear cores` — table format changed again
+
+Second rework in two releases (3.3.0 added the name/type columns; this replaces that table wholesale):
+
+- Real header row (`Name  Type  Link  Length  Writable  Size`, bold) plus a separator rule above and below, and between groups of cores belonging to different drives.
+- `Type` values are now bare `core`/`blobs` (no brackets—3.3.0's `[core]`/`[blobs]` are gone).
+- New `Size` column (byte-formatted, via the existing `byteSize` helper), `Writable` renders `✔` or blank instead of the old `(length: N, writable)` suffix.
+- `blobs` rows render dimmed/gray.
+- Summary line: `Total cores: N (writable: M)` on one line, `Total size:  <byteSize>` on the next—replaces 3.3.0's `Total cores: N | Writable: M`.
+- Empty state: `[ No cores ]`, replacing the bare `No cores`.
+- `--json`: each `"tag": "core"` object gains `byteLength`; the closing `final` object gains `byteLength` (total).
+
+This fully supersedes the 3.3.0 sample block at `content/reference/pear/cli.mdx` around the `pear cores` section—replace it rather than layering another `<VersionGate>` on top, and gate the *new* block `since="3.4.0"`, keeping the 3.3.0 block behind its existing gate for readers on that doc-state.
+
+### 2.7 Hints move to stderr, and re-indent
+
+`lib/terminal.js`'s `hint()`: was `stdio.out.write(out)` (title indented 2 spaces, items indented 4); now `stdio.err.write(out + '\n')` (title flush left, items indented 2, trailing blank line). This directly affects the `<Callout type="info">` at `content/reference/pear/cli.mdx` around the `--json`/`pear touch` interaction (lines 92–94 as of 3.3.0), which explicitly says the next-step hint goes to **stdout** and is captured by command substitution—**that becomes false in 3.4.0** and needs a `<Since v="3.4.0" />` correction, not just an addition. Same for the "Next-step hints" section's general framing (§67–81 as of 3.3.0), which never mentions a stream at all—now worth stating explicitly.
+
+### 2.8 Hint text/tabs and internal error-plumbing
+
+`4616ab6` "adjust hint tabs" and `a124322` "use inner sidecar error details in CLI output" are internal formatting/plumbing changes with no distinct user-facing surface beyond what §2.7 already covers—skip separate documentation, matching how 3.3.0's plan treated similarly internal commits (`a0e71f0` "remove tests numbers" is a test-only change, also skip).
+
+## 3. Dependency updates (full audit, per your instruction)
+
+From `git diff v3.3.0 v3.4.0 -- package.json`:
+
+| Package | From | To | Action |
+| --- | --- | --- | --- |
+| `hyperdht` | (indirect) | `^6.33.2` (direct pin) | Already a documented building-block (`content/reference/building-blocks/hyperdht.mdx`); confirm its `upstreamVersion` pin is current via `check:upstream-pins`—Release Overview already notes Pear 3.3.0 bundled 6.33.1 vs. current 6.33.2, so this may already be settled. |
+| `pear-ipc` | `^6.12.0` | `^6.15.0` | No dedicated reference page (internal IPC transport, listed only in the `pear-modules.mdx` catalog table). Check its GitHub releases for anything observably different; likely an "Internal — deps bump" line. |
+| `blind-peer` | — (new) | `^3.12.6` | Server library `pear blind-peer` wraps. **No dedicated reference page**—matches existing precedent: `content/explanation/availability-and-blind-peering.mdx` already links `blind-peer` externally rather than documenting its API, because its own README documents almost no public surface beyond a bare `require('blind-peer')` (it's meant to be run via a CLI, not called directly). |
+| `blind-peering` | — (new, already a dependency of end-user apps, now also embedded in Pear itself) | `^2.6.3` | Real documented client API (`BlindPeering` class: `addCore`, `addAutobase`, `sendNotification`, `suspend`/`resume`/`close`, etc.)—**but already covered externally** by the existing explanation/how-to pages, which link straight to its README rather than duplicating it in `/reference/helpers/`. Keep that precedent; don't add a new reference page. |
+| `blind-relay` | — (new) | `^1.6.1` | Protocol-level (wire messages + stats), already covered inline by §2.2's CLI reference section. No dedicated reference page, same reasoning. |
+
+**Ran `npm run check:upstream-pins`.** Result: `hyperdht`'s existing 6.33.2 pin already matches exactly what Pear 3.4.0 bundles—no change needed. `pear-ipc` has no dedicated reference page to pin. The checker also reports 30 pages of drift (19 patch, 9 minor, 1 major, 6 unpinned)—but every one of those is pre-existing site-wide drift against each package's current npm latest, unrelated to Pear's own 3.4.0 lockfile bump (e.g. `bare-tty`, `bare-ws`, `bare-https`, `hypercore`, `corestore`—none of these moved in Pear's `package.json` between 3.3.0 and 3.4.0). Scoping "full audit" to what this release actually bumped (per your instruction, "every bumped package") means none of that backlog belongs in this PR—same call the 3.3.0 plan made for its own leftover drift (§7.7 there). Left alone as a separate, pre-existing pass.
+
+## 4. Update the Release Overview
+
+New `## <ship-date> — Pear 3.4.0` section, directly below the `changelog:insert` marker and above `## 2026-08-24 — Pear 3.3.0`. Lede: feature release, not breaking by upstream's own classification, but flag the `package.json` upward-search removal (§2.5) as the one item that can break an existing project layout. `### pear (CLI) — v3.4.0` subheadings per §2.1–2.7, deep-linking into the new `cli.mdx` anchors and into `/explanation/availability-and-blind-peering` and `/explanation/peer-to-peer-demystified` for the new commands' concepts. Add module subheadings for `blind-peer`, `blind-peering`, and `blind-relay` (all new to the lockfile) and `pear-ipc` if its bump is observable; fold `hyperdht` in only if its patch delta between what 3.3.0 bundled and 3.4.0 bundles has anything new (likely already covered per §3).
+
+Run `npm run sync:upstream-releases` first and edit its draft rather than hand-writing from scratch.
+
+## 5. Bookkeeping
+
+| File | Change |
+| --- | --- |
+| `src/lib/docs-versions.ts` | Add `{ label: '3.4', value: '3.4.0', stable: true }`; drop `stable` from 3.3. |
+| `scripts/upstream-commits-state.json` | `pear-cli`: `e388e63c7571613fb99d3b519821fbb2db9f78a2` → `16204fad1dc0769ea30048fb096ce2f837dce131` (the `v3.4.0` tag's commit). |
+| `scripts/upstream-releases-state.json` | `holepunchto/pear`: `v3.2.0` → `v3.4.0`. |
+| `content/reference/pear/cli.mdx` | Tracking callout → 3.4.0. |
+| `content/release-overview/index.mdx` | New section (§4). |
+
+## 6. Concept/how-to pages to update (not create)
+
+Discovered mid-pass: `content/explanation/availability-and-blind-peering.mdx` and `content/how-to/blind-peering/*.mdx` already document blind peering in depth, built around the standalone `blind-peer-cli` package and manual `blind-peering` client wiring—predating Pear 3.4.0's native CLI integration. Updates, not new pages:
+
+- `content/explanation/availability-and-blind-peering.mdx`: in "Running a blind peer server," add `pear blind-peer start [--trusted-peer <key>]` as the platform-native alternative to `npm i -g blind-peer-cli`. In "Registering cores from an application," note `pear seed --blind-peer <key>` as a zero-code shortcut for the common single-drive case, alongside the full `BlindPeering` client for multi-core/Autobase registration.
+- `content/how-to/blind-peering/keep-data-available-with-blind-peering.mdx`: update the "Two roles" table and "Run your own blind peer" section the same way.
+- `content/explanation/peer-to-peer-demystified.mdx`: the "Hole punching and NAT traversal" section's sentence "Pear also supports relay paths when direct connectivity fails" is currently vague/forward-looking—make it concrete with a pointer to `pear blind-relay` and `--relay <key>` (in prose, since explanation pages carry no version axis—express the version as "As of Pear 3.4.0" rather than a `<Since>` badge).
+
+## 7. Output samples
+
+Derive `pear cores`, `pear seed`, `pear stage`, `pear blind-peer`, `pear blind-relay` sample output from source (the scratch clone's `cmd/*.js`, `lib/terminal.js`) since the local `pear` install here is 3.3.0. Flag each for recapture against a real 3.4.0 build.
+
+## 8. Verification
+
+```bash
+npm run check:docs-versions
+npm run check:upstream-pins
+npm run check:internal-links && npm run check:cross-links && npm run check:doctypes
+npm run types:check && npm run lint && npm run build
+npm run check:examples && npm run check:includes
+```
+
+## 9. Flagged: items that needed a decision, not just an edit
+
+1. **New commands vs. new pages.** Given the existing blind-peering explanation/how-to content, the right move is updating it in place rather than writing a parallel concept page—confirmed by reading both files before writing anything new.
+2. **`blind-peering`'s real API doesn't get its own reference page.** It has one (unlike `blind-peer`/`blind-relay`), but the docs team already chose to cover it via the explanation/how-to pages rather than `/reference/helpers/`—matching that precedent instead of introducing a second, redundant treatment.
+3. **`package.json` upward-search removal is this release's `gc cores`-confirmation-equivalent**—the one item that deserves a warning callout, not just a bullet, because it can silently change which `package.json` a project stages against (or fail where it previously succeeded).
+4. **Hint stream change invalidates existing prose**, not just adds new prose—the `--json`/`pear touch` callout's claim that hints go to stdout needs correcting, not appending to.

--- a/scripts/upstream-commits-state.json
+++ b/scripts/upstream-commits-state.json
@@ -84,5 +84,5 @@
   "building-block:mirrordrive": "4306c697b296e0da18e4db8973789208dc20d4ff",
   "building-block:protomux": "9cf17f2ecc7cb9d4e197ec146a483233a3e27888",
   "building-block:secretstream": "b022ed663bbebb59b55b92f87c23e672028c191b",
-  "pear-cli": "e388e63c7571613fb99d3b519821fbb2db9f78a2"
+  "pear-cli": "06d118de02ff6c9be23345888d48903dbc2c7a9f"
 }

--- a/scripts/upstream-releases-state.json
+++ b/scripts/upstream-releases-state.json
@@ -1,10 +1,10 @@
 {
-  "holepunchto/pear": "v3.2.0",
+  "holepunchto/pear": "v3.4.0",
   "holepunchto/pear-runtime": "v1.3.1",
   "holepunchto/pear-runtime-updater": "v3.4.0",
   "holepunchto/pear-electron": "v1.9.0-rc.0",
-  "holepunchto/pear-build": "v1.2.0",
-  "holepunchto/pear-install": "v1.2.2",
+  "holepunchto/pear-build": "v1.3.0",
+  "holepunchto/pear-install": "v1.3.0",
   "holepunchto/bare": "v1.30.3",
   "holepunchto/hypercore": "v11.35.2",
   "holepunchto/hyperbee": "v2.27.3",

--- a/src/lib/custom-tree.ts
+++ b/src/lib/custom-tree.ts
@@ -198,6 +198,11 @@ export const customTree: Node[] = [
             name: 'Host multiple rooms in one chat app',
             url: '/how-to/connect-to-peers/host-multiple-rooms-in-one-chat-app',
           },
+          {
+            type: 'page',
+            name: 'Relay connections through a blind relay',
+            url: '/how-to/connect-to-peers/relay-connections-through-a-blind-relay',
+          },
         ],
       },
       {

--- a/src/lib/docs-versions.ts
+++ b/src/lib/docs-versions.ts
@@ -40,7 +40,8 @@ export interface DocsVersion {
  * by a gate in `content/` present here.
  */
 export const DOCS_VERSIONS: DocsVersion[] = [
-  { label: '3.3', value: '3.3.0', stable: true },
+  { label: '3.4', value: '3.4.0', stable: true },
+  { label: '3.3', value: '3.3.0' },
   { label: '3.2', value: '3.2.0' },
   { label: '3.1', value: '3.1.0' },
   { label: '3.0', value: '3.0.0' },


### PR DESCRIPTION
## Summary
- Registers 3.4 as the stable doc-state and documents the new `pear blind-peer`/`pear blind-relay` commands, the global `--relay` flag, `pear seed --blind-peer`, `pear stage --skip-package-json` (and its hardened `package.json` validation), the reworked `pear cores` table, and next-step hints moving from stdout to stderr.
- Updates the pre-existing blind-peering explanation/how-to pages to point at the new native commands instead of only the standalone `blind-peer-cli`/`blind-peering` packages, and makes `peer-to-peer-demystified.mdx`'s relay mention concrete.
- Adds the matching Release Overview entry and bumps the `pear-cli`/`holepunchto/pear` bookkeeping pins, which had drifted since before 3.2.0.
- Includes `docs/plans/PEAR-3.4.0-RELEASE-PLAN.md`, the execution record (upstream diff, per-command changes, dependency audit findings).

## Test plan
- [x] `npm run check:docs-versions`, `check:internal-links`, `check:cross-links`, `check:doctypes`, `check:includes`, `check:examples:lint`, `types:check`, `lint` all pass
- [x] `npm run check:upstream-pins` run — no changes needed for this release's own dependency bump (hyperdht's existing pin already matches what 3.4.0 bundles); the 30 pages of unrelated pre-existing drift it reports are out of scope for this PR
- [x] Verified rendering via `npm run dev`: new sections, badges, and cross-links render correctly in the default (annotate) view
- [ ] Command output samples for `pear cores`, `pear seed`, `pear blind-peer`, `pear blind-relay` are derived from source (local `pear` install is still 3.3.0) — flagged in the plan doc for recapture against a real 3.4.0 build
- [x] Re-diff against the final tag: upstream **re-cut `v3.4.0`** on release day (force-updated `release/3.4.x`, now a lightweight tag at `06d118d`, was annotated at `16204fa`). Re-diffed: the only delta is `pear-install ^1.0.8 → ^1.3.0`; no `cmd/`, `lib/` or `subsystems/` changes, so the documented CLI surface is unaffected. Pin and docs updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

