### PR TITLE
docs: add pear-runtime-react-native reference page

### DIFF
--- a/content/getting-started/from-a-template/start-from-hello-pear-react-native.mdx
+++ b/content/getting-started/from-a-template/start-from-hello-pear-react-native.mdx
@@ -86,7 +86,7 @@ npm run production:android
 | [`workers/main.js`](https://github.com/holepunchto/hello-pear-react-native/blob/main/workers/main.js) | The app logic—a [Bare](/reference/modules/bare-modules) worker that owns the swarm, storage, and updater. | Yes—this is your backend. |
 | [`package.json`](https://github.com/holepunchto/hello-pear-react-native/blob/main/package.json) | App metadata, scripts, and the `upgrade` link. | Yes—branding and release link. |
 | [`pear.json`](https://github.com/holepunchto/hello-pear-react-native/blob/main/pear.json) | The `updates.minver` compatibility floor. Ships inside every OTA payload, so a `multisig` block added here travels with it. | At production time. |
-| [`app.json`](https://github.com/holepunchto/hello-pear-react-native/blob/main/app.json) | Expo config—icons, bundle identifiers, and the `pear-runtime-react-native` config plugin registration. | Yes—brand assets and platform identifiers. |
+| [`app.json`](https://github.com/holepunchto/hello-pear-react-native/blob/main/app.json) | Expo config—icons, bundle identifiers, and the [`pear-runtime-react-native`](/reference/pear/mobile-boot-control) config plugin registration. | Yes—brand assets and platform identifiers. |
 | [`metro.config.js`](https://github.com/holepunchto/hello-pear-react-native/blob/main/metro.config.js) | Merges the React Native and Expo Metro defaults, used to produce OTA payloads. | Rarely. |
 | [`scripts/check-upgrade.js`](https://github.com/holepunchto/hello-pear-react-native/blob/main/scripts/check-upgrade.js) | Validates `package.json#upgrade` before `npm run ios`/`android` hand off to Expo. | Rarely. |
 

--- a/content/reference/index.mdx
+++ b/content/reference/index.mdx
@@ -18,6 +18,7 @@ If you're trying to accomplish a specific task, see **[How To](/how-to)**. For t
 - [Pear CLI](/reference/pear/cli)—covers `pear stage`, `pear seed`, `pear build`, `pear install`, and every flag.
 - [Pear OTA](/reference/pear/runtime)—the `pear-runtime` library and JavaScript API for over-the-air updates inside a running Pear app.
 - [Pear Mobile OTA](/reference/pear/mobile)—the `pear-mobile` module: the same OTA and storage model, embedded in React Native and Expo apps via a Bare worklet.
+- [Mobile OTA Boot Control](/reference/pear/mobile-boot-control)—the `pear-runtime-react-native` Expo config plugin: chooses between the bundle shipped in a native build and a downloaded OTA update.
 - [Configuration](/reference/pear/configuration)—every key in `package.json`'s `pear` block.
 - [Pear API (removed)](/reference/pear/api)—the older direct-access `global.Pear` API, removed in v3. Use the Pear OTA (`pear-runtime`) module instead.
 

--- a/content/reference/pear/mobile-boot-control.mdx
+++ b/content/reference/pear/mobile-boot-control.mdx
@@ -1,0 +1,126 @@
+---
+title: "Mobile OTA Boot Control"
+description: "The pear-runtime-react-native Expo config plugin: how it chooses between a native build's bundled JS and a downloaded Pear OTA update."
+seoTitle: "Mobile OTA Boot Control: pear-runtime-react-native"
+docType: reference
+schemaType: APIReference
+---
+
+# Mobile OTA Boot Control
+
+**Mobile OTA boot control** is provided by the [`pear-runtime-react-native`](https://github.com/holepunchto/pear-runtime-react-native) package, an [Expo](https://expo.dev) config plugin. It owns exactly one thing: patching a React Native app's generated native projects so a release build boots either the JS bundle shipped in the binary or a newer one downloaded via [Pear Mobile OTA](/reference/pear/mobile).
+
+<Callout type="warn">
+`pear-runtime-react-native` is MVP and experimental—expect the API to keep moving.
+</Callout>
+
+It has no runtime API and nothing to import in app code. The runtime side—storage, the Bare worklet, the update flow—is [`pear-mobile`](/reference/pear/mobile). Install both together:
+
+```sh
+npm install pear-runtime-react-native pear-mobile react-native-bare-kit
+npx expo install expo-build-properties
+```
+
+## Expo setup
+
+The plugin requires Expo and Prebuild—there's no autolinking path and no runtime patching, only generate-then-patch. Register it in `app.json`:
+
+```json
+{
+  "expo": {
+    "plugins": [
+      "pear-runtime-react-native",
+      [
+        "expo-build-properties",
+        { "android": { "minSdkVersion": 29 } }
+      ]
+    ],
+    "ios": { "bundleIdentifier": "com.example.app" },
+    "android": { "package": "com.example.app" }
+  }
+}
+```
+
+Then generate the native projects:
+
+```sh
+npx expo prebuild
+```
+
+The plugin edits two functions: `bundleURL()` in `AppDelegate.swift`, and the `jsBundleFilePath` passed into `ExpoReactHostFactory.getDefaultReactHost()` in `MainApplication.kt`. Re-run with `--clean` to regenerate already-patched files.
+
+For a project without Expo, the same logic has to be applied by hand—see [Plain React Native](#plain-react-native) below.
+
+## Boot control
+
+A release build loads the downloaded OTA update only if the `version` in the OTA's `package.json` is newer than the installed app version; otherwise it loads the bundle shipped in the binary. Debug builds always load from Metro—OTA behavior can only be verified in a release build.
+
+| Platform | OTA folder | Compared against |
+| --- | --- | --- |
+| iOS | `<Application Support>/pear-runtime/ota` | `CFBundleShortVersionString` |
+| Android | `<filesDir>/pear-runtime/ota` | the package `versionName` |
+
+Comparison is plain [SemVer 2.0.0](https://semver.org), no extra rules. Both sides must be valid SemVer—anything the spec rejects counts as not newer, so a bad version string just means the app keeps booting the binary's bundle rather than erroring.
+
+<Callout type="warn">
+An OTA may change JavaScript and bundled worker code only when that code stays compatible with the exact native modules, native ABI, configuration, and assets shipped in the installed store build.
+</Callout>
+
+## Version synchronization
+
+`package.json`'s `version` is the single source of truth for four values that all have to move together: the OTA manifest version this plugin compares, Expo's `version`, `CFBundleShortVersionString`, and `versionName`. An `app.config.js` keeps the native side in sync, since Expo writes its `version` into both native projects during prebuild:
+
+```js
+const app = require('./app.json')
+const { version } = require('./package.json')
+
+module.exports = { ...app.expo, version }
+```
+
+Versions must be valid SemVer and strictly monotonic across native and OTA releases combined: every OTA version must be greater than the installed native version and every previously published OTA, and every new native release must be greater than every previously published OTA. Never reuse or decrease a published version.
+
+Two independent gates enforce different halves of that rule, and they're worth keeping apart:
+
+- **`pear.json` `updates.minver`**, checked by [`pear-mobile`](/reference/pear/mobile) before a payload is downloaded and applied. It stops an OTA from reaching a native build too old for it—the forward direction.
+- **Boot control**, in this package, runs on every launch and compares only the installed OTA manifest version against the native version. It never reads `pear.json`, so `minver` plays no part in choosing which bundle boots.
+
+## Runtime activation
+
+Applying an update writes the new bundle and manifest into `pear-runtime/ota`, but doesn't switch the running app over—activation happens at the next native bundle selection, and the two platforms differ on when that is:
+
+- **iOS** re-reads `bundleURL()` on reload, so a JavaScript reload can pick up a freshly applied OTA.
+- **Android** captures `jsBundleFilePath` when the React host is created and caches it, so a JavaScript reload generally reuses the old path—the update takes effect after a full process restart.
+
+Treat a full restart as the requirement on both platforms.
+
+## What the plugin will and won't touch
+
+The plugin only rewrites the two functions named above, wrapping what it writes in a marker comment (`pear-runtime-react-native OTA v3` / `... end`). A later prebuild reads that marker before touching anything:
+
+| What it finds | What it does |
+| --- | --- |
+| No marker | Links the plugin's code. |
+| This version's marker | Leaves it alone. |
+| Another version's marker, present | Replaces the whole block. |
+| Another version's marker, removed | Warns, changes nothing. |
+
+Editing the generated code is fine as long as the marker comment stays—removing it hands ownership of that block to the project, and prebuild will only warn that a newer version wasn't linked (a clean `--clean` prebuild replaces it either way).
+
+<Callout type="warn">
+Adopting this plugin in a project that already has its own code in `bundleURL()` or `getDefaultReactHost()` overwrites it on the next prebuild—the plugin can't tell a hand-written implementation from Expo's generated one. An app should have exactly one owner of bundle selection; this conflicts with anything else that also claims it, including Expo Updates or another OTA system.
+</Callout>
+
+## Plain React Native
+
+The plugin only works with Expo—it runs as a config mod, and the Android patch looks for `ExpoReactHostFactory`. Without Expo, apply the same logic by hand:
+
+- **iOS**: override `bundleURL()` in `AppDelegate`. Return `<Application Support>/pear-runtime/ota/app.bundle` if it exists and its `package.json` `version` is newer than `CFBundleShortVersionString`, otherwise return the shipped `main.jsbundle`.
+- **Android**: override `getJSBundleFile()` on the `ReactNativeHost`. Return `<filesDir>/pear-runtime/ota/app.bundle` under the same condition, otherwise `null`.
+
+The Swift and Kotlin the plugin generates is available for reference in [`lib/ota-templates.js`](https://github.com/holepunchto/pear-runtime-react-native/blob/main/lib/ota-templates.js).
+
+## See also
+
+- [Pear Mobile OTA](/reference/pear/mobile)—the runtime half: the Bare worklet, storage, and update flow this plugin's boot control activates.
+- [Start from the hello-pear-react-native template](/getting-started/from-a-template/start-from-hello-pear-react-native)—this plugin already wired into a working template's `app.json`.
+- [`pear-runtime-react-native` on GitHub](https://github.com/holepunchto/pear-runtime-react-native)—full README, including deployment sequencing.

--- a/content/reference/pear/mobile.mdx
+++ b/content/reference/pear/mobile.mdx
@@ -106,6 +106,7 @@ goodbye(() => pear.close()) // e.g. via graceful-goodbye
 ## See also
 
 - [Pear OTA](/reference/pear/runtime)—the desktop counterpart this module mirrors.
+- [Mobile OTA Boot Control](/reference/pear/mobile-boot-control)—the `pear-runtime-react-native` Expo config plugin that activates the updates this module downloads.
 - [`hello-pear-worker`](https://github.com/holepunchto/hello-pear-worker)—the shared worker that requires `pear-runtime` and lets each template's `package.json` redirect it to `pear-mobile` on mobile.
 - [Start from the hello-pear-react-native template](/getting-started/from-a-template/start-from-hello-pear-react-native)—this module in a working template.
 - [Bare Kit](/reference/bare/bare-kit)—the `Worklet` and `IPC` API `pear-mobile` runs on.

--- a/src/lib/custom-tree.ts
+++ b/src/lib/custom-tree.ts
@@ -456,6 +456,11 @@ export const customTree: Node[] = [
           { type: 'page', name: 'Pear Mobile OTA', url: '/reference/pear/mobile' },
           {
             type: 'page',
+            name: 'Mobile OTA Boot Control',
+            url: '/reference/pear/mobile-boot-control',
+          },
+          {
+            type: 'page',
             name: 'Configuration',
             url: '/reference/pear/configuration',
           },


### PR DESCRIPTION
Documents the Expo config plugin that controls which JS bundle a React Native release build boots (native vs. downloaded Pear OTA update) — previously named only in passing in the
hello-pear-react-native template's app.json table.

- New content/reference/pear/mobile-boot-control.mdx covering setup, boot control mechanics, version synchronization, runtime activation timing, and the plain-React-Native manual integration path.
- Cross-link from Pear Mobile OTA's See also, the References index, the sidebar nav, and the template page's app.json row.