### PR TITLE
fix: handle SIGINT teardown rejection in how-to examples

### DIFF
--- a/examples/how-to/connect-to-peers/connect-to-many-peers-by-topic-with-hyperswarm/peer-app/index.js
+++ b/examples/how-to/connect-to-peers/connect-to-many-peers-by-topic-with-hyperswarm/peer-app/index.js
@@ -6,7 +6,7 @@ import process from 'bare-process'
 
 const swarm = new Hyperswarm()
 const name = b4a.toString(swarm.keyPair.publicKey, 'hex')
-process.once('SIGINT', () => swarm.destroy().then(() => process.exit(0)))
+process.once('SIGINT', () => swarm.destroy().then(() => process.exit(0), () => process.exit(0)))
 
 // Keep track of all connections and console.log incoming data
 const conns = []

--- a/examples/how-to/connect-to-peers/connect-two-peers-by-key-with-hyperdht/server-app/index.js
+++ b/examples/how-to/connect-to-peers/connect-two-peers-by-key-with-hyperdht/server-app/index.js
@@ -25,4 +25,4 @@ server.listen(keyPair).then(() => {
 
 // Unannounce the public key before exiting the process
 // (Not strictly required, but it helps avoid DHT pollution.)
-process.once('SIGINT', () => server.close().then(() => process.exit(0)))
+process.once('SIGINT', () => server.close().then(() => process.exit(0), () => process.exit(0)))

--- a/examples/how-to/store-and-replicate/replicate-and-persist-with-hypercore/reader-app/index.js
+++ b/examples/how-to/store-and-replicate/replicate-and-persist-with-hypercore/reader-app/index.js
@@ -5,7 +5,7 @@ import Hyperswarm from 'hyperswarm'
 import Hypercore from 'hypercore'
 
 const swarm = new Hyperswarm()
-process.once('SIGINT', () => swarm.destroy().then(() => process.exit(0)))
+process.once('SIGINT', () => swarm.destroy().then(() => process.exit(0), () => process.exit(0)))
 
 const core = new Hypercore(path.join('./storage', 'reader-storage'), Bare.argv[2])
 await core.ready()

--- a/examples/how-to/store-and-replicate/replicate-and-persist-with-hypercore/writer-app/index.js
+++ b/examples/how-to/store-and-replicate/replicate-and-persist-with-hypercore/writer-app/index.js
@@ -6,7 +6,7 @@ import Hypercore from 'hypercore'
 import b4a from 'b4a'
 
 const swarm = new Hyperswarm()
-process.once('SIGINT', () => swarm.destroy().then(() => process.exit(0)))
+process.once('SIGINT', () => swarm.destroy().then(() => process.exit(0), () => process.exit(0)))
 
 const core = new Hypercore(path.join('./storage', 'writer-storage'))
 

--- a/examples/how-to/store-and-replicate/share-append-only-databases-with-hyperbee/bee-reader-app/index.js
+++ b/examples/how-to/store-and-replicate/share-append-only-databases-with-hyperbee/bee-reader-app/index.js
@@ -13,7 +13,7 @@ if (!key) throw new Error('provide a key')
 const store = new Corestore('./bee-reader-storage')
 
 const swarm = new Hyperswarm()
-process.once('SIGINT', () => swarm.destroy().then(() => process.exit(0)))
+process.once('SIGINT', () => swarm.destroy().then(() => process.exit(0), () => process.exit(0)))
 
 // replication of the corestore instance on connection with other peers
 swarm.on('connection', (conn) => store.replicate(conn))

--- a/examples/how-to/store-and-replicate/share-append-only-databases-with-hyperbee/bee-writer-app/index.js
+++ b/examples/how-to/store-and-replicate/share-append-only-databases-with-hyperbee/bee-writer-app/index.js
@@ -8,7 +8,7 @@ import b4a from 'b4a'
 const store = new Corestore('./bee-writer-storage')
 
 const swarm = new Hyperswarm()
-process.once('SIGINT', () => swarm.destroy().then(() => process.exit(0)))
+process.once('SIGINT', () => swarm.destroy().then(() => process.exit(0), () => process.exit(0)))
 
 // replication of corestore instance
 swarm.on('connection', conn => store.replicate(conn))

--- a/examples/how-to/store-and-replicate/share-append-only-databases-with-hyperbee/core-reader-app/index.js
+++ b/examples/how-to/store-and-replicate/share-append-only-databases-with-hyperbee/core-reader-app/index.js
@@ -13,7 +13,7 @@ if (!key) throw new Error('provide a key')
 const store = new Corestore('./reader-storage')
 
 const swarm = new Hyperswarm()
-process.once('SIGINT', () => swarm.destroy().then(() => process.exit(0)))
+process.once('SIGINT', () => swarm.destroy().then(() => process.exit(0), () => process.exit(0)))
 
 // replication of the corestore instance on connection with other peers
 swarm.on('connection', conn => store.replicate(conn))

--- a/examples/how-to/store-and-replicate/work-with-many-hypercores-using-corestore/multicore-reader-app/index.js
+++ b/examples/how-to/store-and-replicate/work-with-many-hypercores-using-corestore/multicore-reader-app/index.js
@@ -11,7 +11,7 @@ const store = new Corestore('./multicore-reader-storage')
 await store.ready()
 
 const swarm = new Hyperswarm()
-process.once('SIGINT', () => swarm.destroy().then(() => process.exit(0)))
+process.once('SIGINT', () => swarm.destroy().then(() => process.exit(0), () => process.exit(0)))
 
 // replication of corestore instance on every connection
 swarm.on('connection', (conn) => store.replicate(conn))

--- a/examples/how-to/store-and-replicate/work-with-many-hypercores-using-corestore/multicore-writer-app/index.js
+++ b/examples/how-to/store-and-replicate/work-with-many-hypercores-using-corestore/multicore-writer-app/index.js
@@ -6,7 +6,7 @@ import process from 'bare-process'
 
 const store = new Corestore('./multicore-writer-storage')
 const swarm = new Hyperswarm()
-process.once('SIGINT', () => swarm.destroy().then(() => process.exit(0)))
+process.once('SIGINT', () => swarm.destroy().then(() => process.exit(0), () => process.exit(0)))
 
 // A name is a purely-local, and maps to a key pair. It's not visible to readers.
 // Since a name always corresponds to a key pair, these are all writable

--- a/examples/how-to/stream-and-share-media/create-a-full-peer-to-peer-filesystem-with-hyperdrive/drive-bee-reader-app/index.js
+++ b/examples/how-to/stream-and-share-media/create-a-full-peer-to-peer-filesystem-with-hyperdrive/drive-bee-reader-app/index.js
@@ -12,7 +12,7 @@ if (!key) throw new Error('provide a key')
 const store = new Corestore('./drive-bee-reader-storage')
 
 const swarm = new Hyperswarm()
-process.once('SIGINT', () => swarm.destroy().then(() => process.exit(0)))
+process.once('SIGINT', () => swarm.destroy().then(() => process.exit(0), () => process.exit(0)))
 
 swarm.on('connection', conn => store.replicate(conn))
 

--- a/examples/how-to/stream-and-share-media/create-a-full-peer-to-peer-filesystem-with-hyperdrive/drive-reader-app/index.js
+++ b/examples/how-to/stream-and-share-media/create-a-full-peer-to-peer-filesystem-with-hyperdrive/drive-reader-app/index.js
@@ -15,7 +15,7 @@ if (!key) throw new Error('provide a key')
 const store = new Corestore('./drive-reader-storage')
 
 const swarm = new Hyperswarm()
-process.once('SIGINT', () => swarm.destroy().then(() => process.exit(0)))
+process.once('SIGINT', () => swarm.destroy().then(() => process.exit(0), () => process.exit(0)))
 
 // replication of store on connection with other peers
 swarm.on('connection', conn => store.replicate(conn))

--- a/examples/how-to/stream-and-share-media/create-a-full-peer-to-peer-filesystem-with-hyperdrive/drive-writer-app/index.js
+++ b/examples/how-to/stream-and-share-media/create-a-full-peer-to-peer-filesystem-with-hyperdrive/drive-writer-app/index.js
@@ -10,7 +10,7 @@ import b4a from 'b4a'
 // create a Corestore instance 
 const store = new Corestore('./drive-writer-storage')
 const swarm = new Hyperswarm()
-process.once('SIGINT', () => swarm.destroy().then(() => process.exit(0)))
+process.once('SIGINT', () => swarm.destroy().then(() => process.exit(0), () => process.exit(0)))
 
 // replication of the corestore instance on connection with other peers
 swarm.on('connection', conn => store.replicate(conn))


### PR DESCRIPTION
## Problem

Every runnable how-to example that tears down on SIGINT used:

    process.once('SIGINT', () => swarm.destroy().then(() => process.exit(0)))

(or `server.close()` for the HyperDHT example). If the teardown call rejects for any reason, there's no rejection handler, so it becomes an unhandled promise rejection instead of a clean `process.exit(0)`.

## Fix

Added a rejection handler that still exits cleanly:

    process.once('SIGINT', () => swarm.destroy().then(() => process.exit(0), () => process.exit(0)))

Applied to all 12 affected files under `examples/how-to/`.

Two files (`store-and-serve-large-media-with-hyperblobs/{writer-app,reader-app}`) use an async SIGINT handler with the same gap but a different shape — left out of this PR's scope, flagged separately.

## Verification

- `npm run check:code-imports` — clean (4 pre-existing unrelated warnings)
- `npm run check:examples:lint` — clean
- Edits stayed single-line each, so no `.mdx` line-number highlight ranges needed updating

🤖 Generated with [Claude Code](https://claude.com/claude-code)