### PR TITLE
Fix setState-in-effect lint error in the react-native example

### DIFF
--- a/content/getting-started/from-a-template/start-from-hello-pear-react-native.mdx
+++ b/content/getting-started/from-a-template/start-from-hello-pear-react-native.mdx
@@ -106,7 +106,7 @@ Desktop's `hello-pear-electron` splits into three processes—renderer, Electron
 
 Your UI lives in `src/App.tsx`. On mount, it starts the worklet with [`PearRuntime.run`](/reference/pear/mobile#starting-the-worklet-react-native-side) and wraps its `IPC` in a [`FramedStream`](https://www.npmjs.com/package/framed-stream):
 
-```js file=<rootDir>/examples/getting-started/hello-pear-react-native/src/App.tsx#L24-L30 title="src/App.tsx"
+```js file=<rootDir>/examples/getting-started/hello-pear-react-native/src/App.tsx#L28-L34 title="src/App.tsx"
 ```
 
 There is no framework requirement beyond Expo/React Native itself—the template ships plain `View`/`Text`/`Pressable`, but bring your own component library. The only rule is: your UI reaches the peer-to-peer core **only** through this one IPC pipe.

--- a/examples/getting-started/hello-pear-react-native/src/App.tsx
+++ b/examples/getting-started/hello-pear-react-native/src/App.tsx
@@ -1,6 +1,6 @@
 /* global __DEV__ */
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import { LinearGradient } from 'expo-linear-gradient'
 import { reloadAppAsync } from 'expo-modules-core'
 import { StatusBar } from 'expo-status-bar'
@@ -17,8 +17,12 @@ const appName = productName ?? name
 export default function App() {
   const [status, setStatus] = useState('')
   const [error, setError] = useState('')
-  const [applyUpdate, setApplyUpdate] = useState<(() => void) | null>(null)
   const shouldReload = useRef(false)
+  const pipeRef = useRef<InstanceType<typeof FramedStream> | null>(null)
+
+  const applyUpdate = useCallback(() => {
+    pipeRef.current?.write('pear:applyUpdate')
+  }, [])
 
   useEffect(() => {
     const IPC = PearRuntime.run('/worker.bundle', bundle, [
@@ -28,8 +32,7 @@ export default function App() {
       appName
     ])
     const pipe = new FramedStream(IPC)
-
-    setApplyUpdate(() => () => pipe.write('pear:applyUpdate'))
+    pipeRef.current = pipe
 
     pipe.on('data', (data) => {
       const parsed = b4a.toString(data)
@@ -73,6 +76,7 @@ export default function App() {
     pipe.on('error', (err) => console.error(err))
 
     return () => {
+      pipeRef.current = null
       pipe.destroy()
     }
   }, [])
@@ -99,12 +103,12 @@ export default function App() {
         <Text style={styles.title}>{title}</Text>
         {(status === 'updated' || status === 'applying') && (
           <Pressable
-            disabled={status === 'applying' || !applyUpdate}
+            disabled={status === 'applying'}
             onPress={() => {
               setStatus('applying')
               try {
                 shouldReload.current = true
-                applyUpdate?.()
+                applyUpdate()
               } catch (err) {
                 shouldReload.current = false
                 setError(`Update failed: ${err instanceof Error ? err.message : String(err)}`)


### PR DESCRIPTION
## Summary
`npm run lint` currently fails on `published`. `examples/getting-started/hello-pear-react-native/src/App.tsx` stores the update callback in state and assigns it from the effect body, which `react-hooks/set-state-in-effect` flags — it forces a second render on mount.

Holds the pipe in a ref and derives `applyUpdate` with `useCallback` instead. The `Pressable`'s `!applyUpdate` guard goes with it: `applyUpdate` is now always defined, and the ref's optional call no-ops if the pipe is gone, which is what the guard was doing.

Found while reviewing #368 — unrelated to that PR, so it's split out here.

## Note
**No CI job runs eslint**, which is why this landed green. Worth adding one, but that would start failing other PRs until the tree is clean, so I've left it out of this change rather than bundle a workflow change with a fix.

## Test plan
- [x] `npm run lint` — clean (was 1 error)
- [x] `npm run types:check` — passes
- [ ] Not exercised at runtime: this is an Expo/React Native example and I can't run it here. The change is behaviour-preserving by inspection, but a quick manual check of the update button on a device would be worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)